### PR TITLE
Fix uninitialized variable in FvwmIconMan colorset loop.

### DIFF
--- a/modules/FvwmIconMan/x.c
+++ b/modules/FvwmIconMan/x.c
@@ -963,6 +963,8 @@ void create_manager_window (int man_id)
   for (i = 0; i < NUM_CONTEXTS; i++) {
 	  if (man->colorsets[i] != -2)
 	  {
+		  gcmask = GCForeground;
+		  gcval.foreground = man->backcolor[i];
 		  man->backContext[i] =
 			  fvwmlib_XCreateGC(
 				  theDisplay, man->theWindow, gcmask, &gcval);
@@ -973,6 +975,8 @@ void create_manager_window (int man_id)
 			  line_style, cap_style,
 			  join_style);
 	  }
+	  gcmask = GCForeground;
+	  gcval.foreground = man->forecolor[i];
 	  man->hiContext[i] = fvwmlib_XCreateGC(
 		  theDisplay, man->theWindow, gcmask, &gcval);
 	  if (man->FButtonFont->font != NULL)


### PR DESCRIPTION
In FvwmIconMan, using colorsets to set various styles (e.g., PlainColorset,
SelectColorset, etc.) is broken.  Essentially, background colors for one color
end up being mapped to the shadow color of the previously used colorset.  This
is because the loop that calls fvwmlib_XCreateGC on the various colorsets does
not happen to set the background color from the colorset inside the loop.  This
makes the code function OK with just one colorset, but adding a second colorset
in your settings causes problems.

This change explicitly set the background color on the GC within the loop, so as
to not carry forth the shadow color from the end of the previous iteration.