### PR TITLE
should not compare menu positions with screen width/height.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,4 +13,5 @@ insert_final_newline = false
 indent_style = tab
 
 [*.{c,h}]
+indent_style = tab
 indent_size = 8

--- a/fvwm/menubindings.c
+++ b/fvwm/menubindings.c
@@ -1074,15 +1074,15 @@ void menu_shortcuts(
 
 					if (
 						menu_y + menu_height >
-						MR_SCREEN_HEIGHT(mr))
+						MR_SCREEN_Y(mr) + MR_SCREEN_HEIGHT(mr))
 					{
 						FWarpPointer(
 							dpy, 0, 0, 0, 0, 0, 0,
 							0,
 							MR_SCREEN_HEIGHT(mr) -
 							menu_y - menu_height);
-						menu_y = MR_SCREEN_HEIGHT(mr) -
-							menu_height;
+						menu_y = MR_SCREEN_Y(mr) + MR_SCREEN_HEIGHT(mr) -
+							 menu_height;
 					}
 				}
 				if (old_y != menu_y)
@@ -1123,15 +1123,14 @@ void menu_shortcuts(
 				"can't get geometry of menu %s", MR_NAME(mr));
 			return;
 		}
-		if (menu_y < 0 || menu_y + menu_height > MR_SCREEN_HEIGHT(mr))
+		if (menu_y < 0 || menu_y + menu_height > MR_SCREEN_Y(mr) + MR_SCREEN_HEIGHT(mr))
 		{
 			menu_y = (menu_y < 0) ?
-				0 : MR_SCREEN_HEIGHT(mr) - menu_height;
+				 0 : MR_SCREEN_Y(mr) + MR_SCREEN_HEIGHT(mr) - menu_height;
 			pmret->rc = MENU_NEWITEM_MOVEMENU;
 			*ret_menu_x = menu_x;
 			*ret_menu_y = menu_y;
 		}
 	}
-
 	return;
 }

--- a/fvwm/menudim.h
+++ b/fvwm/menudim.h
@@ -21,6 +21,8 @@
 #define MDIM_HILIGHT_WIDTH(d)      ((d).hilight_width)
 #define MDIM_SCREEN_WIDTH(d)       ((d).screen_width)
 #define MDIM_SCREEN_HEIGHT(d)      ((d).screen_height)
+#define MDIM_SCREEN_X(d)           ((d).screen_x_offset)
+#define MDIM_SCREEN_Y(d)           ((d).screen_y_offset)
 
 /* ---------------------------- type definitions --------------------------- */
 
@@ -51,6 +53,8 @@ struct MenuDimensions
 	 * the menu was mapped on */
 	int screen_width;
 	int screen_height;
+	int screen_x_offset;
+	int screen_y_offset;
 };
 
 /* ---------------------------- exported variables (globals) --------------- */

--- a/fvwm/menuroot.h
+++ b/fvwm/menuroot.h
@@ -75,6 +75,8 @@ typedef struct MenuRootStatic
 #define MR_HILIGHT_WIDTH(m)      MDIM_HILIGHT_WIDTH((m)->s->dim)
 #define MR_SCREEN_WIDTH(m)       MDIM_SCREEN_WIDTH((m)->s->dim)
 #define MR_SCREEN_HEIGHT(m)      MDIM_SCREEN_HEIGHT((m)->s->dim)
+#define MR_SCREEN_X(m)           MDIM_SCREEN_X((m)->s->dim)
+#define MR_SCREEN_Y(m)           MDIM_SCREEN_Y((m)->s->dim)
 #define MR_ITEMS(m)              ((m)->s->items)
 #define MR_SIDEPIC(m)            ((m)->s->sidePic)
 #define MR_SIDECOLOR(m)          ((m)->s->sideColor)

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -1981,8 +1981,7 @@ static void make_menu(MenuRoot *mr, Bool is_tear_off)
  * changed. */
 static void update_menu(MenuRoot *mr, MenuParameters *pmp)
 {
-	int sw;
-	int sh;
+	int sw, sh, sx, sy;
 	Bool has_screen_size_changed = False;
 	fscreen_scr_arg fscr;
 
@@ -2004,10 +2003,13 @@ static void update_menu(MenuRoot *mr, MenuParameters *pmp)
 	}
 	fscr.xypos.x = pmp->screen_origin_x;
 	fscr.xypos.y = pmp->screen_origin_y;
-	FScreenGetScrRect(&fscr, FSCREEN_XYPOS, &JunkX, &JunkY, &sw, &sh);
-	if (sw != MR_SCREEN_WIDTH(mr) || sh != MR_SCREEN_HEIGHT(mr))
+	FScreenGetScrRect(&fscr, FSCREEN_XYPOS, &sx, &sy, &sw, &sh);
+	if (sw != MR_SCREEN_WIDTH(mr) || sh != MR_SCREEN_HEIGHT(mr)
+	    || sx != MR_SCREEN_X(mr) || sy != MR_SCREEN_Y(mr))
 	{
 		has_screen_size_changed = True;
+		MR_SCREEN_X(mr) = sx;
+		MR_SCREEN_Y(mr) = sy;
 		MR_SCREEN_WIDTH(mr) = sw;
 		MR_SCREEN_HEIGHT(mr) = sh;
 	}


### PR DESCRIPTION
Under a vertical dual display setup, menu would jump from the lower display to the higher one when invoking `MenuMoveCursor`. This patch fixes that.

In general, we should not compare a position with the screen width/height. Screens have x/y positions too.