### PR TITLE
WorkArea: use screen dimensions to compute area

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -991,11 +991,8 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 
 	x = left;
 	y = top;
-	width = (m->virtual_scr.MyDisplayWidth) - (left + right);
-	height =(m->virtual_scr.MyDisplayHeight) - (top + bottom);
-
-	if (width == 0)
-		width = m->si->w;
+	width = (m->si->w) - (left + right);
+	height =(m->si->h) - (top + bottom);
 
 	if (
 		m->Desktops->ewmh_working_area.x != x ||


### PR DESCRIPTION
When working out the working area for a desktop, use the monitor's
coordinates (width/height) and not the XServer's display width or height
as these will differ.

Fixes GH issue #52