### PR TITLE
Per-monitor EWMHBaseStruts

### DIFF
--- a/fvwm/borders.c
+++ b/fvwm/borders.c
@@ -4730,11 +4730,6 @@ void border_draw_decorations(
 		Scr.Hilite = NULL;
 	}
 
-	m = fw->m;
-	if (fw->Desk != m->virtual_scr.CurrentDesk)
-	{
-		return;
-	}
 	if (IS_ICONIFIED(fw))
 	{
 		DrawIconWindow(fw, True, True, True, False, NULL);

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1805,16 +1805,14 @@ void monitor_update_ewmh(void)
 
 	TAILQ_FOREACH(m, &monitor_q, entry) {
 		if (m->flags & MONITOR_NEW) {
-			m->virtual_scr.Vx = mref->virtual_scr.Vx;
-			m->virtual_scr.Vy = mref->virtual_scr.Vy;
-			m->virtual_scr.VxMax = mref->virtual_scr.VxMax;
-			m->virtual_scr.VyMax = mref->virtual_scr.VyMax;
-
 			if (m->Desktops == NULL) {
 				m->Desktops = fxcalloc(1, sizeof *m->Desktops);
 				*m->Desktops = *mref->Desktops;
-			}
+				calculate_page_sizes(m, mref->dx, mref->dy);
+				m->virtual_scr.Vx = 0;
+				m->virtual_scr.Vy = 0;
 
+			}
 			m->flags &= ~MONITOR_NEW;
 		}
 		EWMH_Init(m);

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1809,9 +1809,17 @@ void monitor_update_ewmh(void)
 				int ewbs[4] = {0, 0, 0, 0};
 
 				m->Desktops = fxcalloc(1, sizeof *m->Desktops);
-				*m->Desktops = *mref->Desktops;
+				m->Desktops->name = NULL;
+				m->Desktops->next = NULL;
+				m->Desktops->desk = 0;
+				apply_desktops_monitor(m);
 
 				calculate_page_sizes(m, mref->dx, mref->dy);
+
+				fprintf(stderr,
+				"%s: new_monitor: %s (%p) compared to (%p)\n",
+				__func__, m->si->name, m->Desktops->next,
+				mref->Desktops->next);
 
 				m->virtual_scr.Vx = 0;
 				m->virtual_scr.Vy = 0;

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1806,12 +1806,17 @@ void monitor_update_ewmh(void)
 	TAILQ_FOREACH(m, &monitor_q, entry) {
 		if (m->flags & MONITOR_NEW) {
 			if (m->Desktops == NULL) {
+				int ewbs[4] = {0, 0, 0, 0};
+
 				m->Desktops = fxcalloc(1, sizeof *m->Desktops);
 				*m->Desktops = *mref->Desktops;
+
 				calculate_page_sizes(m, mref->dx, mref->dy);
+
 				m->virtual_scr.Vx = 0;
 				m->virtual_scr.Vy = 0;
 
+				set_ewmhc_strut_values(m, ewbs);
 			}
 			m->flags &= ~MONITOR_NEW;
 		}

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1810,6 +1810,11 @@ void monitor_update_ewmh(void)
 			m->virtual_scr.VxMax = mref->virtual_scr.VxMax;
 			m->virtual_scr.VyMax = mref->virtual_scr.VyMax;
 
+			if (m->Desktops == NULL) {
+				m->Desktops = fxcalloc(1, sizeof *m->Desktops);
+				*m->Desktops = *mref->Desktops;
+			}
+
 			m->flags &= ~MONITOR_NEW;
 		}
 		EWMH_Init(m);

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1071,6 +1071,11 @@ void EWMH_GetWorkAreaIntersection(
 	int area_h = m->Desktops->ewmh_working_area.height;
 	Bool is_dynamic = False;
 
+	fprintf(stderr, "%s: mon: %s {ax: %d, ay: %d, aw: %d, ah: %d\n",
+		__func__, m->si->name, area_x, area_y, area_w, area_h);
+	fprintf(stderr, "%s: mon: %s {x: %d, y: %d, w: %d, h: %d\n",
+		__func__, m->si->name, *x, *y, *w, *h);
+
 	/* FIXME: needs broadcast if global monitor in use. */
 
 	switch(type)
@@ -1101,6 +1106,9 @@ void EWMH_GetWorkAreaIntersection(
 	*y = ny;
 	*w = nw;
 	*h = nh;
+
+	fprintf(stderr, "%s: mon: %s RETURNING: {x: %d, y: %d, w: %d, h: %d}\n",
+		__func__, m->si->name, *x, *y, *w, *h);
 
 	return;
 }
@@ -1146,28 +1154,28 @@ float ewmh_GetStrutIntersection(struct monitor *m,
 	x21 = 0;
 	y21 = 0;
 	x22 = left;
-	y22 = m->si->w;
+	y22 = m->virtual_scr.MyDisplayHeight;
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 	/* right */
-	x21 = m->si->w - right;
+	x21 = m->virtual_scr.MyDisplayWidth - right;
 	y21 = 0;
-	x22 = m->si->w;
-	y22 = m->si->h;
+	x22 = m->virtual_scr.MyDisplayWidth;
+	y22 = m->virtual_scr.MyDisplayHeight;
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 	/* top */
 	x21 = 0;
 	y21 = 0;
-	x22 = m->si->w;
+	x22 = m->virtual_scr.MyDisplayWidth;
 	y22 = top;
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 	/* bottom */
 	x21 = 0;
-	y21 = m->si->y - bottom;
-	x22 = m->si->w;
-	y22 = m->si->h;
+	y21 = m->virtual_scr.MyDisplayHeight - bottom;
+	x22 = m->virtual_scr.MyDisplayWidth;
+	y22 = m->virtual_scr.MyDisplayHeight;
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 
@@ -1191,11 +1199,11 @@ float EWMH_GetStrutIntersection(struct monitor *m,
 	/* FIXME: needs broadcast if global monitor in use. */
 
 	left = m->Desktops->ewmh_working_area.x;
-	right = m->si->w -
+	right = m->virtual_scr.MyDisplayWidth -
 		(m->Desktops->ewmh_working_area.x
 		 + m->Desktops->ewmh_working_area.width);
 	top = m->Desktops->ewmh_working_area.y;
-	bottom = m->si->y -
+	bottom = m->virtual_scr.MyDisplayHeight -
 		(m->Desktops->ewmh_working_area.y
 		 + m->Desktops->ewmh_working_area.height);
 

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1111,14 +1111,17 @@ void EWMH_GetWorkAreaIntersection(
 	}
 	nx = max(*x, area_x);
 	ny = max(*y, area_y);
-	nw = min(*x + *w, area_x + area_w) - nx;
-	if (nw == 0)
-		nw = m->si->w;
-	nh = min(*y + *h, area_y + area_h) - ny;
-	*x = abs(nx);
-	*y = abs(ny);
-	*w = abs(nw);
-	*h = abs(nh);
+	nw = min(*x + *w, area_x + area_w);
+	nh = min(*y + *h, area_y + area_h);
+	*x = nx;
+	*y = ny;
+	*w = nw;
+	*h = nh;
+
+	if ((nw - nx) > 0)
+		*w = nw - nx;
+	if ((nh - ny) > 0)
+		*h = nh - ny;
 
 	return;
 }

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1,10 +1,10 @@
 /* -*-c-*- */
 /* Copyright (C) 2001  Olivier Chapuis */
 /* This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -521,32 +521,31 @@ void EWMH_SetNumberOfDesktops(struct monitor *m)
 {
 	long val;
 
-	/* FIXME: needs broadcasting to each monitor if global. */
-
-	if (ewmhc.CurrentNumberOfDesktops < ewmhc.NumberOfDesktops)
+	if (m->ewmhc.CurrentNumberOfDesktops < m->ewmhc.NumberOfDesktops)
 	{
-		ewmhc.CurrentNumberOfDesktops = ewmhc.NumberOfDesktops;
+		m->ewmhc.CurrentNumberOfDesktops = m->ewmhc.NumberOfDesktops;
 	}
 
-	if (ewmhc.CurrentNumberOfDesktops > ewmhc.NumberOfDesktops ||
-	    ewmhc.NeedsToCheckDesk)
+	if (m->ewmhc.CurrentNumberOfDesktops > m->ewmhc.NumberOfDesktops ||
+	    m->ewmhc.NeedsToCheckDesk)
 	{
 		int d = check_desk();
 
-		ewmhc.NeedsToCheckDesk = False;
-		if (d >= ewmhc.MaxDesktops && ewmhc.MaxDesktops != 0)
+		m->ewmhc.NeedsToCheckDesk = False;
+		if (d >= m->ewmhc.MaxDesktops && m->ewmhc.MaxDesktops != 0)
 			d = 0;
-		ewmhc.CurrentNumberOfDesktops =
-			max(ewmhc.NumberOfDesktops, d+1);
+		m->ewmhc.CurrentNumberOfDesktops =
+			max(m->ewmhc.NumberOfDesktops, d+1);
 	}
 
-	if (m->virtual_scr.CurrentDesk >= ewmhc.CurrentNumberOfDesktops &&
-	    (m->virtual_scr.CurrentDesk < ewmhc.MaxDesktops || ewmhc.MaxDesktops == 0))
+	if (m->virtual_scr.CurrentDesk >= m->ewmhc.CurrentNumberOfDesktops &&
+	    (m->virtual_scr.CurrentDesk < m->ewmhc.MaxDesktops ||
+	    ewmhc.MaxDesktops == 0))
 	{
 		ewmhc.CurrentNumberOfDesktops = m->virtual_scr.CurrentDesk + 1;
 	}
 
-	val = (long)ewmhc.CurrentNumberOfDesktops;
+	val = (long)m->ewmhc.CurrentNumberOfDesktops;
 	ewmh_ChangeProperty(Scr.Root, "_NET_NUMBER_OF_DESKTOPS",
 			    EWMH_ATOM_LIST_CLIENT_ROOT,
 			    (unsigned char *)&val, 1);
@@ -945,7 +944,8 @@ void ewmh_SetWorkArea(struct monitor *m)
 	long val[256][4]; /* no more than 256 desktops */
 	int i = 0;
 
-	/* FIXME:  needs broadcast if monitor is global. */
+	if (m->Desktops == NULL)
+		return;
 
 	while(i < ewmhc.NumberOfDesktops && i < 256)
 	{
@@ -964,10 +964,10 @@ void ewmh_SetWorkArea(struct monitor *m)
 
 void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 {
-	int left = ewmhc.BaseStrut.left;
-	int right = ewmhc.BaseStrut.right;
-	int top = ewmhc.BaseStrut.top;
-	int bottom = ewmhc.BaseStrut.bottom;
+	int left = m->ewmhc.BaseStrut.left;
+	int right = m->ewmhc.BaseStrut.right;
+	int top = m->ewmhc.BaseStrut.top;
+	int bottom = m->ewmhc.BaseStrut.bottom;
 	int x,y,width,height;
 	FvwmWindow *fw;
 
@@ -1020,10 +1020,10 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 
 void ewmh_HandleDynamicWorkArea(struct monitor *m)
 {
-	int dyn_left = ewmhc.BaseStrut.left;
-	int dyn_right = ewmhc.BaseStrut.right;
-	int dyn_top = ewmhc.BaseStrut.top;
-	int dyn_bottom = ewmhc.BaseStrut.bottom;
+	int dyn_left = m->ewmhc.BaseStrut.left;
+	int dyn_right = m->ewmhc.BaseStrut.right;
+	int dyn_top = m->ewmhc.BaseStrut.top;
+	int dyn_bottom = m->ewmhc.BaseStrut.bottom;
 	int x,y,width,height;
 	FvwmWindow *fw;
 
@@ -1073,8 +1073,6 @@ void EWMH_UpdateWorkArea(struct monitor *m)
 {
 	ewmh_ComputeAndSetWorkArea(m);
 	ewmh_HandleDynamicWorkArea(m);
-
-	return;
 }
 
 void EWMH_GetWorkAreaIntersection(

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1064,6 +1064,9 @@ void EWMH_GetWorkAreaIntersection(
 	FvwmWindow *fw, int *x, int *y, int *w, int *h, int type)
 {
 	struct monitor	*m = (fw && fw->m) ? fw->m : monitor_get_current();
+
+	EWMH_UpdateWorkArea(m);
+
 	int nx,ny,nw,nh;
 	int area_x = m->Desktops->ewmh_working_area.x;
 	int area_y = m->Desktops->ewmh_working_area.y;

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -994,6 +994,11 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 	width = (m->si->w) - (left + right);
 	height =(m->si->h) - (top + bottom);
 
+	monitor_dump_state(m);
+	fprintf(stderr, "%s: monitor '%s': {l: %d, r: %d, t: %d, b: %d} "
+		"{x: %d, y: %d, w: %d, h: %d}\n", __func__, m->si->name,
+		left, right, top, bottom, x, y, width, height);
+
 	if (
 		m->Desktops->ewmh_working_area.x != x ||
 		m->Desktops->ewmh_working_area.y != y ||
@@ -1004,6 +1009,9 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 		m->Desktops->ewmh_working_area.y = y;
 		m->Desktops->ewmh_working_area.width = width;
 		m->Desktops->ewmh_working_area.height = height;
+
+		fprintf(stderr, "%s: differ, so setting work area\n", __func__);
+
 		ewmh_SetWorkArea(m);
 	}
 

--- a/fvwm/ewmh.h
+++ b/fvwm/ewmh.h
@@ -58,6 +58,7 @@ void EWMH_Init(struct monitor *);
 void EWMH_ExitStuff(void);
 
 /* ewmh_conf.c */
+void set_ewmhc_strut_values(struct monitor *, int *);
 
 /* ewmh_events.c */
 Bool EWMH_ProcessClientMessage(const exec_context_t *exc);

--- a/fvwm/ewmh.h
+++ b/fvwm/ewmh.h
@@ -39,9 +39,9 @@ void EWMH_SetClientListStacking(struct monitor *);
 void EWMH_UpdateWorkArea(struct monitor *);
 void EWMH_GetWorkAreaIntersection(
 	FvwmWindow *fw, int *x, int *y, int *w, int *h, int type);
-float EWMH_GetBaseStrutIntersection(
+float EWMH_GetBaseStrutIntersection(struct monitor *m,
 	int x11, int y11, int x12, int y12, Bool use_percent);
-float EWMH_GetStrutIntersection(
+float EWMH_GetStrutIntersection(struct monitor *m,
 	int x11, int y11, int x12, int y12, Bool use_percent);
 void EWMH_SetFrameStrut(FvwmWindow *fw);
 void EWMH_SetAllowedActions(FvwmWindow *fw);

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -108,27 +108,31 @@ void CMD_EwmhNumberOfDesktops(F_CMD_ARGS)
 		return;
 	}
 
-	if (num == 2 && ewmhc.MaxDesktops != val[1])
-	{
-		ewmhc.MaxDesktops = val[1];
-		num = 3;
-	}
-	else if (num == 1 && ewmhc.MaxDesktops != 0)
-	{
-		ewmhc.MaxDesktops = 0;
-		num = 3;
-	}
+	TAILQ_FOREACH(m, &monitor_q, entry) {
+		if (monitor_should_ignore_global(m))
+			continue;
+		if (num == 2 && m->ewmhc.MaxDesktops != val[1])
+		{
+			m->ewmhc.MaxDesktops = val[1];
+			num = 3;
+		}
+		else if (num == 1 && m->ewmhc.MaxDesktops != 0)
+		{
+			m->ewmhc.MaxDesktops = 0;
+			num = 3;
+		}
 
-	if (ewmhc.NumberOfDesktops != val[0])
-	{
-		ewmhc.NumberOfDesktops = val[0];
-		num = 3;
-	}
+		if (m->ewmhc.NumberOfDesktops != val[0])
+		{
+			m->ewmhc.NumberOfDesktops = val[0];
+			num = 3;
+		}
 
-	if (num == 3)
-	{
-		ewmhc.NeedsToCheckDesk = True;
-		EWMH_SetNumberOfDesktops(monitor_get_current());
+		if (num == 3)
+		{
+			m->ewmhc.NeedsToCheckDesk = True;
+			EWMH_SetNumberOfDesktops(m);
+		}
 	}
 }
 

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -152,9 +152,11 @@ void CMD_EwmhBaseStruts(F_CMD_ARGS)
 		/* Actually get the screen value. */
 		option = PeekToken(action, &action);
 
-		if ((m = monitor_by_name(option)) == NULL) {
+		m = monitor_by_name(option);
+		if (strcmp(m->si->name, option) != 0) {
 			fvwm_msg(ERR, "CMD_EwmhBaseStruts",
 				"Invalid screen: %s", option);
+			return;
 		}
 	}
 

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -38,6 +38,10 @@
 #include "ewmh_intern.h"
 #include "move_resize.h"
 
+/* Forward declarations */
+static void set_ewmhc_strut_values(struct monitor *, int *);
+static void set_ewmhc_desktop_values(struct monitor *, int, int *);
+
 /*
  * CMDS
  */
@@ -96,8 +100,23 @@ Bool EWMH_BugOpts(char *opt, Bool toggle)
 
 void CMD_EwmhNumberOfDesktops(F_CMD_ARGS)
 {
+	struct monitor	*m = NULL;
+	char *option;
 	int val[2];
 	int num;
+
+	option = PeekToken(action, NULL);
+	if (StrEquals(option, "screen")) {
+		/* Skip literal 'screen' */
+		option = PeekToken(action, &action);
+		/* Actually get the screen value. */
+		option = PeekToken(action, &action);
+
+		if ((m = monitor_by_name(option)) == NULL) {
+			fvwm_msg(ERR, "CMD_EwmhNumberOfDesktops",
+				"Invalid screen: %s", option);
+		}
+	}
 
 	num = GetIntegerArguments(action, NULL, val, 2);
 	if ((num != 1 && num != 2) || val[0] < 1 ||
@@ -108,37 +127,37 @@ void CMD_EwmhNumberOfDesktops(F_CMD_ARGS)
 		return;
 	}
 
+	/* If m is still NULL, then no monitor was specified, therefore assume
+	 * all monitors will be used.
+	 */
+	if (m != NULL) {
+		set_ewmhc_desktop_values(m, num, val);
+		return;
+	}
+
 	TAILQ_FOREACH(m, &monitor_q, entry) {
-		if (monitor_should_ignore_global(m))
-			continue;
-		if (num == 2 && m->ewmhc.MaxDesktops != val[1])
-		{
-			m->ewmhc.MaxDesktops = val[1];
-			num = 3;
-		}
-		else if (num == 1 && m->ewmhc.MaxDesktops != 0)
-		{
-			m->ewmhc.MaxDesktops = 0;
-			num = 3;
-		}
-
-		if (m->ewmhc.NumberOfDesktops != val[0])
-		{
-			m->ewmhc.NumberOfDesktops = val[0];
-			num = 3;
-		}
-
-		if (num == 3)
-		{
-			m->ewmhc.NeedsToCheckDesk = True;
-			EWMH_SetNumberOfDesktops(m);
-		}
+		set_ewmhc_desktop_values(m, num, val);
 	}
 }
 
 void CMD_EwmhBaseStruts(F_CMD_ARGS)
 {
+	struct monitor *m = NULL;
+	char *option;
 	int val[4];
+
+	option = PeekToken(action, NULL);
+	if (StrEquals(option, "screen")) {
+		/* Skip literal 'screen' */
+		option = PeekToken(action, &action);
+		/* Actually get the screen value. */
+		option = PeekToken(action, &action);
+
+		if ((m = monitor_by_name(option)) == NULL) {
+			fvwm_msg(ERR, "CMD_EwmhBaseStruts",
+				"Invalid screen: %s", option);
+		}
+	}
 
 	if (GetIntegerArguments(action, NULL, val, 4) != 4 ||
 	    val[0] < 0 || val[1] < 0 || val[2] < 0 || val[3] < 0)
@@ -148,19 +167,65 @@ void CMD_EwmhBaseStruts(F_CMD_ARGS)
 		return;
 	}
 
-	if (ewmhc.BaseStrut.left != val[0] ||
-	    ewmhc.BaseStrut.right != val[1] ||
-	    ewmhc.BaseStrut.top != val[2] ||
-	    ewmhc.BaseStrut.bottom != val[3])
-	{
-		ewmhc.BaseStrut.left   = val[0];
-		ewmhc.BaseStrut.right  = val[1];
-		ewmhc.BaseStrut.top    = val[2];
-		ewmhc.BaseStrut.bottom = val[3];
+	/* If m is still NULL, then no monitor was specified, therefore assume
+	 * all monitors will be used.
+	 */
+	if (m != NULL) {
+		set_ewmhc_strut_values(m, val);
+		return;
+	}
 
-		EWMH_UpdateWorkArea(monitor_get_current());
+	TAILQ_FOREACH(m, &monitor_q, entry) {
+		fprintf(stderr, "%s: mon: %s {l: %d, r: %d, t: %d, b: %d}\n",
+			__func__, m->si->name, val[0], val[1], val[2], val[3]);
+		set_ewmhc_strut_values(m, val);
 	}
 }
+
+static void
+set_ewmhc_desktop_values(struct monitor *m, int num, int *val)
+{
+	if (num == 2 && m->ewmhc.MaxDesktops != val[1])
+	{
+		m->ewmhc.MaxDesktops = val[1];
+		num = 3;
+	}
+	else if (num == 1 && m->ewmhc.MaxDesktops != 0)
+	{
+		m->ewmhc.MaxDesktops = 0;
+		num = 3;
+	}
+
+	if (m->ewmhc.NumberOfDesktops != val[0])
+	{
+		m->ewmhc.NumberOfDesktops = val[0];
+		num = 3;
+	}
+
+	if (num == 3)
+	{
+		m->ewmhc.NeedsToCheckDesk = True;
+		EWMH_SetNumberOfDesktops(m);
+	}
+}
+
+static void
+set_ewmhc_strut_values(struct monitor *m, int *val)
+{
+	if (m->ewmhc.BaseStrut.left != val[0] ||
+	    m->ewmhc.BaseStrut.right != val[1] ||
+	    m->ewmhc.BaseStrut.top != val[2] ||
+	    m->ewmhc.BaseStrut.bottom != val[3])
+	{
+		m->ewmhc.BaseStrut.left   = val[0];
+		m->ewmhc.BaseStrut.right  = val[1];
+		m->ewmhc.BaseStrut.top    = val[2];
+		m->ewmhc.BaseStrut.bottom = val[3];
+
+		EWMH_UpdateWorkArea(m);
+	}
+}
+
 /*
  * Styles
  */

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -168,8 +168,8 @@ void CMD_EwmhBaseStruts(F_CMD_ARGS)
 		return;
 	}
 
-	/* If m is still NULL, then no monitor was specified, therefore assume
-	 * all monitors will be used.
+	/* If m is valid here, it's been set by "screen foo" above, so only
+	 * apply these settings to that monitor.
 	 */
 	if (m != NULL) {
 		set_ewmhc_strut_values(m, val);

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -39,7 +39,6 @@
 #include "move_resize.h"
 
 /* Forward declarations */
-static void set_ewmhc_strut_values(struct monitor *, int *);
 static void set_ewmhc_desktop_values(struct monitor *, int, int *);
 
 /*
@@ -209,7 +208,7 @@ set_ewmhc_desktop_values(struct monitor *m, int num, int *val)
 	}
 }
 
-static void
+void
 set_ewmhc_strut_values(struct monitor *m, int *val)
 {
 	if (m->ewmhc.BaseStrut.left != val[0] ||

--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -147,7 +147,7 @@ int ewmh_NumberOfDesktops(
 		}
 		else
 		{
-			mvwm_msg(
+			fvwm_msg(
 				WARN, "ewmh_NumberOfDesktops",
 				"The application window (id %#lx)\n"
 				"  \"%s\" tried to set an invalid number of desktops"

--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -136,26 +136,28 @@ int ewmh_NumberOfDesktops(
 	int d = ev->xclient.data.l[0];
 	struct monitor	*m;
 
-	m = (fw && fw->m) ? fw->m : monitor_get_current();
-
 	/* not a lot of sinification for fvwm */
-	if (d > 0 && (d <= ewmhc.MaxDesktops || ewmhc.MaxDesktops == 0))
-	{
-		ewmhc.NumberOfDesktops = d;
+	TAILQ_FOREACH(m, &monitor_q, entry) {
 		EWMH_SetNumberOfDesktops(m);
-	}
-	else
-	{
-		fvwm_msg(
-			WARN, "ewmh_NumberOfDesktops",
-			"The application window (id %#lx)\n"
-			"  \"%s\" tried to set an invalid number of desktops"
-			" (%ld)\n"
-			"  using an EWMH client message.\n"
-			"    fvwm is ignoring this request.\n",
-			fw ? FW_W(fw) : 0, fw ? fw->name.name : "(none)",
-			ev->xclient.data.l[0]);
-		fvwm_msg_report_app_and_workers();
+
+		if (d > 0 &&
+		    (d <= m->ewmhc.MaxDesktops || m->ewmhc.MaxDesktops == 0))
+		{
+			m->ewmhc.NumberOfDesktops = d;
+		}
+		else
+		{
+			mvwm_msg(
+				WARN, "ewmh_NumberOfDesktops",
+				"The application window (id %#lx)\n"
+				"  \"%s\" tried to set an invalid number of desktops"
+				" (%ld)\n"
+				"  using an EWMH client message.\n"
+				"    fvwm is ignoring this request.\n",
+				fw ? FW_W(fw) : 0, fw ? fw->name.name : "(none)",
+				ev->xclient.data.l[0]);
+			fvwm_msg_report_app_and_workers();
+		}
 	}
 
 	return -1;

--- a/fvwm/ewmh_names.c
+++ b/fvwm/ewmh_names.c
@@ -282,9 +282,6 @@ void EWMH_SetDesktopNames(struct monitor *m)
 		return;
 	}
 
-	if (m->Desktops == NULL)
-		m->Desktops = ReferenceDesktops;
-
 	d = m->Desktops->next;
 	/* skip negative desk */
 	while (d != NULL && d->desk < 0)

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -1356,7 +1356,7 @@ void resize_icon_title_height(FvwmWindow *fw, int dh)
 void get_page_offset_rectangle(FvwmWindow *fw,
 	int *ret_page_x, int *ret_page_y, rectangle *r)
 {
-	struct monitor	*m = monitor_get_current();
+	struct monitor	*m = (fw && fw->m) ? fw->m : monitor_get_current();
 
 	/* FIXME: broadcast if global monitor in use. */
 

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -4492,6 +4492,7 @@ static void MaximizeHeight(
 	int *win_y, Bool grow_up, Bool grow_down, int top_border,
 	int bottom_border, int *layers)
 {
+	struct monitor	*mon;
 	FvwmWindow *cwin;
 	int x11, x12, x21, x22;
 	int y11, y12, y21, y22;
@@ -4506,8 +4507,13 @@ static void MaximizeHeight(
 	new_y1 = top_border;
 	new_y2 = bottom_border;
 
+	mon = win->m;
+
 	for (cwin = Scr.FvwmRoot.next; cwin; cwin = cwin->next)
 	{
+		if (cwin->m != mon)
+			continue;
+
 		if (cwin == win ||
 		    (cwin->Desk != win->Desk &&
 		     !is_window_sticky_across_desks(cwin)))
@@ -4567,6 +4573,7 @@ static void MaximizeWidth(
 	int win_y, Bool grow_left, Bool grow_right, int left_border,
 	int right_border, int *layers)
 {
+	struct monitor	*mon;
 	FvwmWindow *cwin;
 	int x11, x12, x21, x22;
 	int y11, y12, y21, y22;
@@ -4581,8 +4588,13 @@ static void MaximizeWidth(
 	new_x1 = left_border;
 	new_x2 = right_border;
 
+	mon = win->m;
+
 	for (cwin = Scr.FvwmRoot.next; cwin; cwin = cwin->next)
 	{
+		if (cwin->m != mon)
+			continue;
+
 		if (cwin == win ||
 		    (cwin->Desk != win->Desk &&
 		     !is_window_sticky_across_desks(cwin)))

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -1080,13 +1080,14 @@ static pl_penalty_t __pl_minoverlap_get_pos_penalty(
 	/* now handle the working area */
 	{
 		const pl_penalty_struct *mypp;
+		struct monitor *m = FindScreenOfXY(arg->place_g.x, arg->place_g.y);
 
 		mypp = (arg->scratch->pp != 0 && 0) ? arg->scratch->pp :
 			&arg->place_fw->pl_penalty;
 		if (arg->flags.use_ewmh_dynamic_working_areapercent == 1)
 		{
 			penalty += EWMH_STRUT_PLACEMENT_PENALTY(mypp) *
-				EWMH_GetStrutIntersection(
+				EWMH_GetStrutIntersection(m,
 					arg->place_g.x, arg->place_g.y,
 					arg->place_p2.x, arg->place_p2.y,
 					arg->flags.use_percent);
@@ -1097,7 +1098,7 @@ static pl_penalty_t __pl_minoverlap_get_pos_penalty(
 			 */
 			penalty +=
 				EWMH_STRUT_PLACEMENT_PENALTY(mypp) *
-				EWMH_GetBaseStrutIntersection(
+				EWMH_GetBaseStrutIntersection(m,
 					arg->place_g.x, arg->place_g.y,
 					arg->place_p2.x, arg->place_p2.y,
 					arg->flags.use_percent);

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -90,9 +90,6 @@ static void apply_window_updates(
 	rectangle frame_g;
 	const exec_context_t *exc;
 	exec_context_changes_t ecc;
-	struct monitor	*m;
-
-	m = (t && t->m) ? t->m : monitor_get_current();
 
 	frame_g.x = t->g.frame.x;
 	frame_g.y = t->g.frame.y;

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -521,7 +521,7 @@ static void apply_window_updates(
 	}
 	if (flags->do_update_working_area)
 	{
-		EWMH_UpdateWorkArea(m);
+		EWMH_UpdateWorkArea(t->m ? t->m : monitor_get_current());
 	}
 	if (flags->do_update_ewmh_stacking_hints)
 	{

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2224,8 +2224,8 @@ void CMD_DesktopSize(F_CMD_ARGS)
 			(long)m->virtual_scr.CurrentDesk,
 			(long)m->virtual_scr.MyDisplayWidth,
 			(long)m->virtual_scr.MyDisplayHeight,
-			(long)((m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth)),
-			(long)((m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight)),
+			(long)((m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth) + 1),
+			(long)((m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight)+ 1),
 			(long)m->si->rr_output);
 
 		/* FIXME: likely needs per-monitor considerations!!! */

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2197,6 +2197,15 @@ void CMD_DesktopConfiguration(F_CMD_ARGS)
 	BroadcastMonitorList(NULL);
 }
 
+void
+calculate_page_sizes(struct monitor *m, int dx, int dy)
+{
+	m->virtual_scr.VxMax = dx *
+		m->virtual_scr.MyDisplayWidth - m->virtual_scr.MyDisplayWidth;
+	m->virtual_scr.VyMax = dy *
+		m->virtual_scr.MyDisplayHeight - m->virtual_scr.MyDisplayHeight;
+}
+
 void CMD_DesktopSize(F_CMD_ARGS)
 {
 	int val[2];
@@ -2210,13 +2219,12 @@ void CMD_DesktopSize(F_CMD_ARGS)
 		return;
 	}
 
-	/* FIXME: this needs broadcasting for all modules when global used. */
-
 	TAILQ_FOREACH(m, &monitor_q, entry) {
-		m->virtual_scr.VxMax = (val[0] <= 0) ?
-			0: val[0]*m->virtual_scr.MyDisplayWidth - m->virtual_scr.MyDisplayWidth;
-		m->virtual_scr.VyMax = (val[1] <= 0) ?
-			0: val[1]*m->virtual_scr.MyDisplayHeight - m->virtual_scr.MyDisplayHeight;
+		m->dx = val[0] <= 0 ? 1 : val[0];
+		m->dy = val[1] <= 0 ? 1 : val[1];
+
+		calculate_page_sizes(m, m->dx, m->dy);
+
 		BroadcastPacket(
 			M_NEW_PAGE, 8,
 			(long)m->virtual_scr.Vx,
@@ -2225,7 +2233,7 @@ void CMD_DesktopSize(F_CMD_ARGS)
 			(long)m->virtual_scr.MyDisplayWidth,
 			(long)m->virtual_scr.MyDisplayHeight,
 			(long)((m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth) + 1),
-			(long)((m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight)+ 1),
+			(long)((m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight) + 1),
 			(long)m->si->rr_output);
 
 		/* FIXME: likely needs per-monitor considerations!!! */

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -5,6 +5,7 @@
 
 #include "libs/FScreen.h"
 
+void calculate_page_sizes(struct monitor *, int, int);
 int HandlePaging(
 	XEvent *pev, int HorWarpSize, int VertWarpSize, int *xl, int *yt,
 	int *delta_x, int *delta_y, Bool Grab, Bool fLoop,

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -21,4 +21,15 @@ Bool get_page_arguments(FvwmWindow *, char *action, int *page_x, int *page_y,
     struct monitor **);
 char *GetDesktopName(struct monitor *, int desk);
 
+struct desktop_cmd {
+	int				 desk;
+	char				*name;
+
+	TAILQ_ENTRY(desktop_cmd)	 entry;
+};
+TAILQ_HEAD(desktop_cmds, desktop_cmd);
+struct desktop_cmds	 desktop_cmd_q;
+
+void apply_desktops_monitor(struct monitor *);
+
 #endif /* _VIRTUAL_ */

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -375,12 +375,6 @@ void FScreenInit(Display *dpy)
 
 	fprintf(stderr, "Using RandR %d.%d\n", major, minor);
 
-	if (ReferenceDesktops == NULL) {
-		ReferenceDesktops = fxcalloc(1, sizeof *ReferenceDesktops);
-		ReferenceDesktops->next = NULL;
-		ReferenceDesktops->desk = 0;
-	}
-
 	/* XRandR is present, so query the screens we have. */
 	res = XRRGetScreenResources(dpy, DefaultRootWindow(dpy));
 
@@ -395,8 +389,11 @@ void FScreenInit(Display *dpy)
 	scan_screens(dpy);
 
 	TAILQ_FOREACH(m, &monitor_q, entry) {
-		fprintf(stderr, "%s: mon: %s (%d x %d)\n", __func__, m->si->name,
-			m->virtual_scr.MyDisplayWidth, m->virtual_scr.MyDisplayHeight);
+		m->Desktops = fxcalloc(1, sizeof *m->Desktops);
+		m->Desktops->name = NULL;
+		m->Desktops->next = NULL;
+		m->Desktops->desk = 0;
+
 		monitor_set_flags(m);
 	}
 

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -567,9 +567,6 @@ FindScreen(fscreen_scr_arg *arg, fscreen_scr_t screen)
 		break;
 	}
 
-	if (m == NULL)
-		m = TAILQ_FIRST(&monitor_q);
-
 	return (m);
 }
 

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -9,12 +9,6 @@
 /* For CARD32 */
 #include <X11/Xproto.h>
 
-#include "fvwm/fvwm.h"
-#include "fvwm/execcontext.h"
-#include "fvwm/misc.h"
-#include "fvwm/screen.h"
-#include "fvwm/ewmh_intern.h"
-
 /* needs X11/Xlib.h and X11/Xutil.h */
 
 typedef struct

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -111,9 +111,6 @@ struct monitor {
          */
 	DesktopsInfo    *Desktops;
 
-	/* Information about EWMH */
-	ewmhInfo ewmhc;
-
         /* Information about EWMH. */
         struct {
                 unsigned NumberOfDesktops;

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -99,6 +99,7 @@ struct monitor {
 	struct screen_info	*si;
 	int			 win_count;
 	int			 flags;
+	int			 dx, dy;
 
 	/* info for some desktops; the first entries should be generic info
          * correct for any desktop not in the list

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -6,6 +6,15 @@
 #include <X11/extensions/Xrandr.h>
 #endif
 
+/* For CARD32 */
+#include <X11/Xproto.h>
+
+#include "fvwm/fvwm.h"
+#include "fvwm/execcontext.h"
+#include "fvwm/misc.h"
+#include "fvwm/screen.h"
+#include "fvwm/ewmh_intern.h"
+
 /* needs X11/Xlib.h and X11/Xutil.h */
 
 typedef struct
@@ -101,6 +110,9 @@ struct monitor {
          * correct for any desktop not in the list
          */
 	DesktopsInfo    *Desktops;
+
+	/* Information about EWMH */
+	ewmhInfo ewmhc;
 
         /* Information about EWMH. */
         struct {


### PR DESCRIPTION
These patches pave the way for `EWMHBaseStruts` per monitor, which as a config change would be described as:

```
EWMHBaseStruts screen SCREEN_NAME 1 2 3 4
```
* `SCREEN_NAME` is xrandr(1)-aware;
* `1 2 3 4` are pixel offsets from the screen edge not to cover.

If no `screen` parameter is given, the config is therefore applied to all screens.