### PR TITLE
unmaximize: use window's current screen for positioning

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -4640,9 +4640,11 @@ static void MaximizeWidth(
 static void unmaximize_fvwm_window(
 	FvwmWindow *fw)
 {
+	char	*cmd;
 	rectangle new_g;
 
 	SET_MAXIMIZED(fw, 0);
+
 	if (IS_SHADED(fw))
 	{
 		get_shaded_geometry(fw, &new_g, &new_g);
@@ -4686,6 +4688,11 @@ static void unmaximize_fvwm_window(
 
 	frame_setup_window(
 		fw, new_g.x, new_g.y, new_g.width, new_g.height, True);
+
+	asprintf(&cmd, "MoveToScreen %s", fw->m->si->name);
+	execute_function_override_window(NULL, NULL, cmd, 0, fw);
+	free(cmd);
+
 	border_draw_decorations(
 		fw, PART_ALL, (Scr.Hilite == fw), True, CLEAR_ALL, NULL, NULL);
 


### PR DESCRIPTION
When moving a maximized window between pages or screens, FVWM records
the previous geometry of the unmaximized window, so it can restore
correctly.

However, this doesn't work well when the maximized window itself has
moved between screens or different pages, since the unmaximized geometry
from the point of view of the maximized window is now incorrect.
Subsequently, unmaximizing a window will put that window in to the
ether.

For now, the approach is to make unmaximizing a window imply
MoveToScreen (relative to the window's screen) such that it remains
visible, and should largely do what the user expects.

Fixes #68