### PR TITLE
UPDATE_FVWM_SCREEN: remove win_count functionality

### DIFF
--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -475,18 +475,8 @@ typedef struct ScreenInfo
 		struct monitor *mnew; \
 		get_unshaded_geometry((fw), &g); \
 		mnew = FindScreenOfXY((fw)->g.frame.x, (fw)->g.frame.y); \
-		if (mnew == NULL) { \
-			fprintf(stderr, "CRAP - WHICH MONITOR?\n"); \
-			mnew = monitor_get_current(); \
-		} \
-		if (mnew != NULL) { \
-			if ((fw) && (fw)->m) { \
-				(fw)->m->win_count--; \
-			} \
-			(fw)->m_prev = (fw)->m; \
-			(fw)->m = mnew; \
-			(fw)->m->win_count++; \
-		} \
+		(fw)->m_prev = (fw)->m; \
+		(fw)->m = mnew; \
 	} while(0)
 
 /* A macro to to simplify he "ewmh desktop code" */

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -94,7 +94,6 @@ struct screen_info	*screen_info_by_name(const char *);
 
 struct monitor {
 	struct screen_info	*si;
-	int			 win_count;
 	int			 flags;
 
 	/* info for some desktops; the first entries should be generic info


### PR DESCRIPTION
In previous iterations of tracking which screen a given window was on,
or moved to, the assigned struct monitor would maintain a count of the
number of its windows.

This was meant to provide functionality which is not going to be used
now, so this can be removed.

Fixes #70