### PR TITLE
BroadcastMonitorList: reorder packet logic

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2599,6 +2599,8 @@ void HandleFocusIn(const evh_args_t *ea)
 		last_focus_w = focus_w;
 		last_focus_fw = focus_fw;
 		was_nothing_ever_focused = False;
+
+		BroadcastMonitorList(NULL);
 	}
 	if ((sf = get_focus_window()) != ffw_old)
 	{

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -458,35 +458,35 @@ void BroadcastName(
 void BroadcastMonitorList(fmodule *this)
 {
 	char		*name;
-	struct monitor	*m, *mcur;
+	struct monitor	*m;
 	fmodule_list_itr moditr;
 	fmodule *module;
 
 	module_list_itr_init(&moditr);
 
-	mcur = monitor_get_current();
-	TAILQ_FOREACH(m, &monitor_q, entry) {
-		if (m->si->is_disabled)
-			continue;
-		asprintf(&name, "Monitor %s %d %d %d %d %d %d %d %d",
-			m->si->name,
-			(int)m->si->rr_output,
-			m == mcur,
-			m->virtual_scr.MyDisplayWidth,
-			m->virtual_scr.MyDisplayHeight,
-			m->virtual_scr.Vx,
-			m->virtual_scr.Vy,
-			m->virtual_scr.VxMax,
-			m->virtual_scr.VyMax
-		);
+	while ((module = module_list_itr_next(&moditr)) != NULL) {
+		TAILQ_FOREACH(m, &monitor_q, entry) {
+			if (m->si->is_disabled)
+				continue;
+			asprintf(&name, "Monitor %s %d %d %d %d %d %d %d %d %d %d %d %d",
+				m->si->name,
+				(int)m->si->rr_output,
+				m == monitor_get_current(),
+				m->virtual_scr.MyDisplayWidth,
+				m->virtual_scr.MyDisplayHeight,
+				m->virtual_scr.Vx,
+				m->virtual_scr.Vy,
+				m->virtual_scr.VxMax,
+				m->virtual_scr.VyMax,
+				m->si->x,
+				m->si->y,
+				m->si->w,
+				m->si->h
+			);
 
-		if (this != NULL)
-			SendName(this, M_CONFIG_INFO, 0, 0, 0, name);
-		else {
-			while ((module = module_list_itr_next(&moditr)) != NULL)
-				SendName(module, M_CONFIG_INFO, 0, 0, 0, name);
+			SendName(module, M_CONFIG_INFO, 0, 0, 0, name);
+			free(name);
 		}
-		free(name);
 	}
 }
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -189,6 +189,8 @@ fpmonitor_by_output(int output)
 	return (NULL);
 }
 
+
+
 struct fpmonitor *
 fpmonitor_this(void)
 {
@@ -1506,18 +1508,23 @@ void list_config_info(unsigned long *body)
 	} else if (StrEquals(token, "Monitor")) {
 		char	*mname;
 		int		 output, mdw, mdh, vx, vy, vxmax, vymax, iscur;
+		int		 x, y, w, h;
 		int		 updated = 0;
 
 		tline = GetNextToken(tline, &mname);
-		sscanf(tline, "%d %d %d %d %d %d %d %d", &output, &iscur, &mdw, &mdh,
-				&vx, &vy, &vxmax, &vymax);
-
-		m = fxcalloc(1, sizeof(*m));
+		sscanf(tline, "%d %d %d %d %d %d %d %d %d %d %d %d",
+			&output, &iscur, &mdw, &mdh, &vx, &vy, &vxmax, &vymax,
+			&x, &y, &w, &h);
 
 		TAILQ_FOREACH(m2, &fp_monitor_q, entry) {
+			updated = 0;
 			if (strcmp(m2->name, mname) == 0) {
+				m2->x = x;
+				m2->y = y;
+				m2->w = w;
+				m2->h = h;
 				m2->output = output;
-				m2->is_current = iscur; 
+				m2->is_current = iscur;
 				m2->virtual_scr.MyDisplayWidth = mdw;
 				m2->virtual_scr.MyDisplayHeight = mdh;
 				m2->virtual_scr.Vx = vx;
@@ -1528,12 +1535,16 @@ void list_config_info(unsigned long *body)
 			}
 		}
 
-		if (updated) {
-			free(m);
+		if (updated)
 			return;
-		}
+
+		m = fxcalloc(1, sizeof(*m));
 
 		m->name = fxstrdup(mname);
+		m->x = x;
+		m->y = y;
+		m->w = w;
+		m->h = h;
 		m->is_current = iscur;
 		m->output = output;
 		m->virtual_scr.MyDisplayWidth = mdw;
@@ -1852,7 +1863,7 @@ void ParseOptions(void)
 	    TAILQ_FOREACH(m2, &fp_monitor_q, entry) {
 		    if (strcmp(m2->name, mname) == 0) {
 			    m2->output = output;
-			    m2->is_current = iscur; 
+			    m2->is_current = iscur;
 			    m2->virtual_scr.MyDisplayWidth = mdw;
 			    m2->virtual_scr.MyDisplayHeight = mdh;
 			    m2->virtual_scr.Vx = vx;
@@ -2433,7 +2444,7 @@ void ParseOptions(void)
 			  m->virtual_scr.VHeight, m->virtual_scr.VxPages, m->virtual_scr.VyPages);
 
   }
-  
+
   return;
 }
 

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -6,11 +6,11 @@
 struct fpmonitor {
 	char		*name;
 	int		 is_primary, output;
-	int 		 number;
 	int		 win_count;
 	int		 wants_refresh;
 	int		 is_disabled;
 	int		 is_current;
+	int		 x, y, w, h;
 
         struct {
                 int VxMax;


### PR DESCRIPTION
When a module requests M_CONFIG_INFO for Monitor, recalculate that per
module, rather than the other way round.

Should help fix #44