### PR TITLE
remove dependency on Perl4::CoreLibs::getcwd (fvwm3)

### DIFF
--- a/perllib/General/FileSystem.pm
+++ b/perllib/General/FileSystem.pm
@@ -1066,7 +1066,7 @@ Returns the current working directory.
 
 
 sub get_cwd () {
-	$^O eq "MSWin32" ? Win32::GetCwd() : require "getcwd.pl" && getcwd();
+	$^O eq "MSWin32" ? Win32::GetCwd() : require Cwd && getcwd()."\n";
 }
 
 


### PR DESCRIPTION
Cwd module is used instead of outdated getcwd.pl from Perl4::CoreLibs
see: https://metacpan.org/pod/Perl4::CoreLibs
To keep old behaviour "\n" is added to the output.