### PR TITLE
UPDATE_FVWM_SCREEN: respect StartsOnDesk style

### DIFF
--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -603,6 +603,7 @@ typedef struct style_flags
 	unsigned has_initial_map_command_string : 1;
 	unsigned has_title_format_string : 1;
 	unsigned has_icon_title_format_string : 1;
+	unsigned initial_placement_done : 1;
 } style_flags;
 
 typedef struct style_id_t

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -1556,8 +1556,6 @@ static int __place_get_nowm_pos(
 		attr_g->y = final_g.y;
 	}
 
-	UPDATE_FVWM_SCREEN(fw);
-
 	return 0;
 }
 
@@ -1693,7 +1691,6 @@ static int __place_window(
 			FScreenGetScrRect(&arg, FSCREEN_BY_NAME,
 				&screen_g.x, &screen_g.y,
 				&screen_g.width, &screen_g.height);
-			free(e);
 
 			/* FIXME:  Set the monitor here, but make
 			 * UPDATE_FVWM_SCREEN aware of how to do this.
@@ -1701,6 +1698,7 @@ static int __place_window(
 			 * This is necessary for StartsOnScreen
 			 */
 			fw->m = monitor_by_name(arg.name);
+			free(e);
 		}
 		else
 		{
@@ -1810,6 +1808,7 @@ static int __place_window(
 			}
 		}
 
+#if 0
 		{
 			/* migo - I am not sure this block is ever needed */
 
@@ -1834,6 +1833,7 @@ static int __place_window(
 				}
 			}
 		}
+#endif
 	}
 	reason->desk.desk = fw->Desk;
 	/* I think it would be good to switch to the selected desk
@@ -1904,7 +1904,8 @@ static int __place_window(
 		((!Restarting && Scr.flags.are_windows_captured))) {
 		struct monitor *mnew = FindScreenOfXY(attr_g->x, attr_g->y);
 		fw->m = mnew;
-		fw->Desk = mnew->virtual_scr.CurrentDesk;
+		do_move_window_to_desk(fw, mnew->virtual_scr.CurrentDesk);
+		pstyle->flags.initial_placement_done = 1;
 	}
 
 	reason->pos.x = attr_g->x;

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -31,6 +31,11 @@
 #ifndef _SCREEN_
 #define _SCREEN_
 
+#include "config.h"
+
+#include "fvwm/update.h"
+#include "fvwm/style.h"
+
 #include "libs/flist.h"
 #include "libs/Bindings.h"
 
@@ -469,14 +474,22 @@ typedef struct ScreenInfo
 	} last_added_item;
 } ScreenInfo;
 
-#define UPDATE_FVWM_SCREEN(fw) \
-	do { \
-		rectangle g; \
-		struct monitor *mnew; \
-		get_unshaded_geometry((fw), &g); \
-		mnew = FindScreenOfXY((fw)->g.frame.x, (fw)->g.frame.y); \
-		(fw)->m_prev = (fw)->m; \
-		(fw)->m = mnew; \
+#define UPDATE_FVWM_SCREEN(fw)						   \
+	do {								   \
+		rectangle g;						   \
+		struct monitor *mnew;					   \
+		window_style style;					   \
+									   \
+		lookup_style((fw), &style);				   \
+		get_unshaded_geometry((fw), &g);			   \
+		mnew = FindScreenOfXY((fw)->g.frame.x, (fw)->g.frame.y);   \
+		/* Avoid unnecessary updates. */			   \
+		if (mnew == (fw)->m)					   \
+			break;						   \
+		(fw)->m_prev = (fw)->m;					   \
+		(fw)->m = mnew;						   \
+		(fw)->Desk = mnew->virtual_scr.CurrentDesk;		   \
+		BroadcastConfig(M_CONFIGURE_WINDOW, (fw));		   \
 	} while(0)
 
 /* A macro to to simplify he "ewmh desktop code" */

--- a/fvwm/stack.c
+++ b/fvwm/stack.c
@@ -1511,6 +1511,7 @@ static Bool is_on_top_of_layer_ignore_rom(FvwmWindow *fw)
 {
 	FvwmWindow *t;
 	Bool ontop = True;
+	struct monitor *m = fw->m;
 
 	if (IS_SCHEDULED_FOR_DESTROY(fw))
 	{
@@ -1523,6 +1524,9 @@ static Bool is_on_top_of_layer_ignore_rom(FvwmWindow *fw)
 	}
 	for (t = fw->stack_prev; t != &Scr.FvwmRoot; t = t->stack_prev)
 	{
+		if (t->m != m)
+			continue;
+
 		if (t->layer > fw->layer)
 		{
 			break;


### PR DESCRIPTION
Previously, when StartsOnDesk was used, although the desk was correctly
set, the desk would never change thereafter, once the window was moved.

This was because the UPDATE_FVWM_SCREEN macro assumed it could always
update the window, but never took into account that when moving
monitors, the desk also needed to be changed.

But this can't blindly happen in all cases, as on initla mapping of the
window, the UPDATE_FVWM_SCREEN macro would have overriden the
StartsOnDesk style.

This change introduces a flag to track this as well as reducing the
number of assigments which weren't needed when updating the screen.
Also removed an extraneous assignment.

Helps #86