### PR TITLE
configure: resurrect VERSIONINFO

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,15 +13,13 @@ fi
 # Silence warning: ar: 'u' modifier ignored since 'D' is the default
 AC_SUBST(AR_FLAGS, [cr])
 
-AC_INIT([fvwm3],
-	m4_esyscmd_s([utils/fvwm-version-str.sh]),
-	[fvwm-workers@fvwm.org])
+AC_INIT([fvwm3], 3.0.0, [fvwm-workers@fvwm.org])
 AC_CONFIG_AUX_DIR(etc)
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
 AM_CONFIG_HEADER(config.h)
 
-VERSIONINFO=""
+VERSIONINFO=m4_esyscmd([./utils/fvwm-version-str.sh])
 
 dnl date of the released version (please zero pad the day in the last 2 dates)
 dnl for example: "4 February 2003", "04 Feb 2003", "2003-02-04"
@@ -1710,7 +1708,7 @@ test x"$USE_NLS" = xno && my_localedir="(Not installed) $my_localdir"
 echo "
 Fvwm3 Configuration:
 
-  Version:     $VERSION$VERSIONINFO
+  Version:     $VERSION ($VERSIONINFO)
 
   Executables: $my_bindir
   Man pages:   $my_mandir

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1261,7 +1261,7 @@ static void setVersionInfo(void)
 	int support_len;
 
 	/* Set version information string */
-	sprintf(version_str, "fvwm3 %s%s compiled on %s at %s",
+	sprintf(version_str, "fvwm3 %s (%s) compiled on %s at %s",
 		VERSION, VERSIONINFO, __DATE__, __TIME__);
 	Fvwm_VersionInfo = fxstrdup(version_str);
 

--- a/modules/FvwmConsole/FvwmConsole.c
+++ b/modules/FvwmConsole/FvwmConsole.c
@@ -191,7 +191,7 @@ void server(void)
 	socklen_t clen;     /* length of sockaddr */
 	char buf[MAX_COMMAND_SIZE];      /*  command line buffer */
 	char *tline;
-	char ver[40];
+	char ver[200];
 	fd_set fdset;
 	char *home;
 	int s;
@@ -255,12 +255,10 @@ void server(void)
 		GetConfigLine(Fd, &tline);
 	}
 	fvwm_send(Ns, C_END, strlen(C_END), 0);
-	strcpy(ver, "*");
-	strcpy(ver, module->name);
-	strcat(ver, " version ");
-	strcat(ver, VERSION VERSIONINFO);
-	strcat(ver, "\n");
+	snprintf(ver, sizeof ver, "*%s version %s (%s)", module->name, VERSION,
+	    VERSIONINFO);
 	fvwm_send(Ns, ver, strlen(ver), 0);
+	fvwm_send(Ns, "\n\n", 2, 0);
 
 	while (1)
 	{

--- a/utils/fvwm-version-str.sh
+++ b/utils/fvwm-version-str.sh
@@ -10,7 +10,7 @@
 #
 # Intended to be called from configure.ac (via autogen.sh)
 
-VERSION=3.0.0
+VERSION=""
 
 [ -d ".git" ] || { echo "$VERSION" && exit 0 ; }
 


### PR DESCRIPTION
When embedding the git revision string into the version number of FVWM3,
don't overwrite VERSION with the git SHA1.

VERSION is required as the released version so that modules are
maintained in a correct manner, and that version checks for things like
state files (across FVWM3 reboots) are still honoured correctly.