### PR TITLE
key binding and menu option for dmenu_run

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -284,6 +284,7 @@ AddToMenu   MenuFvwmRoot "Fvwm" Title
 + "&Programs%icons/programs.png%" Popup MenuPrograms
 + "XDG &Menu%icons/apps.png%" Popup XDGMenu
 + "&XTerm%icons/terminal.png%" Exec exec $[infostore.terminal]
+Test (x dmenu_run) + "Run command" Exec exec dmenu_run
 + "" Nop
 + "Fvwm&Console%icons/terminal.png%" Module FvwmConsole -terminal $[infostore.terminal]
 + "&Wallpapers%icons/wallpaper.png%" Popup BGMenu
@@ -449,6 +450,7 @@ AddToMenu   MenuFvwmManPages "Help" Title
 # Alt-F1 or Menu to load the root menu and Alt-Tab for a WindowList.
 # Ctrl-F1/F2/F3/F4 will switch between the Virtual Desktops.
 # Super_R (windows key) will launch a terminal.
+# Alt-Space to launch dmenu (Note: dmenu must be present in the system)
 #
 # Silent supresses any errors (such as keyboards with no Menu key).
 Silent Key F1 A M Menu MenuFvwmRoot
@@ -459,6 +461,7 @@ Silent Key F2 A C GotoDesk 0 1
 Silent Key F3 A C GotoDesk 0 2
 Silent Key F4 A C GotoDesk 0 3
 Silent Key Super_R A A Exec exec $[infostore.terminal]
+Silent Key Space A M Exec exec dmenu_run
 
 # Window Buttons: [1 3 5 7 9  TTTTT  0 8 6 4 2]
 #   1 - Open the WindowOps menu.


### PR DESCRIPTION
Adds Meta+Space as trigger for dmenu_run
Tests the existence of dmenu and if present Adds "Run command" into fvwm menu. (Probably a run command icon is required) to accompany the menu.