### PR TITLE
verbose: actually open log file

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2081,6 +2081,7 @@ int main(int argc, char **argv)
 		else if (strcmp(argv[i], "-v") == 0)
 		{
 			log_set_level(1);
+			log_open();
 		}
 		else
 		{


### PR DESCRIPTION
When passing -v to fvwm3, actually open the log file, rather than just
setting the log level.