### PR TITLE
IconBox: reference screen correctly

### DIFF
--- a/fvwm/icons.c
+++ b/fvwm/icons.c
@@ -1791,8 +1791,19 @@ void AutoPlaceIcon(
 	break;
       }
       /* get the screen dimensions for the icon box */
-      FScreenGetScrRect(fscr, FSCREEN_CURRENT,
+      if (icon_boxes_ptr->IconScreen == NULL ||
+          strcmp(icon_boxes_ptr->IconScreen, "global") == 0) {
+	      ref.x = 0;
+	      ref.y = 0;
+	      ref.width = monitor_get_all_widths();
+	      ref.height = monitor_get_all_heights();
+	      fvwm_debug(__func__, "using global screen");
+      } else {
+	      fscr->name = icon_boxes_ptr->IconScreen;
+	      FScreenGetScrRect(fscr, FSCREEN_BY_NAME,
 		        &ref.x, &ref.y, &ref.width, &ref.height);
+	      fvwm_debug(__func__, "using screen %s ", fscr->name);
+      }
       dim[1].screen_offset = ref.y;
       dim[1].screen_dimension = ref.height;
       dim[2].screen_offset = ref.x;

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -1826,7 +1826,7 @@ static char *style_parse_icon_box_style(
 
 	/* otherwise try to parse the icon box */
 	IconBoxes = fxcalloc(1, sizeof(icon_boxes));
-	IconBoxes->IconScreen = "global";
+	IconBoxes->IconScreen = fxstrdup("global");
 	/* init grid x */
 	IconBoxes->IconGrid[0] = 3;
 	/* init grid y */
@@ -1838,7 +1838,10 @@ static char *style_parse_icon_box_style(
 		is_screen_given = True;
 		option = PeekToken(rest, &rest); /* skip screen */
 		option = PeekToken(rest, &rest); /* get the screen spec */
-		IconBoxes->IconScreen = option;
+		free(IconBoxes->IconScreen);
+		IconBoxes->IconScreen = fxstrdup(option);
+
+		fvwm_debug(__func__, "screen set: %s", option);
 	}
 
 	/* try for 4 numbers x y x y */
@@ -1892,6 +1895,7 @@ static char *style_parse_icon_box_style(
 		option = PeekToken(rest, NULL);
 		if (!option)
 		{
+			fvwm_debug(__func__, "No option set, returning: <<%s>>", rest);
 			return rest;
 		}
 		l = strlen(option);
@@ -1899,9 +1903,11 @@ static char *style_parse_icon_box_style(
 		{
 			char *scr;
 
+			fvwm_debug(__func__, "option 1: %s", option);
 			/* advance */
 			option = PeekToken(rest, &rest);
 			/* if word found, not too long */
+			fvwm_debug(__func__, "option 2: %s", option);
 			geom_flags = FScreenParseGeometryWithScreen(
 				option, &IconBoxes->IconBox[0],
 				&IconBoxes->IconBox[1],	(unsigned int*)&width,
@@ -4810,12 +4816,7 @@ void free_icon_boxes(icon_boxes *ib)
 		temp = ib->next;
 		if (ib->use_count == 0)
 		{
-			if (ib->do_free_screen)
-			{
-				free(ib->IconScreen);
-				ib->IconScreen = NULL;
-				ib->do_free_screen = 0;
-			}
+			free(ib->IconScreen);
 			free(ib);
 		}
 		else


### PR DESCRIPTION
When the IconBox style is used to specify a particular screen, use the
existing API to reference that screen.

Fixes #40
