### PR TITLE
removed BroadcastMonitorList from HandleFocusIn:

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2596,7 +2596,6 @@ void HandleFocusIn(const evh_args_t *ea)
 		last_focus_fw = focus_fw;
 		was_nothing_ever_focused = False;
 
-		BroadcastMonitorList(NULL);
 	}
 	if ((sf = get_focus_window()) != ffw_old)
 	{


### PR DESCRIPTION
In HandleFocusIn do_force_broadcast gets set which forces BroadcastMonitorList to be sent to all modules every time focus is moved to a window.  As a result FvwmBacker reloads background screen way too often, even when monitor has not changed.  Perhaps monitor updates should be handled by monitor_update_ewmh ...