### PR TITLE
Colorset variable expansion features.

### DIFF
--- a/doc/fvwm/expansion.xml
+++ b/doc/fvwm/expansion.xml
@@ -441,15 +441,32 @@ command can be used:</para>
       $[bg.cs&lt;n&gt;]
       $[hilight.cs&lt;n&gt;]
       $[shadow.cs&lt;n&gt;]
+      $[fgsh.cs&lt;n&gt;]
     </term>
     <listitem>
       <para>
 	These parameters are replaced with the name of the foreground
-	(fg), background (bg), hilight (hilight) or shadow (shadow) color
-	that is defined in colorset &lt;n&gt; (replace &lt;n&gt; with zero
-	or a positive integer).  For example "$[fg.cs3]" is expanded to the
-	name of the foreground color of colorset 3 (in rgb:rrrr/gggg/bbbb
-	form).  Please refer to the
+	(fg), background (bg), hilight (hilight), shadow (shadow), or
+        the font shadow (fgsh) color that is defined in colorset &lt;n&gt;
+        (replace &lt;n&gt; with zero or a positive integer).  For example
+        "$[fg.cs3]" is expanded to the name of the foreground color of
+        colorset 3 (in rgb:rrrr/gggg/bbbb form).
+      </para>
+      <para>
+        If .lighten&lt;p&gt; or .darken&lt;p&gt; is appeneded to the
+        parameters, they are instead replaced with a color that is
+        lighter or darker than the one defined in colorset &lt;n&gt;
+        by a percentage value &lt;p&gt; (between 0 and 100). For example
+        "$[bg.cs3.lighten15]" is expanded to the background color of
+        colorset 3 and then lightened 15% (in rgb:rrrr/gggg/bbbb form).
+      </para>
+      <para>
+        If .hash is appened to the end the color output will use
+        #rrggbb form (instead of rgb:rrrr/gggg/bbbb). For example,
+        $[bg.cs3.hash] or $[bg.cs3.lighten15.hash].
+      </para>
+      <para>
+        Please refer to the
 	<fvwmref sect="colorsets" opt="colorsets" name="Colorsets"/>
 	section for details about colorsets.
       </para>

--- a/doc/fvwm/expansion.xml
+++ b/doc/fvwm/expansion.xml
@@ -453,7 +453,7 @@ command can be used:</para>
         colorset 3 (in rgb:rrrr/gggg/bbbb form).
       </para>
       <para>
-        If .lighten&lt;p&gt; or .darken&lt;p&gt; is appeneded to the
+        If .lighten&lt;p&gt; or .darken&lt;p&gt; is appended to the
         parameters, they are instead replaced with a color that is
         lighter or darker than the one defined in colorset &lt;n&gt;
         by a percentage value &lt;p&gt; (between 0 and 100). For example

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -407,10 +407,10 @@ static signed int expand_vars_extended(
 				csadj = -l;
 			}
 			/* Check for .hash */
-			if (strcmp(rest + n + nn,  ".hash") == 0)
+			if (StrEquals(rest + n + nn,  ".hash"))
 			{
 				use_hash = True;
-				nn = nn + 5;
+				nn += strlen(".hash");
 				if (csadj == 101)
 				{
 					csadj = 0;

--- a/libs/ColorUtils.h
+++ b/libs/ColorUtils.h
@@ -17,13 +17,13 @@ Pixel GetTintedPixel(Pixel in, Pixel tint, int percent);
 /* This function converts the colour stored in a colorcell (pixel) into the
  * string representation of a colour.  The output is printed at the
  * address 'output'.  It is either in rgb format ("rgb:rrrr/gggg/bbbb") if
- * use_hash is False or in hash notation ("#rrrrggggbbbb") if use_hash is true.
+ * use_hash is False or in hash notation ("#rrggbb") if use_hash is true.
  * The return value is the number of characters used by the string.  The
  * rgb values of the output are undefined if the colorcell is invalid.  The
  * memory area pointed at by 'output' must be at least 64 bytes (in case of
  * future extensions and multibyte characters).*/
 int pixel_to_color_string(
-	Display *dpy, Colormap cmap, Pixel pixel, char *output, Bool use_hash);
+	Display *dpy, Colormap cmap, Pixel pixel, char *output, Bool use_hash, int adj);
 
 Pixel GetSimpleColor(char *name);
 /* handles colorset color names too */


### PR DESCRIPTION
```
  * Added appending .lighten<p> and .darken<p> to a colorset
    variable expansion, such as $[fg.cs<n>.lighten<p>]
    or $[shadow.cs<n>.darken<p>], that will lighten or darken
    the color by percentage p before outputing the color string.
  * Added appending .hash to the end of the colorset variable
    expansion to output the color as a hash, "#rrggbb", instead
    of the color form "rgb:rrrr/gggg/bbbb". Examples:
    $[bg.cs10.hash] or $[fgsh.cs5.darken20.hash].
  * Added missing $[fgsh.cs<n>] description to the manpage.
```