### PR TITLE
monitor: track focus event separately

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2444,6 +2444,7 @@ void HandleFocusIn(const evh_args_t *ea)
 	static Window last_focus_fw = None;
 	static Bool was_nothing_ever_focused = True;
 	FvwmWindow *fw = ea->exc->w.fw;
+	struct monitor *mon = monitor_get_current();
 
 	Scr.focus_in_pending_window = NULL;
 	/* This is a hack to make the PointerKey command work */
@@ -2591,12 +2592,17 @@ void HandleFocusIn(const evh_args_t *ea)
 				(unsigned long)IsLastFocusSetByMouse(),
 				(long)fc, (long)bc);
 			EWMH_SetActiveWindow(focus_w);
+
+			if (fw != NULL && strcmp(fw->m->si->name, prev_focused_monitor) != 0) {
+				BroadcastName(MX_MONITOR_FOCUS, -1, -1, -1,
+				    fw->m->si->name /* Name of the monitor. */
+			        );
+			}
 		}
 		last_focus_w = focus_w;
 		last_focus_fw = focus_fw;
 		was_nothing_ever_focused = False;
 
-		BroadcastMonitorList(NULL);
 	}
 	if ((sf = get_focus_window()) != ffw_old)
 	{

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -58,6 +58,7 @@ DesktopsInfo	 *ReferenceDesktops;
 struct screen_infos	 screen_info_q;
 struct monitors		monitor_q;
 int randr_event;
+const char *prev_focused_monitor;
 
 static void GetMouseXY(XEvent *eventp, int *x, int *y)
 {
@@ -117,11 +118,20 @@ monitor_get_current(void)
 	int		 JunkX = 0, JunkY = 0, x, y;
 	Window		 JunkRoot, JunkChild;
 	unsigned int	 JunkMask;
+	struct monitor	  *mon;
+	static const char *cur_mon;
+
+	prev_focused_monitor = cur_mon;
 
 	FQueryPointer(disp, DefaultRootWindow(disp), &JunkRoot, &JunkChild,
 			&JunkX, &JunkY, &x, &y, &JunkMask);
 
-	return (FindScreenOfXY(x, y));
+	mon = FindScreenOfXY(x, y);
+
+	if (mon != NULL)
+		cur_mon = mon->si->name;
+
+	return (mon);
 }
 
 struct monitor *

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -167,6 +167,7 @@ void		 monitor_add_new(void);
 #define FSCREEN_MANGLE_USPOS_HINTS_MAGIC ((short)-32109)
 
 extern int randr_event;
+extern const char *prev_focused_monitor;
 
 /* Control */
 Bool FScreenIsEnabled(void);

--- a/libs/Module.h
+++ b/libs/Module.h
@@ -121,8 +121,9 @@ typedef struct
 #define MX_MONITOR_ENABLED        ((1<<4) | M_EXTENDED_MSG)
 #define MX_MONITOR_DISABLED       ((1<<5) | M_EXTENDED_MSG)
 #define MX_MONITOR_CHANGED        ((1<<6) | M_EXTENDED_MSG)
-#define MX_REPLY		  ((1<<7) | M_EXTENDED_MSG)
-#define MAX_EXTENDED_MESSAGES     8
+#define MX_MONITOR_FOCUS	  ((1<<7) | M_EXTENDED_MSG)
+#define MX_REPLY		  ((1<<8) | M_EXTENDED_MSG)
+#define MAX_EXTENDED_MESSAGES     9
 #define DEFAULT_XMSG_MASK         0x00000000
 #define MAX_XMSG_MASK             0x0000001f
 


### PR DESCRIPTION
When modules learned of the ability to send monitor information, this
was previously sent on all window focus events, as the FVWM modules
required this to reset which monitor had the focus.

This is not ideal with other modules which end up consuming this
information when they might not care about monitor information at all.

Instead, remove BroadcastMonitor() from FocusIn events and set FvwmPager
to be a listener of MX_MONITOR_FOCUS.