### PR TITLE
Github shields: switch to Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 FVWM3
 -----
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/0bfafcfd16b84a96a1305e92de2d6c4c)](https://app.codacy.com/gh/fvwmorg/fvwm3?utm_source=github.com&utm_medium=referral&utm_content=fvwmorg/fvwm3&utm_campaign=Badge_Grade_Settings)
-[![Build Status](https://travis-ci.org/fvwmorg/fvwm3.svg?branch=master)](https://travis-ci.org/fvwmorg/fvwm3)
+[![Codacy Status](https://api.codacy.com/project/badge/Grade/0bfafcfd16b84a96a1305e92de2d6c4c)](https://app.codacy.com/gh/fvwmorg/fvwm3?utm_source=github.com&utm_medium=referral&utm_content=fvwmorg/fvwm3&utm_campaign=Badge_Grade_Settings)
+![Build Status](https://github.com/fvwmorg/fvwm3/workflows/FVWM3%20CI/badge.svg)
 ![Open issues](https://img.shields.io/github/issues-raw/fvwmorg/fvwm3)
 ![GitHub contributors](https://img.shields.io/github/contributors/fvwmorg/fvwm3)
 


### PR DESCRIPTION
Migrate the CI shield from Travis-CI to Github Actions.