### PR TITLE
CI: switch to using image on Docker hub

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,12 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        repo-token: ${{ secrets.FVWM3_READ_TOKEN }}
-    - name: Docker Login
-      run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{ secrets.FVWM3_READ_TOKEN }}
     - name: Pulling docker image
-      run: docker pull docker.pkg.github.com/smoothwall/build-core/build-base:latest
+      run: docker pull fvwmorg/fvwm3-build:latest
     - name: Build Package
       run: 'docker build -t fvwm3 .'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.pkg.github.com/fvwmorg/fvwm3/fvwm3-build:latest
+FROM fvwmorg/fvwm3-build:latest
+#FROM docker.pkg.github.com/fvwmorg/fvwm3/fvwm3-build:latest
 
 COPY . /build
 WORKDIR /build


### PR DESCRIPTION
Until such time that Github Actions allow for pulling from public Docker
images without credentials, move this to Docker Hub.

This sucks.