### PR TITLE
Avoid use uninitialized variables

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -417,23 +417,25 @@ static inline void _handle_cr_on_icon(XEvent *e, FvwmWindow *fw)
 	{
 		rectangle g;
 
-		get_icon_picture_geometry(fw, &g);
-		xwc.x = g.x;
-		xwc.y = g.y;
-		xwcm = cre->value_mask & (CWX | CWY);
-		XConfigureWindow(
-			dpy, FW_W_ICON_PIXMAP(fw), xwcm, &xwc);
+		if(get_icon_picture_geometry(fw, &g)){
+			xwc.x = g.x;
+			xwc.y = g.y;
+			xwcm = cre->value_mask & (CWX | CWY);
+			XConfigureWindow(
+				dpy, FW_W_ICON_PIXMAP(fw), xwcm, &xwc);
+		}
 	}
 	if (FW_W_ICON_TITLE(fw) != None)
 	{
 		rectangle g;
 
-		get_icon_title_geometry(fw, &g);
-		xwc.x = g.x;
-		xwc.y = g.y;
-		xwcm = cre->value_mask & (CWX | CWY);
-		XConfigureWindow(
-			dpy, FW_W_ICON_TITLE(fw), xwcm, &xwc);
+		if(get_icon_title_geometry(fw, &g)){
+			xwc.x = g.x;
+			xwc.y = g.y;
+			xwcm = cre->value_mask & (CWX | CWY);
+			XConfigureWindow(
+				dpy, FW_W_ICON_TITLE(fw), xwcm, &xwc);
+		}
 	}
 
 	return;


### PR DESCRIPTION
I think this patch avoids any possible use of an uninitialized variable.
The **get_icon_picture_geometry** and **get_icon_title_geometry** functions can return false. In this case, the variables **g.x** and **g.y** could be empty.