### PR TITLE
update documentation for PrintInfo : it now writes to ~/fvwm3-output instead of stderr

### DIFF
--- a/doc/commands/PrintInfo.xml
+++ b/doc/commands/PrintInfo.xml
@@ -23,7 +23,13 @@
 
 <para>Print information on
 <replaceable>subject</replaceable>
-on stderr.  An optional integer argument
+to debug log file, which defaults to <filename>$HOME/.fvwm/fvwm3-output.log</filename> . Environment variables <envar>$FVWM_USERDIR</envar> and 
+<envar>$FVWM3_LOGFILE</envar> can alter this default.  For this logfile to be 
+written, either fvwm3 has to be started with <option>-v</option> option or 
+<option>SIGUSR2</option> signal can be used to toggle opening/closing debug 
+log file.</para>
+
+<para> An optional integer argument
 <replaceable>verbose</replaceable>
 defines the level of information which is given.
 The current valid subjects are:</para>

--- a/doc/fvwm/description.xml
+++ b/doc/fvwm/description.xml
@@ -11,18 +11,14 @@ memory consumption, provide a 3D look to window frames, and a
 virtual desktop.</para>
 
 <para>Note that there are several window managers around that have
-"fvwm" in their name.  In the past, version 2.x of fvwm was
-commonly called fvwm2 to distinguish it from the former version
-1.x (fvwm or even fvwm1).  Since version 1.x has been replaced by
-version 2.x a long time ago we simply call version 2.x and all
-versions to come, fvwm, throughout this document, and the
-executable program is named fvwm.  There is an fvwm offspring
-called fvwm95, it is mostly a patched version of fvwm-2.0.43.  The
-main goal of fvwm95 was to supply a Windows 95 like look and
-feel. Since then, fvwm has been greatly enhanced and practically
-all fvwm95 features can be achieved by fvwm.</para>
+"fvwm" in their name. Fvwm3 is the successor to fvwm2, which 
+preceded the 1.x versions of fvwm. This version is simply called
+fvwm throughout this document, while the main executable is named 
+fvwm3.</para>
 
-<para>Fvwm provides both a large
+<para> Fvwm is intended to have a small memory footprint but a rich feature 
+set, be extremely customizable and extendible, and have a high degree of Motif 
+mwm compatibility.  Fvwm provides both a large
 <emphasis remap='I'>virtual desktop</emphasis>
 and
 <emphasis remap='I'>multiple disjoint desktops</emphasis>

--- a/doc/fvwm/environment.xml
+++ b/doc/fvwm/environment.xml
@@ -21,11 +21,31 @@ are the following:
     </listitem>
   </varlistentry>
   <varlistentry>
+    <term><envar>FVWM_USERDIR</envar></term>
+    <listitem>
+      <para>Used to determine the user's data directory for reading and
+	writing files. If this variable is not already
+	set, it is set by fvwm to <filename>$HOME/.fvwm</filename>, which
+	is the default user's data directory.</para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
     <term><envar>FVWM3_LOGFILE</envar></term>
     <listitem>
       <para>Used to determine the path and filename to log debug information
-	      from fvwm3.
+          from fvwm3. By default debug log is written to 
+          <envar>$FVWM_USERDIR</envar>/fvwm3-output.log . If an absolute path
+          is specified (starting with /) then <envar>$FVWM_USERDIR</envar> is 
+          ignored, otherwise the log is written to 
+          <envar>$FVWM_USERDIR</envar>/<envar>$FVWM3_LOGFILE</envar> .
       </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term><envar>FVWM_DATADIR</envar></term>
+    <listitem>
+        <para>Set by fvwm to the directory containing fvwm config and module 
+            data.</para>
     </listitem>
   </varlistentry>
   <varlistentry>
@@ -33,15 +53,6 @@ are the following:
     <listitem>
       <para>Set by fvwm to the directory containing the standard fvwm
 	modules.</para>
-    </listitem>
-  </varlistentry>
-  <varlistentry>
-    <term><envar>FVWM_USERDIR</envar></term>
-    <listitem>
-      <para>Used to determine the user's data directory for reading and
-	sometimes writing personal files. If this variable is not already
-	set, it is set by fvwm to <filename>$HOME/.fvwm</filename>, which
-	is the default user's data directory.</para>
     </listitem>
   </varlistentry>
   <varlistentry>
@@ -70,4 +81,5 @@ and normally are removed automatically when not used anymore.</para>
     </listitem>
   </varlistentry>
 </variablelist>
+<para><command>fvwm-config --info</command> is useful to query fvwm3 compiled-in paths</para>
 </section>

--- a/doc/fvwm/ewmh.xml
+++ b/doc/fvwm/ewmh.xml
@@ -10,7 +10,7 @@
 <title>Extended Window Manager Hints</title>
 <para>Fvwm attempts to respect the extended window manager hints (ewmh
 or <acronym>EWMH</acronym> for short) specification:
-<ulink url='http://www.freedesktop.org/wiki/Standards_2fwm_2dspec'>http://www.freedesktop.org/wiki/Standards_2fwm_2dspec</ulink>
+<ulink url='https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html'>https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html</ulink>
 and some extensions of this specification.  This allows fvwm to
 work with
 <acronym>KDE</acronym>

--- a/doc/fvwm/options.xml
+++ b/doc/fvwm/options.xml
@@ -79,8 +79,7 @@ instead of the name obtained from the environment variable
   <listitem>
 <para>Puts X transactions in synchronous mode, which dramatically slows
 things down, but guarantees that fvwm's internal error messages
-are correct. Also causes fvwm to output debug messages while
-running.</para>
+are correct.</para>
   </listitem>
   </varlistentry>
   <varlistentry>
@@ -93,9 +92,8 @@ running.</para>
 <replaceable>config-file</replaceable>
 instead of
 <filename>~/.fvwm/config</filename>
-as its initialization file.  This is equivalent to
--c '<fvwmref cmd="Read"/>
-<replaceable>config-file</replaceable>'.</para>
+as its initialization file. <envar>$FVWM_USERDIR</envar> can also be used to 
+change location of default user directory <filename>~/.fvwm</filename>.</para> 
   </listitem>
   </varlistentry>
   <varlistentry>
@@ -234,7 +232,7 @@ follow:</para>
   </varlistentry>
 </variablelist>
 
-<para>These defaults may change before version 2.6. Note that if
+<para>Note that if
 you use a private color map (i.e., fvwm is started with the
 <option>-C</option> or the <option>-I</option> options), then
 other defaults are used.</para>
@@ -370,7 +368,22 @@ internal debugging and should only be used by developers.</para>
   <varlistentry>
   <term><option>-v</option></term>
   <listitem>
-<para>Enables debug logging.  Write to ~/fvwm3-output.log in append mode.</para>
+<para>Enables debug logging.  Writes in append mode to fvwm log file, 
+which is ~/.fvwm/fvwm3-output.log by default. See ENVIRONMENT section on 
+how to override this location on fvwm3 startup using 
+<envar>$FVWM_USERDIR</envar> or <envar>$FVWM3_LOGFILE</envar> .</para>
+  <variablelist>
+    <varlistentry>
+      <term>Logging can also be dynamically toggled on and off using signals:</term>
+      <listitem>
+        <simplelist>
+      <member><option>SIGUSR1</option> : used as a signal to restart Fvwm</member>
+      <member><option>SIGUSR2</option> : used as a signal to toggle opening/closing debug log file</member>
+        </simplelist>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+
   </listitem>
   </varlistentry>
 </variablelist>

--- a/doc/fvwm/synopsis.xml
+++ b/doc/fvwm/synopsis.xml
@@ -10,7 +10,7 @@
 <title>Synopsis</title>
 
 <cmdsynopsis>
-	<command>fvwm</command
+	<command>fvwm3</command
 	><arg choice='opt'
 		><option>-c</option
 		><arg choice='plain'

--- a/doc/index.html
+++ b/doc/index.html
@@ -35,7 +35,7 @@
 	<tr>
         <td valign="top">
         <ul>
-        <li><strong><a href="fvwm/fvwm.man.html">Fvwm man page</a></strong></li>
+        <li><strong><a href="fvwm3/fvwm3.man.html">Fvwm man page</a></strong></li>
         <li><a href="modules.html">Fvwm module man pages</a></li>
         <li><a href="http://www.fvwm.org/documentation/faq.html">Frequently Asked Questions</a></li>
         <li><a href="http://fvwm-themes.sf.net">Fvwm Themes</a></li>

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -295,7 +295,7 @@ Restart(int sig)
 static RETSIGTYPE
 ToggleLogging(int sig)
 {
-	log_toggle();
+	log_toggle(fvwm_userdir);
 
 	SIGNAL_RETURN;
 }
@@ -2069,7 +2069,7 @@ int main(int argc, char **argv)
 		else if (strcmp(argv[i], "-v") == 0)
 		{
 			log_set_level(1);
-			log_open();
+			log_open(fvwm_userdir);
 		}
 		else
 		{

--- a/libs/log.c
+++ b/libs/log.c
@@ -58,7 +58,7 @@ log_open(const char *fvwm_userdir)
 		expanded_path = expand_path(path);
 
 		path = fxstrdup(expanded_path);
-		if (strchr(expanded_path, '/') != NULL)
+		if (expanded_path[0] == '/')
 		{
 				path = fxstrdup(expanded_path);
 		} else {

--- a/libs/log.c
+++ b/libs/log.c
@@ -45,9 +45,10 @@ log_set_level(int ll)
 
 /* Open logging to file. */
 void
-log_open(void)
+log_open(const char *fvwm_userdir)
 {
-	char		*path = fxstrdup(FVWM3_LOGFILE_DEFAULT);
+	char *path;
+	xasprintf(&path, "%s/%s", fvwm_userdir, FVWM3_LOGFILE_DEFAULT);
 
 	if (getenv("FVWM3_LOGFILE")) {
 		const char	*expanded_path;
@@ -57,6 +58,12 @@ log_open(void)
 		expanded_path = expand_path(path);
 
 		path = fxstrdup(expanded_path);
+		if (strchr(expanded_path, '/') != NULL)
+		{
+				path = fxstrdup(expanded_path);
+		} else {
+				xasprintf(&path, "%s/%s", fvwm_userdir, expanded_path);
+		}
 		free((char *)expanded_path);
 	}
 
@@ -77,11 +84,11 @@ log_open(void)
 
 /* Toggle logging. */
 void
-log_toggle(void)
+log_toggle(const char *fvwm_userdir)
 {
 	if (log_level == 0) {
 		log_level = 1;
-		log_open();
+		log_open(fvwm_userdir);
 		fvwm_debug(NULL, "log opened (because of SIGUSR2)");
 	} else {
 		fvwm_debug(NULL, "log closed (because of SIGUSR2)");

--- a/libs/log.h
+++ b/libs/log.h
@@ -6,8 +6,8 @@
 
 void	log_set_level(int);
 int	log_get_level(void);
-void	log_open(void);
-void	log_toggle(void);
+void	log_open(const char *);
+void	log_toggle(const char *);
 void	log_close(void);
 void printflike(2, 3) fvwm_debug(const char *, const char *, ...);
 


### PR DESCRIPTION
PrintInfo uses fvwm_debug instead of fprintf(stderr, ...