### PR TITLE
FvwmMFL: start by default

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1395,6 +1395,7 @@ static void SetRCDefaults(void)
 		{ "Key Up M A MenuMoveCursor -1", "", "" },
 		{ "Key Down M A MenuMoveCursor 1", "", "" },
 		{ "Mouse 1 MI A MenuSelectItem", "", "" },
+		{ "Module FvwmMFL", "", "" },
 		/* don't add anything below */
 		{ RC_DEFAULTS_COMPLETE, "", "" },
 		{ "Read "FVWM_DATADIR"/ConfigFvwmDefaults", "", "" },


### PR DESCRIPTION
Despite the functionality of this being a module, try and start FvwmMFL
by default, and not have the user add it to their configs.  This gives a
greater chance of external modules using FvwmMFL of working out of the
box.
