### PR TITLE
libstroke: fix botched bindings

### DIFF
--- a/fvwm/bindings.c
+++ b/fvwm/bindings.c
@@ -190,7 +190,6 @@ static int bind_get_bound_button_contexts(
 			continue;
 		}
 		if ((b->Context & (C_WINDOW | C_EWMH_DESKTOP)) &&
-		     b->Button_Key == 0 &&
 		    buttons_grabbed != NULL)
 		{
 			if (b->Button_Key == 0)

--- a/libs/Bindings.c
+++ b/libs/Bindings.c
@@ -668,8 +668,7 @@ void GrabWindowButton(
 	dead_modifiers &= ALL_MODIFIERS;
 
 	if ((binding->Context & contexts) &&
-	    ((BIND_IS_MOUSE_BINDING(binding->type) ||
-	      binding->Button_Key !=0)))
+	    ((BIND_IS_MOUSE_BINDING(binding->type))))
 	{
 		int bmin = 1;
 		int bmax = NUMBER_OF_EXTENDED_MOUSE_BUTTONS;


### PR DESCRIPTION
When support for libstroke was removed, some of the logic was
incorrectly applied for mouse bindings.   Fix this by not predicating
bindings for mouse button 0.
