### PR TITLE
Make MFL optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,7 +532,7 @@ PKG_CHECK_MODULES([libbson], [libbson-1.0],
 	libbson_LIBS=-lbson-1.0
 ],
 [
-	 AC_MSG_ERROR([*** libbson not found.  Install its header files. ***])
+	 AC_MSG_WARN([*** libbson not found.  MFL disabled. ***])
 ])
 AC_SUBST(libbson_LIBS)
 AC_SUBST(libbson_CFLAGS)
@@ -545,7 +545,7 @@ PKG_CHECK_MODULES([libevent], [libevent >= 2.0],
 	libevent_LIBS=-levent
 ],
 [
-	 AC_MSG_ERROR([*** libevent >=2 not found.  Install its header files. ***])
+	 AC_MSG_WARN([*** libevent >=2 not found.  MFL disabled. ***])
 ])
 AC_SUBST(libevent_LIBS)
 AC_SUBST(libevent_CFLAGS)

--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -6,6 +6,18 @@
  * Released under the same license as FVWM3 itself.
  */
 
+
+#include <stdio.h>
+#ifndef HAVE_LIBBSON
+
+int main(int argc, char **argv)
+{
+	fprintf(stderr, "MFL support not built\n");
+	return (1);
+}
+
+#else
+
 #include "config.h"
 
 #include "fvwm/fvwm.h"
@@ -20,7 +32,6 @@
 #include <sys/un.h>
 #include <sys/time.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
 #include <err.h>
@@ -655,3 +666,5 @@ int main(int argc, char **argv)
 
 	return (0);
 }
+
+#endif /* HAVE_LIBBSON */


### PR DESCRIPTION
MFL pulls in libevent and libbson while also, arguably, not being a core
module.  Therefore, we build a stub implementation if dependencies are
unavailable. It could make sense to also expose an autoconf flag.