### PR TITLE
FvwmForm: resurrect from retirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1581,6 +1581,7 @@ dnl	bin/fvwm-perllib.1
 	modules/FvwmConsole/FvwmConsole.1
 	modules/FvwmConsole/FvwmConsoleC.pl.1
 	modules/FvwmEvent/FvwmEvent.1
+	modules/FvwmForm/FvwmForm.1
 	modules/FvwmIconMan/FvwmIconMan.1
 	modules/FvwmIdent/FvwmIdent.1
 	modules/FvwmMFL/FvwmMFL.1
@@ -1632,6 +1633,7 @@ dnl
 	modules/FvwmConsole/Makefile
 	modules/FvwmConsole/FvwmConsoleC.pl
 	modules/FvwmEvent/Makefile
+	modules/FvwmForm/Makefile
 	modules/FvwmIconMan/Makefile
 	modules/FvwmIdent/Makefile
 	modules/FvwmMFL/Makefile

--- a/modules/FvwmForm/Changes
+++ b/modules/FvwmForm/Changes
@@ -1,0 +1,21 @@
+2/27/95	Added start-up commands.  Those are specified by *FvwmFormCommand
+	options before any *FvwmFormButton options.
+
+	Added an example in man page, Capture, which is a front-end to xwd,
+	xwud, and xpr.
+
+2/15/95	Created this Changes file.
+
+	Made ^H do backspace in text input fields.
+
+	Added keyboard shortcuts for buttons.  Control chars (^@ .. ^_) that
+	are not editting commands, RETURN and TAB after the last text input
+	field, and F1 .. F35, can be used to activate a button.  The option
+	*FvwmFormButton has a backward compatible format change for this
+	feature.
+
+2/13/95	Announced to fvwm mailing list.
+
+2/11/95	Finished preliminary debugging, wrote manual page.
+
+2/7/95	Project started.

--- a/modules/FvwmForm/FvwmForm-Capture
+++ b/modules/FvwmForm/FvwmForm-Capture
@@ -1,0 +1,29 @@
+# Capture Window - This example is a front-end to xwd, xwud, and xpr.
+DestroyModuleConfig  FvwmForm-Capture: *
+*FvwmForm-Capture: Line       center
+*FvwmForm-Capture: Text       "Capture Window"
+*FvwmForm-Capture: Line       left
+*FvwmForm-Capture: Text       "File: "
+*FvwmForm-Capture: Input      file            25      "/tmp/Capture"
+*FvwmForm-Capture: Line       left
+*FvwmForm-Capture: Text       "Printer: "
+*FvwmForm-Capture: Input      printer         20      "$PRINTER"
+*FvwmForm-Capture: Line       expand
+*FvwmForm-Capture: Selection  PtrType single
+*FvwmForm-Capture: Choice     PS      ps      on      "PostScript"
+*FvwmForm-Capture: Choice     Ljet    ljet    off     "HP LaserJet"
+*FvwmForm-Capture: Line       left
+*FvwmForm-Capture: Text       "xwd options:"
+*FvwmForm-Capture: Line       expand
+*FvwmForm-Capture: Selection  Options multiple
+*FvwmForm-Capture: Choice     Brd     -nobdrs off     "No border"
+*FvwmForm-Capture: Choice     Frm     -frame  on      "With frame"
+*FvwmForm-Capture: Choice     XYZ     -xy     off     "XY format"
+*FvwmForm-Capture: Line       expand
+*FvwmForm-Capture: Button     continue        "Capture"       ^M
+*FvwmForm-Capture: Command    Exec exec xwd -out $(file) $(Options) &
+*FvwmForm-Capture: Button     continue        "Preview"
+*FvwmForm-Capture: Command    Exec exec xwud -in $(file) &
+*FvwmForm-Capture: Button     continue        "Print"
+*FvwmForm-Capture: Command    Exec exec xpr -device $(PtrType) $(file) | lpr -P $(printer) &
+*FvwmForm-Capture: Button     quit            "Quit"

--- a/modules/FvwmForm/FvwmForm-Desktop
+++ b/modules/FvwmForm/FvwmForm-Desktop
@@ -1,0 +1,57 @@
+DestroyModuleConfig  FvwmForm-Desktop: *
+*FvwmForm-Desktop: WarpPointer
+*FvwmForm-Desktop: Line         center
+*FvwmForm-Desktop: Text         "fvwm-menu-desktop options"
+*FvwmForm-Desktop: Line
+
+*FvwmForm-Desktop: Line
+*FvwmForm-Desktop: Text         "Use Icons in Menus?:"
+*FvwmForm-Desktop: Selection    SelItype single
+*FvwmForm-Desktop: Choice       IconsOn  IconsOn    on  "On"
+*FvwmForm-Desktop: Choice       IconsOff IconsOff   off "Off"
+
+*FvwmForm-Desktop: Line
+*FvwmForm-Desktop: Text         "Use Titles in Menus?:"
+*FvwmForm-Desktop: Selection    SelItype single
+*FvwmForm-Desktop: Choice       TitlesOn  TitlesOn    on  "On"
+*FvwmForm-Desktop: Choice       TitlesOff TitlesOff   off "Off"
+
+*FvwmForm-Desktop: Line left
+*FvwmForm-Desktop: Text "Menutype:"
+*FvwmForm-Desktop: Input Menutype 16 "applications"
+*FvwmForm-Desktop: Text " (Eg. applications, settings, server-settings)
+
+*FvwmForm-Desktop: Line left
+*FvwmForm-Desktop: Text "Size:"
+*FvwmForm-Desktop: Input Size 3 "24"
+*FvwmForm-Desktop: Text " (Icon size in pixels.  Default is 24.)
+
+*FvwmForm-Desktop: Line left
+*FvwmForm-Desktop: Text "Theme:"
+*FvwmForm-Desktop: Input Theme 16 ""
+*FvwmForm-Desktop: Text " (theme name for icon selection)
+
+*FvwmForm-Desktop: Line         expand
+*FvwmForm-Desktop: Button       quit    "Set"         ^M
+*FvwmForm-Desktop: Command      Piperead 'fvwm-menu-desktop\
+ $(IconsOn?--enable-mini-icons)\
+ $(TitlesOn?--with-titles)\
+ $(Menutype?--menutype) $(Menutype)\
+ $(Size?-s $(Size))\
+ $(Theme?--theme $(Theme))
+
+# Before saving the data, remove any previously saved data:
+*FvwmForm-Desktop: Command DestroyModuleConfig FvwmForm-DesktopDefault: *
+*FvwmForm-Desktop: Command !(                                      /bin/echo \
+  "# This file last created by FvwmForm-Desktop on: `/bin/date`."; /bin/echo \
+  '*FvwmForm-DesktopDefault: IconsOn $(IconsOn?on) '             ; /bin/echo \
+  '*FvwmForm-DesktopDefault: IconsOff   $(IconsOff?on) '         ; /bin/echo \
+  '*FvwmForm-DesktopDefault: Menutype   $(Menutype) '            ; /bin/echo \
+  '*FvwmForm-DesktopDefault: Size       $(Size) '                ; /bin/echo \
+  '*FvwmForm-DesktopDefault: Theme      $(Theme) '               ; /bin/echo \
+) > ${FVWM_USERDIR}/.FvwmForm-Desktop
+*FvwmForm-Desktop: Button       restart "Reset"
+*FvwmForm-Desktop: Button       quit    "Cancel"        ^[
+*FvwmForm-Desktop: Command      Nop
+# Tell FvwmForm to read vars from the .FvwmForm-DesktopDefault file:
+*FvwmForm-Desktop: UseData .FvwmForm-Desktop *FvwmForm-DesktopDefault

--- a/modules/FvwmForm/FvwmForm-Form
+++ b/modules/FvwmForm/FvwmForm-Form
@@ -1,0 +1,104 @@
+# -*- Mode: fvwm -*-
+DestroyModuleConfig FvwmForm-Form: *
+*FvwmForm-Form: WarpPointer
+*FvwmForm-Form: Line  center
+*FvwmForm-Form: Text  "FvwmForm Set Form Defaults:"
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  ""
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  "Font for text:  "
+*FvwmForm-Form: Input Font 63 "8x13bold"
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  "Font for input: "
+*FvwmForm-Form: Input InputFont 63 "8x13bold"
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  "Font for button:"
+*FvwmForm-Form: Input ButtonFont 63 "8x13bold"
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  "Font for timeout text:"
+*FvwmForm-Form: Input TimeoutFont 63 "8x13bold"
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  "Color of text f/g:   "
+*FvwmForm-Form: Input Fore 15 "Wheat"
+*FvwmForm-Form: Text  "b/g:"
+*FvwmForm-Form: Input Back 15 "Gray50"
+*FvwmForm-Form: Text  "colorset:"
+*FvwmForm-Form: Input Colorset 5 "-1"
+*FvwmForm-Form: Line  left
+*FvwmForm-Form: Text  "Color of buttons f/g:"
+*FvwmForm-Form: Input ItemFore 15 "Black"
+*FvwmForm-Form: Text  "b/g:"
+*FvwmForm-Form: Input ItemBack 15 "Light Gray"
+*FvwmForm-Form: Text  "colorset:"
+*FvwmForm-Form: Input ItemColorset 5 "-1"
+
+*FvwmForm-Form: Line left
+*FvwmForm-Form: Text  "Pointer over button:    "
+*FvwmForm-Form: Input ButtonPointer 20 "hand2"
+*FvwmForm-Form: Text  "f/g"
+*FvwmForm-Form: Input ButtonPointerFore 20 "white"
+*FvwmForm-Form: Text  "b/g"
+*FvwmForm-Form: Input ButtonPointerBack 20 "black"
+
+*FvwmForm-Form: Line left
+*FvwmForm-Form: Text  "Pointer while button in:"
+*FvwmForm-Form: Input ButtonInPointer 20 "hand2"
+*FvwmForm-Form: Text  "f/g"
+*FvwmForm-Form: Input ButtonInPointerFore 20 "black"
+*FvwmForm-Form: Text  "b/g"
+*FvwmForm-Form: Input ButtonInPointerBack 20 "white"
+*FvwmForm-Form: Line left
+*FvwmForm-Form: Text  "Pointer over input:     "
+*FvwmForm-Form: Input InputPointer 20 "xterm"
+*FvwmForm-Form: Text  "f/g"
+*FvwmForm-Form: Input InputPointerFore 20 "white"
+*FvwmForm-Form: Text  "b/g"
+*FvwmForm-Form: Input InputPointerBack 20 "black"
+
+*FvwmForm-Form: Line left
+*FvwmForm-Form: Text  "Activate buttons:"
+*FvwmForm-Form: Selection ActivateOnPress single
+*FvwmForm-Form: Choice    OnRelease off off " on release (default)"
+*FvwmForm-Form: Choice    OnPress on on " on press"
+
+*FvwmForm-Form: Line left
+*FvwmForm-Form: Message
+*FvwmForm-Form: Line         expand
+*FvwmForm-Form: Button       quit "F1 - Save & Restart This Form" F1
+*FvwmForm-Form: Command DestroyModuleConfig FvwmFormDefault: *
+# Caution, this command is getting too long, if you add something,
+# you might have some truncation occur:
+*FvwmForm-Form: Command !(/bin/echo \
+ "# This file last created by FvwmForm-Form on: `/bin/date`."; /bin/echo \
+ '*FvwmFormDefault: Font $(Font)'            ; /bin/echo \
+ '*FvwmFormDefault: InputFont $(InputFont)'  ; /bin/echo \
+ '*FvwmFormDefault: ButtonFont $(ButtonFont)'; /bin/echo \
+ '*FvwmFormDefault: TimeoutFont $(TimeoutFont)'; /bin/echo \
+ '*FvwmFormDefault: Fore $(Fore)'            ; /bin/echo \
+ '*FvwmFormDefault: Back $(Back)'            ; /bin/echo \
+ '*FvwmFormDefault: Colorset $(Colorset)'    ; /bin/echo \
+ '*FvwmFormDefault: ItemFore $(ItemFore)'    ; /bin/echo \
+ '*FvwmFormDefault: ItemBack $(ItemBack)'    ; /bin/echo \
+ '*FvwmFormDefault: ItemColorset $(ItemColorset)'       ; /bin/echo \
+ '*FvwmFormDefault: ButtonPointer $(ButtonPointer)'     ; /bin/echo \
+ '*FvwmFormDefault: ButtonInPointer $(ButtonInPointer)' ; /bin/echo \
+ '*FvwmFormDefault: InputPointer $(InputPointer)' ; /bin/echo  \
+ '*FvwmFormDefault: ActivateOnPress $(ActivateOnPress)'\
+) > ${FVWM_USERDIR}/.FvwmForm
+# This would have surely hit a limit so its appended with >>:
+*FvwmForm-Form: Command !(\
+ /bin/echo '*FvwmFormDefault: ButtonPointerFore $(ButtonPointerFore)';\
+ /bin/echo '*FvwmFormDefault: ButtonPointerBack $(ButtonPointerBack)';\
+ /bin/echo '*FvwmFormDefault: ButtonInPointerFore $(ButtonInPointerFore)';\
+ /bin/echo '*FvwmFormDefault: ButtonInPointerBack $(ButtonInPointerBack)';\
+ /bin/echo '*FvwmFormDefault: InputPointerFore $(InputPointerFore)';\
+ /bin/echo '*FvwmFormDefault: InputPointerBack $(InputPointerBack)';\
+) >> ${FVWM_USERDIR}/.FvwmForm
+
+*FvwmForm-Form: Command *FvwmFormDefault: Read n
+*FvwmForm-Form: Command Module FvwmForm FvwmForm-Form
+*FvwmForm-Form: Button       restart   "F3 - Reset" F3
+*FvwmForm-Form: Button       quit "F4 - Dismiss" F4
+*FvwmForm-Form: Command Nop
+# Tell FvwmForm to read and save vars from the .FvwmForm file.
+*FvwmForm-Form: UseData .FvwmForm *FvwmFormDefault

--- a/modules/FvwmForm/FvwmForm-QuitVerify
+++ b/modules/FvwmForm/FvwmForm-QuitVerify
@@ -1,0 +1,14 @@
+DestroyModuleConfig  FvwmForm-QuitVerify: *
+*FvwmForm-QuitVerify: GrabServer
+*FvwmForm-QuitVerify: WarpPointer
+*FvwmForm-QuitVerify: Command     Beep
+*FvwmForm-QuitVerify: Line        center
+*FvwmForm-QuitVerify: Text        "Do you really want to logout?"
+*FvwmForm-QuitVerify: Line        expand
+*FvwmForm-QuitVerify: Button      quit "Logout" ^M
+*FvwmForm-QuitVerify: Command     Quit
+*FvwmForm-QuitVerify: Button      restart   "Restart" ^R
+*FvwmForm-QuitVerify: Command     Restart
+*FvwmForm-QuitVerify: Button      quit "Cancel" ^[
+*FvwmForm-QuitVerify: Command     Nop
+*FvwmForm-QuitVerify: Timeout     20 Quit "Automatic logout will occur in %% seconds."

--- a/modules/FvwmForm/FvwmForm-Rlogin
+++ b/modules/FvwmForm/FvwmForm-Rlogin
@@ -1,0 +1,30 @@
+DestroyModuleConfig  FvwmForm-Rlogin: *
+*FvwmForm-Rlogin: WarpPointer
+*FvwmForm-Rlogin: Line         center
+*FvwmForm-Rlogin: Text         "Login to Remote Host"
+*FvwmForm-Rlogin: Line         center
+*FvwmForm-Rlogin: Text         "Host:"
+*FvwmForm-Rlogin: Input        HostName        20      ""
+*FvwmForm-Rlogin: Line         center
+*FvwmForm-Rlogin: Selection    UserSel single
+*FvwmForm-Rlogin: Choice       Default Default on      "same user"
+*FvwmForm-Rlogin: Choice       Custom  Custom  off     "user:"
+*FvwmForm-Rlogin: Input        UserName        10      ""
+*FvwmForm-Rlogin: Line         expand
+*FvwmForm-Rlogin: Button       quit    "Login"         ^M
+*FvwmForm-Rlogin: Command      Exec exec ssh $(Custom?-l $(UserName)) $(HostName) xterm -T xterm@$(HostName) -display $HOSTDISPLAY &
+# Before saving the data, remove any previously saved data:
+*FvwmForm-Rlogin: Command DestroyModuleConfig FvwmForm-RloginDefault: *
+# The "Login" button causes a login and a saving of the current data:
+*FvwmForm-Rlogin: Command !(                                      /bin/echo \
+  "# This file last created by FvwmForm-Rlogin on: `/bin/date`."; /bin/echo \
+  '*FvwmForm-RloginDefault: HostName $(HostName)'               ; /bin/echo \
+  '*FvwmForm-RloginDefault: UserName $(UserName)'               ; /bin/echo \
+  '*FvwmForm-RloginDefault: Default $(Default?on)'              ; /bin/echo \
+  '*FvwmForm-RloginDefault: Custom $(Custom?on)' \
+) > ${FVWM_USERDIR}/.FvwmForm-Rlogin
+*FvwmForm-Rlogin: Button       restart "Reset"
+*FvwmForm-Rlogin: Button       quit    "Cancel"        ^[
+*FvwmForm-Rlogin: Command      Nop
+# Tell FvwmForm to read vars from the .FvwmForm-RloginDefault file:
+*FvwmForm-Rlogin: UseData .FvwmForm-Rlogin *FvwmForm-RloginDefault

--- a/modules/FvwmForm/FvwmForm-RootCursor
+++ b/modules/FvwmForm/FvwmForm-RootCursor
@@ -1,0 +1,155 @@
+# This form changes the root cursor font and color.
+
+DestroyModuleConfig FvwmForm-RootCursor: *
+*FvwmForm-RootCursor: WarpPointer
+*FvwmForm-RootCursor: Font	fixed
+*FvwmForm-RootCursor: ButtonFont	6x13
+
+*FvwmForm-RootCursor: Text	"Cursor font"
+*FvwmForm-RootCursor: Selection	cursor_font single
+
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font X_cursor            off "X_cursor           "
+*FvwmForm-RootCursor: Choice cursor_font arrow               off "arrow              "
+*FvwmForm-RootCursor: Choice cursor_font based_arrow_down    off "based_arrow_down   "
+*FvwmForm-RootCursor: Choice cursor_font based_arrow_up      off "based_arrow_up     "
+*FvwmForm-RootCursor: Choice cursor_font boat                off "boat               "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font bogosity            off "bogosity           "
+*FvwmForm-RootCursor: Choice cursor_font bottom_left_corner  off "bottom_left_corner "
+*FvwmForm-RootCursor: Choice cursor_font bottom_right_corner off "bottom_right_corner"
+*FvwmForm-RootCursor: Choice cursor_font bottom_side         off "bottom_side        "
+*FvwmForm-RootCursor: Choice cursor_font bottom_tee          off "bottom_tee         "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font box_spiral          off "box_spiral         "
+*FvwmForm-RootCursor: Choice cursor_font center_ptr          off "center_ptr         "
+*FvwmForm-RootCursor: Choice cursor_font circle              off "circle             "
+*FvwmForm-RootCursor: Choice cursor_font clock               off "clock              "
+*FvwmForm-RootCursor: Choice cursor_font coffee_mug          off "coffee_mug         "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font cross               off "cross              "
+*FvwmForm-RootCursor: Choice cursor_font cross_reverse       off "cross_reverse      "
+*FvwmForm-RootCursor: Choice cursor_font crosshair           off "crosshair          "
+*FvwmForm-RootCursor: Choice cursor_font diamond_cross       off "diamond_cross      "
+*FvwmForm-RootCursor: Choice cursor_font dot                 off "dot                "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font dotbox              off "dotbox             "
+*FvwmForm-RootCursor: Choice cursor_font double_arrow        off "double_arrow       "
+*FvwmForm-RootCursor: Choice cursor_font draft_large         off "draft_large        "
+*FvwmForm-RootCursor: Choice cursor_font draft_small         off "draft_small        "
+*FvwmForm-RootCursor: Choice cursor_font draped_box          off "draped_box         "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font exchange            off "exchange           "
+*FvwmForm-RootCursor: Choice cursor_font fleur               off "fleur              "
+*FvwmForm-RootCursor: Choice cursor_font gobbler             off "gobbler            "
+*FvwmForm-RootCursor: Choice cursor_font gumby               off "gumby              "
+*FvwmForm-RootCursor: Choice cursor_font hand1               off "hand1              "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font hand2               off "hand2              "
+*FvwmForm-RootCursor: Choice cursor_font heart               off "heart              "
+*FvwmForm-RootCursor: Choice cursor_font icon                off "icon               "
+*FvwmForm-RootCursor: Choice cursor_font iron_cross          off "iron_cross         "
+*FvwmForm-RootCursor: Choice cursor_font left_ptr            on  "left_ptr           "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font left_side           off "left_side          "
+*FvwmForm-RootCursor: Choice cursor_font left_tee            off "left_tee           "
+*FvwmForm-RootCursor: Choice cursor_font leftbutton          off "leftbutton         "
+*FvwmForm-RootCursor: Choice cursor_font ll_angle            off "ll_angle           "
+*FvwmForm-RootCursor: Choice cursor_font lr_angle            off "lr_angle           "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font man                 off "man                "
+*FvwmForm-RootCursor: Choice cursor_font middlebutton        off "middlebutton       "
+*FvwmForm-RootCursor: Choice cursor_font mouse               off "mouse              "
+*FvwmForm-RootCursor: Choice cursor_font pencil              off "pencil             "
+*FvwmForm-RootCursor: Choice cursor_font pirate              off "pirate             "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font plus                off "plus               "
+*FvwmForm-RootCursor: Choice cursor_font question_arrow      off "question_arrow     "
+*FvwmForm-RootCursor: Choice cursor_font right_ptr           off "right_ptr          "
+*FvwmForm-RootCursor: Choice cursor_font right_side          off "right_side         "
+*FvwmForm-RootCursor: Choice cursor_font right_tee           off "right_tee          "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font rightbutton         off "rightbutton        "
+*FvwmForm-RootCursor: Choice cursor_font rtl_logo            off "rtl_logo           "
+*FvwmForm-RootCursor: Choice cursor_font sailboat            off "sailboat           "
+*FvwmForm-RootCursor: Choice cursor_font sb_down_arrow       off "sb_down_arrow      "
+*FvwmForm-RootCursor: Choice cursor_font sb_h_double_arrow   off "sb_h_double_arrow  "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font sb_left_arrow       off "sb_left_arrow      "
+*FvwmForm-RootCursor: Choice cursor_font sb_right_arrow      off "sb_right_arrow     "
+*FvwmForm-RootCursor: Choice cursor_font sb_up_arrow         off "sb_up_arrow        "
+*FvwmForm-RootCursor: Choice cursor_font sb_v_double_arrow   off "sb_v_double_arrow  "
+*FvwmForm-RootCursor: Choice cursor_font shuttle             off "shuttle            "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font sizing              off "sizing             "
+*FvwmForm-RootCursor: Choice cursor_font spider              off "spider             "
+*FvwmForm-RootCursor: Choice cursor_font spraycan            off "spraycan           "
+*FvwmForm-RootCursor: Choice cursor_font star                off "star               "
+*FvwmForm-RootCursor: Choice cursor_font target              off "target             "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font tcross              off "tcross             "
+*FvwmForm-RootCursor: Choice cursor_font top_left_arrow      off "top_left_arrow     "
+*FvwmForm-RootCursor: Choice cursor_font top_left_corner     off "top_left_corner    "
+*FvwmForm-RootCursor: Choice cursor_font top_right_corner    off "top_right_corner   "
+*FvwmForm-RootCursor: Choice cursor_font top_side            off "top_side           "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font top_tee             off "top_tee            "
+*FvwmForm-RootCursor: Choice cursor_font trek                off "trek               "
+*FvwmForm-RootCursor: Choice cursor_font ul_angle            off "ul_angle           "
+*FvwmForm-RootCursor: Choice cursor_font umbrella            off "umbrella           "
+*FvwmForm-RootCursor: Choice cursor_font ur_angle            off "ur_angle           "
+*FvwmForm-RootCursor: Line   expand
+*FvwmForm-RootCursor: Choice cursor_font watch               off "watch              "
+*FvwmForm-RootCursor: Choice cursor_font xterm               off "xterm              "
+
+*FvwmForm-RootCursor: Line	expand
+*FvwmForm-RootCursor: Text	"Cursor inner color"
+*FvwmForm-RootCursor: Line	expand
+
+*FvwmForm-RootCursor: Selection	cursor_fg single
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_fg black    on  "  black   "
+*FvwmForm-RootCursor: Choice cursor_fg red      off "  red     "
+*FvwmForm-RootCursor: Choice cursor_fg green    off "  green   "
+*FvwmForm-RootCursor: Choice cursor_fg blue     off "  blue    "
+*FvwmForm-RootCursor: Choice cursor_fg bisque   off "  bisque  "
+*FvwmForm-RootCursor: Choice cursor_fg brown    off "  brown   "
+*FvwmForm-RootCursor: Choice cursor_fg gray     off "  gray    "
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_fg cyan     off "  cyan    "
+*FvwmForm-RootCursor: Choice cursor_fg violet   off "  violet  "
+*FvwmForm-RootCursor: Choice cursor_fg seagreen off "  seagreen"
+*FvwmForm-RootCursor: Choice cursor_fg navy     off "  navy    "
+*FvwmForm-RootCursor: Choice cursor_fg gold     off "  gold    "
+*FvwmForm-RootCursor: Choice cursor_fg yellow   off "  yellow  "
+*FvwmForm-RootCursor: Choice cursor_fg white    off "  white   "
+
+*FvwmForm-RootCursor: Line	expand
+*FvwmForm-RootCursor: Text	"Cursor outer color"
+*FvwmForm-RootCursor: Line	expand
+
+*FvwmForm-RootCursor: Selection	cursor_bg single
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_bg black    off "  black   "
+*FvwmForm-RootCursor: Choice cursor_bg red      off "  red     "
+*FvwmForm-RootCursor: Choice cursor_bg green    off "  green   "
+*FvwmForm-RootCursor: Choice cursor_bg blue     off "  blue    "
+*FvwmForm-RootCursor: Choice cursor_bg bisque   off "  bisque  "
+*FvwmForm-RootCursor: Choice cursor_bg brown    off "  brown   "
+*FvwmForm-RootCursor: Choice cursor_bg gray     off "  gray    "
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_bg cyan     off "  cyan    "
+*FvwmForm-RootCursor: Choice cursor_bg violet   off "  violet  "
+*FvwmForm-RootCursor: Choice cursor_bg seagreen off "  seagreen"
+*FvwmForm-RootCursor: Choice cursor_bg navy     off "  navy    "
+*FvwmForm-RootCursor: Choice cursor_bg gold     off "  gold    "
+*FvwmForm-RootCursor: Choice cursor_bg yellow   off "  yellow  "
+*FvwmForm-RootCursor: Choice cursor_bg white    on  "  white   "
+
+*FvwmForm-RootCursor: Line	expand
+*FvwmForm-RootCursor: Line	expand
+
+*FvwmForm-RootCursor: Button	continue "   Set Root Cursor   "
+*FvwmForm-RootCursor: Command	CursorStyle ROOT $(cursor_font!none) $(cursor_fg) $(cursor_bg)
+*FvwmForm-RootCursor: Button	quit "   Finish   " ^[
+*FvwmForm-RootCursor: Command	Nop

--- a/modules/FvwmForm/FvwmForm-RootCursor.pl
+++ b/modules/FvwmForm/FvwmForm-RootCursor.pl
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+
+# Usage:
+#   perl FvwmForm-RootCursor.pl >FvwmForm-RootCursor
+
+$CHOICES_IN_LINE = 5;
+$CURSORFONT_H = "/usr/X11/include/X11/cursorfont.h";
+
+die "Can't find cursorfont.h, tried '$CURSORFONT_H'.\n"
+	unless -r $CURSORFONT_H;
+
+open(CFH, "<$CURSORFONT_H");
+$cfContent = join('', <CFH>);
+close(CFH);
+
+@cursorFonts = $cfContent =~ /XC_([^\s]*)\s/sg;
+@cursorFonts = grep(!/num_glyphs/, @cursorFonts);
+
+$len = 0; map { $len = length if $len < length } @cursorFonts;
+$include = "";
+$count = $CHOICES_IN_LINE;
+
+foreach (@cursorFonts) {
+	if ($count == $CHOICES_IN_LINE) {
+		$include .= "*FvwmForm-RootCursor: Line   expand\n"; $count = 0;
+	}
+	$include .= sprintf("*FvwmForm-RootCursor: Choice cursor_font %-${len}s off \"%-${len}s\"\n", $_, $_);
+	$count++;
+}
+$include =~ s/(left_ptr\s+)off/$1on /s;  # set default cursor
+
+$_ = join('', <DATA>);
+s/\@INCLUDE_STANDARD_CURSOR_FONTS@\n/$include/s;
+print $_;
+
+# ****************************************************************************
+# Here is the actual FvwmForm-RootCursor template goes
+__DATA__
+# This form changes the root cursor font and color.
+
+DestroyModuleConfig FvwmForm-RootCursor: *
+*FvwmForm-RootCursor: WarpPointer
+*FvwmForm-RootCursor: Font	fixed
+*FvwmForm-RootCursor: ButtonFont	6x13
+
+*FvwmForm-RootCursor: Text	"Cursor font"
+*FvwmForm-RootCursor: Selection	cursor_font single
+
+@INCLUDE_STANDARD_CURSOR_FONTS@
+
+*FvwmForm-RootCursor: Line	expand
+*FvwmForm-RootCursor: Text	"Cursor inner color"
+*FvwmForm-RootCursor: Line	expand
+
+*FvwmForm-RootCursor: Selection	cursor_fg single
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_fg black    on  "  black   "
+*FvwmForm-RootCursor: Choice cursor_fg red      off "  red     "
+*FvwmForm-RootCursor: Choice cursor_fg green    off "  green   "
+*FvwmForm-RootCursor: Choice cursor_fg blue     off "  blue    "
+*FvwmForm-RootCursor: Choice cursor_fg bisque   off "  bisque  "
+*FvwmForm-RootCursor: Choice cursor_fg brown    off "  brown   "
+*FvwmForm-RootCursor: Choice cursor_fg gray     off "  gray    "
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_fg cyan     off "  cyan    "
+*FvwmForm-RootCursor: Choice cursor_fg violet   off "  violet  "
+*FvwmForm-RootCursor: Choice cursor_fg seagreen off "  seagreen"
+*FvwmForm-RootCursor: Choice cursor_fg navy     off "  navy    "
+*FvwmForm-RootCursor: Choice cursor_fg gold     off "  gold    "
+*FvwmForm-RootCursor: Choice cursor_fg yellow   off "  yellow  "
+*FvwmForm-RootCursor: Choice cursor_fg white    off "  white   "
+
+*FvwmForm-RootCursor: Line	expand
+*FvwmForm-RootCursor: Text	"Cursor outer color"
+*FvwmForm-RootCursor: Line	expand
+
+*FvwmForm-RootCursor: Selection	cursor_bg single
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_bg black    off "  black   "
+*FvwmForm-RootCursor: Choice cursor_bg red      off "  red     "
+*FvwmForm-RootCursor: Choice cursor_bg green    off "  green   "
+*FvwmForm-RootCursor: Choice cursor_bg blue     off "  blue    "
+*FvwmForm-RootCursor: Choice cursor_bg bisque   off "  bisque  "
+*FvwmForm-RootCursor: Choice cursor_bg brown    off "  brown   "
+*FvwmForm-RootCursor: Choice cursor_bg gray     off "  gray    "
+*FvwmForm-RootCursor: Line   center
+*FvwmForm-RootCursor: Choice cursor_bg cyan     off "  cyan    "
+*FvwmForm-RootCursor: Choice cursor_bg violet   off "  violet  "
+*FvwmForm-RootCursor: Choice cursor_bg seagreen off "  seagreen"
+*FvwmForm-RootCursor: Choice cursor_bg navy     off "  navy    "
+*FvwmForm-RootCursor: Choice cursor_bg gold     off "  gold    "
+*FvwmForm-RootCursor: Choice cursor_bg yellow   off "  yellow  "
+*FvwmForm-RootCursor: Choice cursor_bg white    on  "  white   "
+
+*FvwmForm-RootCursor: Line	expand
+*FvwmForm-RootCursor: Line	expand
+
+*FvwmForm-RootCursor: Button	continue "   Set Root Cursor   "
+*FvwmForm-RootCursor: Command	CursorStyle ROOT $(cursor_font!none) $(cursor_fg) $(cursor_bg)
+*FvwmForm-RootCursor: Button	quit "   Finish   " ^[
+*FvwmForm-RootCursor: Command	Nop

--- a/modules/FvwmForm/FvwmForm-Talk
+++ b/modules/FvwmForm/FvwmForm-Talk
@@ -1,0 +1,22 @@
+# FvwmForm-Talk - Basic replacement for FvwmTalk
+DestroyModuleConfig  FvwmForm-Talk: *
+*FvwmForm-Talk: WarpPointer
+# Layout
+*FvwmForm-Talk: Line         center
+*FvwmForm-Talk: Text         "Talk to Fvwm"
+*FvwmForm-Talk: Line         left
+*FvwmForm-Talk: Text         "Command:"
+*FvwmForm-Talk: Input        Command 80 ""
+*FvwmForm-Talk: Line         left
+*FvwmForm-Talk: Text         "Msg:"
+*FvwmForm-Talk: Message
+*FvwmForm-Talk: Line         center
+# Buttons
+*FvwmForm-Talk: Button       restart    "Return - Execute"         ^M
+*FvwmForm-Talk: Command        $(Command)
+*FvwmForm-Talk: Button       continue    "F1 - Help" F1
+*FvwmForm-Talk: Command        Module FvwmForm FvwmForm-TalkHelp
+*FvwmForm-Talk: Button       restart     "F3 - Reset input" F3
+*FvwmForm-Talk: Command        Nop
+*FvwmForm-Talk: Button       quit        "F4 - Dismiss"  F4
+*FvwmForm-Talk: Command        Nop

--- a/modules/FvwmForm/FvwmForm-TalkHelp
+++ b/modules/FvwmForm/FvwmForm-TalkHelp
@@ -1,0 +1,27 @@
+# FvwmForm-TalkHelp - Help Text for FvwmForm-Talk
+DestroyModuleConfig  FvwmForm-TalkHelp: *
+*FvwmForm-TalkHelp: WarpPointer
+# Layout
+*FvwmForm-TalkHelp: Line    center
+*FvwmForm-TalkHelp: Text    "Talk to Fvwm - Help"
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    " "
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: PadVText 0
+*FvwmForm-TalkHelp: Text    "Enter commands in the \"Command:\" input field."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "Commands beginning with \"!\" are executed by the"
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "shell as a sub-process of the form."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "All other commands are sent to fvwm for execution."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    ""
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "Fvwm error messages are shown on the \"Msg:\" line."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    ""
+# Buttons
+*FvwmForm-TalkHelp: Line    center
+*FvwmForm-TalkHelp: Button  quit    "Return - Dismiss"         ^M
+*FvwmForm-TalkHelp: Command   Nop

--- a/modules/FvwmForm/FvwmForm-XDGMenuHelp
+++ b/modules/FvwmForm/FvwmForm-XDGMenuHelp
@@ -1,0 +1,70 @@
+# FvwmForm-XDGMenuHelp - Help Text for fvwm-menu-desktop-config XDGMenu
+# V 1.0.4
+DestroyModuleConfig  FvwmForm-XDGMenuHelp: *
+*FvwmForm-XDGMenuHelp:   Title   "$[gt.XDGMenu Help]"
+*FvwmForm-XDGMenuHelp:   WarpPointer
+# Layout
+#*FvwmForm-XDGMenuHelp:   Line    center
+#*FvwmForm-XDGMenuHelp:   Text    "$[gt.XDGMenu.Help]"
+#*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    center
+*FvwmForm-XDGMenuHelp:   Text    "--------------------------------------------------------------------"
+*FvwmForm-XDGMenuHelp:   Line    center
+*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.All the XDG menus found on the system are listed under Available Menus.  Use]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.this FvwmForm to configure some of the defaults options for fvwm-menu-desktop]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.and select which menus are generated.  Select the options you want and then]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.generate then generate the menu by selecting the following:]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.Export Menu:]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.     Generates a menu by calling fvwm-menu-desktop with the selected options]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.     and saves the output to Output Path. After the menu file is created it]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.     is read by fvwm. This option does not save any changes made to settings.]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.Save and Regenerate:]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.     This saves the settings then runs fvwm-menu-desktop with no options using]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.     the defaults saved in the config file. This does not export the menu.]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.Menus are found /etc/xdg/menus, $HOME/.config/menus, and $XDG_MENU_PREFIX.]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.Note that equal menus found under both /etc/xdg/menus AND $HOME/.config/menus/]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.following the XDG menu specification are only shown in $HOME/.config/menus/.]"
+*FvwmForm-XDGMenuHelp:   Line    Left
+*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.If no menus appear check with 'fvwm-menu-desktop --get-menus all -v'.]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Text    "$[gt.Also it is a good idea to check $HOME/.xsession-errors for errors.]"
+*FvwmForm-XDGMenuHelp:   Line    left
+*FvwmForm-XDGMenuHelp:   Line    " "
+*FvwmForm-XDGMenuHelp:   Line    center
+*FvwmForm-XDGMenuHelp:   Text    "--------------------------------------------------------------------"
+*FvwmForm-XDGMenuHelp:   Line    Left
+*FvwmForm-XDGMenuHelp:   Line    " "
+# Buttons
+*FvwmForm-XDGMenuHelp:   Line    center
+*FvwmForm-XDGMenuHelp:   Button  quit    "$[gt.Close]"         ^M
+*FvwmForm-XDGMenuHelp:   Command Nop
+*FvwmForm-XDGMenuHelp:   Button  continue "Options Help"
+*FvwmForm-XDGMenuHelp:   Command Module FvwmForm FvwmForm-XDGOptionsHelp
+*FvwmForm-XDGMenuHelp:   Button  continue "fvwm-menu-desktop man page"        
+*FvwmForm-XDGMenuHelp:   Command Exec exec xterm -g 100x50 -n "Help fvwm-menu-desktop" -T "Help fvwm-menu-desktop" -e "man fvwm-menu-desktop"
+*FvwmForm-XDGMenuHelp:   Line    Left
+*FvwmForm-XDGMenuHelp:   Line    " "
+

--- a/modules/FvwmForm/FvwmForm-XDGOptionsHelp
+++ b/modules/FvwmForm/FvwmForm-XDGOptionsHelp
@@ -1,0 +1,138 @@
+# FvwmForm-XDGOptionsHelp - Help Text for fvwm-menu-desktop-config XDGMenu Options
+# V 1.0.3
+DestroyModuleConfig  FvwmForm-XDGOptionsHelp: *
+*FvwmForm-XDGOptionsHelp:   Title   "$[gt.XDGMenu Options Help]"
+*FvwmForm-XDGOptionsHelp:   WarpPointer
+# Layout
+#*FvwmForm-XDGOptionsHelp:   Line    center
+#*FvwmForm-XDGOptionsHelp:   Text    "$[gt.XDGMenu Options Help]"
+#*FvwmForm-XDGOptionsHelp:   Line 
+#*FvwmForm-XDGOptionsHelp:   Line    center
+#*FvwmForm-XDGOptionsHelp:   Text    "----------------------------------------------------------------------------------------"
+#*FvwmForm-XDGOptionsHelp:   Line    center
+#*FvwmForm-XDGOptionsHelp:   Text    "$[gt.General Options]"
+*FvwmForm-XDGOptionsHelp:   Line    left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Include in Menu:    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Set if XDGMenu will include menu items to Configure and/or Regenerate the menu]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.at the bottom of the top level menu.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Use Icons?          ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Option enables mini-icons in the menu(s). Warning! If ImageMagick is installed]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.the script may generate all the icons and pause your system until the job is]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.done. After the icons are generated, it will not take as long to regenerate.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Icon size:          ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.If 'Use Icons' is set, by default 24x24 mini-icons are used. If another size is]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.desired enter the wanted size in this field.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Icon directory:     ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.If the specified icon isn't that size it is converted if ImageMagick is installed.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Generated icons are saved in $HOME/.fvwm/icons or the directory specified here.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Otherwise no icon appears in the menu for that entry.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Used Icon theme:    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Sets the used icon theme. Default is 'gnome' but all others found in]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt./usr/share/icons can used except the hicolor theme because it's the default]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.fallback theme if no icon is found. Note that the theme name must be written]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.exactly as the icon directory e.g.] /usr/share/icons/Mint-X => 'Mint-X'."
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Directory Icon:     ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.If 'Use Icons' is enabled and for a directory in a menu no icon is found]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "'gnome-fs-directory' $[gt.as default icon is used. But if the gnome icon theme isn't]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.installed no default icon appears. Another icon can defined here.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Only the name of an icon is needed not the path!]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Application Icon:   ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.If 'Use Icons' is enabled and for an application no icon is found]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "'gnome-applications' $[gt.as default icon is used. But if the gnome icon theme isn't]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.installed no default icon appears. Another icon can defined here.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Only the name of an icon is needed not the path!]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Use Titles?         ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.If this option is set menus are generated with titles. Default is use titles.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Top Menu Name:      ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Sets the name of the name of the top level menu. Default is XDGMenu.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Insert Menu Into:   ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Inserts the menu items into the given Menu.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Terminal Command:   ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Enter terminal emulator command used to launch terminal applications. The command]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.                    ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.must end with an execute option (-e). Default xterm -e.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Output path:        ]"
+*FvwmForm-XDGOptionsHelp:   Text    "$[gt.Enter the FULL path to export menu. Default $FVWM_USERDIR/.XDGMmenu.]"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+#*FvwmForm-XDGOptionsHelp:   Line    center
+#*FvwmForm-XDGOptionsHelp:   Text    "----------------------------------------------------------------------------------------"
+#*FvwmForm-XDGOptionsHelp:   Line    Left
+#*FvwmForm-XDGOptionsHelp:   Line    " "
+# Buttons
+*FvwmForm-XDGOptionsHelp:   Line    center
+*FvwmForm-XDGOptionsHelp:   Button  quit    "$[gt.Close]"         ^M
+*FvwmForm-XDGOptionsHelp:   Command Nop
+*FvwmForm-XDGOptionsHelp:   Button  continue "XDGMenu Help"
+*FvwmForm-XDGOptionsHelp:   Command Module FvwmForm FvwmForm-XDGMenuHelp
+*FvwmForm-XDGOptionsHelp:   Button  continue "fvwm-menu-desktop $[gt.manpage]"        
+*FvwmForm-XDGOptionsHelp:   Command Exec exec xterm -g 100x50 -n "Help fvwm-menu-desktop" -T "Help fvwm-menu-desktop" -e "man fvwm-menu-desktop"
+*FvwmForm-XDGOptionsHelp:   Line    Left
+*FvwmForm-XDGOptionsHelp:   Line    " "
+

--- a/modules/FvwmForm/FvwmForm.1.in
+++ b/modules/FvwmForm/FvwmForm.1.in
@@ -1,0 +1,788 @@
+.\" Same macro as used in fvwm.1
+.\" @(#)@PACKAGE@-@VERSION@ @RELDATELONG@
+.de EX		\"Begin example
+.ne 5
+.if n .sp 1
+.if t .sp .5
+.nf
+.in +.5i
+..
+.de EE
+.fi
+.in -.5i
+.if n .sp 1
+.if t .sp .5
+..
+.TH FvwmForm 1 "@RELDATELONG@ (@VERSION@)" Fvwm "Fvwm Modules"
+.SH NAME
+FvwmForm - input form module for Fvwm
+.SH SYNOPSIS
+\fBModule FvwmForm\fP [ \fIAlias\fP ]
+
+FvwmForm must be spawned by Fvwm.
+If invoked from the command line,
+FvwmForm prints its version number and exits.
+.SH DESCRIPTION
+FvwmForm provides a mechanism to get user input and act accordingly.
+This is achieved by means of a form that the user can fill out,
+and from which the user can select actions he wants Fvwm to take.
+A form consists of five types of items:
+text labels,
+single-line text inputs,
+mutually-exclusive selections,
+multiple-choice selections,
+and action buttons.
+These items are arranged into several lines,
+with a very flexible layout.
+
+A text label only serves the purpose of explanation.
+It cannot accept any input.
+
+A timeout entry provides a mechanism for timing out the form
+and performing a certain action when the timeout occurs.  The countdown
+is displayed similar to a text label except that it updates with the
+amount of time left.
+
+A text input field can be used to edit a single-line string.
+FvwmForm accepts Emacs-style cursor movement keys.
+See FvwmFormInput for details.
+Mouse copy is not supported, but you can paste.
+
+A selection consists of several choices.
+
+The selection itself is a logical entity that doesn't have any display
+feature.
+
+Each choice is displayed as a push-button followed by a explanatory
+text label.
+When selected, an exclusive choice shows a circle in the middle,
+while a multiple choice shows a check.
+
+An action button, when activated sends one or more commands to
+Fvwm or executes shell commands.
+The shell commands can contain the content of the input fields
+on the form and reflect the setting of choices on the form.
+
+The action buttons can be activated thru keyboard or mouse.
+.SH INITIALIZATION
+
+FvwmForm invoked without an alias uses configuration
+commands  starting with "*FvwmForm".
+
+Normally you would invoke FvwmForm with
+an alias representing the name of a form, its configuration commands and
+configuration file.
+For example, the command "Module FvwmForm Rlogin" uses configuration
+commands starting with "*Rlogin", and reads the optional configuration file
+"Rlogin".
+
+All forms, regardless of alias,  scan first for configuration commands
+that start with  "*FvwmFormDefault".   These  commands  normally come
+from the builtin form "FvwmForm-Form" which saves commands to the file
+".FvwmForm".
+
+The physical reading of the optional input file, ".FvwmForm",
+is done only the first time FvwmForm is invoked, or after
+"FvwmForm-Form" updates the file.
+
+When the file ".FvwmForm" is read,  it is done  by sending the command
+"Read .FvwmForm  Quiet"   to fvwm.  Because of  the   way the  "read"
+command works, the file can  reside in your personal fvwm user directory,
+or be in the fvwm data directory.  See the description of the read
+command in the fvwm man page for more information about the environment
+variable $FVWM_USERDIR.
+
+Then FvwmForm reads the rest of the configuration fvwm has stored
+up.  Fvwm stores configuration on an ongoing basis.  The initial
+configuration comes from the .fvwm2rc file.  Other sources,
+including "Read" commands can define a form.
+
+When letting  FvwmForm and fvwm  read files, remember that these files
+contain commands  that can  execute shell commands,  so  you should be
+careful about setting permissions on these files.
+
+When FvwmForm is invoked with a window context, e.g. from a window menu,
+all commands it sends to Fvwm will have that window context.
+This would allow FvwmForm to control the window it is invoked from.
+
+After all the configuration commands have been read, FvwmForm displays
+the form defined by the commands.
+
+.SH DEFAULTS
+FvwmForm creates a built-in form named "FvwmForm-Form" that creates
+a file called ".FvwmForm".  This file contains saved default form colors and
+fonts.  Other forms use these defaults unless they are overridden within the
+form.
+
+The default creating form would normally be invoked from a "module menu".
+For example, if you call your module menu "Module-Popup", you would
+add the line:
+.EX
+AddToMenu "Module-Popup" "FvwmForm Defaults" FvwmForm FvwmForm-Form
+.EE
+When you select "FvwmForm Defaults" from your module menu,
+a form is displayed that shows the current defaults and allows you
+to change them.  If you activate the "Save Restart Me" button,
+the ".FvwmForm" file is written and "FvwmForm-Form" exits and restarts
+to show the new defaults.
+
+An example of what this file might contain after a save is:
+.EX
+  # This file last created by FvwmForm-Form on Sun Nov 28 11:18:26 EST 1999.
+  *FvwmFormDefault: Font 10x20
+  *FvwmFormDefault: InputFont 8x13bold
+  *FvwmFormDefault: ButtonFont 10x20
+  *FvwmFormDefault: TimeoutFont 10x20
+  *FvwmFormDefault: Fore white
+  *FvwmFormDefault: Back cornflowerblue
+  *FvwmFormDefault: Colorset -1
+  *FvwmFormDefault: ItemFore green
+  *FvwmFormDefault: ItemBack gray40
+  *FvwmFormDefault: ItemColorset -1
+  *FvwmFormDefault: ButtonPointer hand2
+  *FvwmFormDefault: ButtonInPointer star
+  *FvwmFormDefault: InputPointer gumby
+  *FvwmFormDefault: ButtonPointerFore blue
+  *FvwmFormDefault: ButtonPointerBack gray
+  *FvwmFormDefault: ButtonInPointerFore gray
+  *FvwmFormDefault: ButtonInPointerBack blue
+  *FvwmFormDefault: InputPointerFore
+  *FvwmFormDefault: InputPointerBack
+.EE
+The commands in this file are just like any other FvwmForm
+command except that they start with "*FvwmFormDefault".
+
+FvwmForm only reads the file ".FvwmForm" the first time it is started
+or after the file is changed by "FvwmForm-Form".  It does so
+by sending the command "*FvwmFormDefault: Read x". With "x" set to "y" or
+"n".  "n" makes FvwmForm send a "read .FvwmForm quiet" command to fvwm.
+
+.SH VARIABLE SUBSTITUTION
+
+If you supply variables and values on the command line used to start
+FvwmForm (like this):
+
+.EX
+Module FvwmForm MyForm ACTION=Browse "TITLE=Browse Form"
+.EE
+
+Then all FvwmForm input commands undergo variable substitution.
+The variables from the command line are exported.
+Then every command gets expanded using the variables from the
+environment.  For example, assuming the above invocation
+of "MyForm", commands would be changed like this:
+
+.EX
+Before  *MyForm: Text "$TITLE, Home $HOME, Going to $ACTION"
+After   *MyForm: TEXT "Browse Form, Home /home/me, Going to Browse"
+.EE
+
+Using this facility should make it possible for one form to be used for
+different sets of input data.
+
+.SH CONFIGURATION
+The following commands can be set in the .fvwm2rc file or thru
+any of the other ways that fvwm can accept commands.
+The simplest technique is to create a file in the read-only
+architecture-independent data directory,
+[PREFIX/share/fvwm] or your personal fvwm directory [$HOME/.fvwm],
+that matches the form alias.
+
+In the following paragraphs the string "FvwmForm"
+would normally be the form alias.
+
+FvwmForm reads commands before the form is ever displayed,
+and while the form is being displayed.
+
+The following commands are accepted before the form is displayed:
+.EX
+Back
+Button
+ButtonFont
+ButtonInPointer
+ButtonInPointerFore
+ButtonInPointerBack
+ButtonPointer
+ButtonPointerFore
+ButtonPointerBack
+Choice
+Command
+Colorset
+Font
+Fore
+GrabServer
+Input
+InputFont
+InputPointer
+ItemBack
+ItemColorset
+ItemFore
+InputPointerFore
+InputPointerBack
+Line
+Message
+PadVText
+Position
+Selection
+Separator
+Text
+Timeout
+TimeoutFont
+Title
+UseData
+WarpPointer
+.EE
+
+The following commands are accepted while the form is displayed:
+.EX
+Map
+Stop
+UnMap
+.EE
+
+The "Map", "UnMap" and "Stop" facility is under development
+and is currently not explained in this document, since it is likely
+to change.
+
+The order of the options DOES matter.
+The first background text color, "*FvwmFormBack",
+encountered before
+a displayable item
+sets the default
+background color for the entire form.
+
+Other than that, colors, fonts, text, choices and buttons
+can be intermixed in any order.
+The are no builtin limits on form size, number of items on
+a form, or number of fonts or colors used.
+
+.TP 4
+.B *FvwmForm: GrabServer
+This option makes FvwmForm grab the mouse pointer on startup.
+This feature is useful for things like logout verification.
+.TP 4
+.B *FvwmForm: WarpPointer
+This option makes FvwmForm warp the mouse pointer into its window on startup.
+It saves the user some mouse-travelling.
+.TP 4
+.B *FvwmForm: Geometry \fIgeometry\fP
+Specifies the FvwmForm window location.  This is similar to what
+the Position option does but is more flexible.
+.TP 4
+.B *FvwmForm: Position \fIx\fP \fIy\fP
+Puts the FvwmForm window at location (\fIx\fP, \fIy\fP) on the screen.
+By convention, a negative \fIx\fP (\fIy\fP) value measures
+distance from the right (bottom) of the screen.
+
+If this option is omitted, FvwmForm starts at the center of the screen.
+.TP 4
+.B *FvwmForm: Colorset \fIn\fP
+Tells the module to use colorset \fIn\fP.
+.TP 4
+.B *FvwmForm: Back \fIcolor\fP
+Specifies the background color of the FvwmForm window
+and any text in the window.
+The first background color FvwmForm reads determines the overall
+screen background color. Switches off the Colorset option.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: Fore \fIcolor\fP
+Specifies the foreground color for displaying text labels.
+Switches off the Colorset option.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: ItemColorset \fIn\fP
+Tells the module to use colorset \fIn\fP for items.
+.TP 4
+.B *FvwmForm: ItemBack \fIcolor\fP
+Specifies the background color for the text input windows, and
+the buttons.
+Buttons are displayed as 3D depressable buttons.
+Inputs are displayed as 3D indented fields.
+Medium shade background colors work best.
+Switches off the ItemColorset option.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: ItemFore \fIcolor\fP
+Specifies the foreground color for the text input strings and button
+text. Switches off the ItemColorset option.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: Font \fIfont\fP
+Specifies the font for displaying plain text.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: ButtonFont \fIfont\fP
+Specifies the font for text in the action buttons.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: InputFont \fIfont\fP
+Specifies the font for text input.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: TimeoutFont \fIfont\fP
+Specifies the font for display the timeout counter and related text.
+See DEFAULTS.
+.TP 4
+.B *FvwmForm: Line \fIjustification\fP
+Starts a new line.
+A line can contain any number of text, input, buttons and choice items.
+A FvwmForm window can have any number of lines.
+The width of the window is that of the longest line.
+
+Justification of items in the line is specified by \fIjustification\fP,
+which can be one of the following:
+.TP 16
+.B \fIleft\fP
+Items are justified to the left of the window.
+.TP 16
+.B \fIright\fP
+Items are justified to the right of the window.
+.TP 16
+.B \fIcenter\fP
+Items are placed in the center of the window.
+.TP 16
+.B \fIexpand\fP
+If there is only one item in the line, the item is centered in the window.
+If two or more items are present, they are spread to fill the whole
+width of the window.
+.TP 4
+.B *FvwmForm: Message
+Defines a text area on the form that contains the last error message
+from fvwm.  For purposes of determining form size, the message area
+is considered to be 80 bytes long.  Its actual length is the same as
+the message received.  If the message exceeds 80 bytes, you can see the
+rest of the message by resizing the form.
+
+You should not attempt to put any text, buttons or input fields on the
+same line after a message field.  Messages greater than 80 bytes will overlay
+the remainder of the line.
+.TP 4
+.B *FvwmForm: PadVText "\fIPixels\fP"
+The number of pixels used as vertical padding between text items, line
+to line.  The default is 6 which looks good on lines containing text
+intermixed with input boxes, choices or buttons.
+
+For straight text, such as might appear on a help form, padding of
+zero looks better.
+
+(There are lots of other padding values used in form layout
+which can't currently be changed with commands.)
+.TP 4
+.B *FvwmForm: Text "\fIstring\fP"
+Displays \fIstring\fP as plain text.
+Line breaks must be achieved by multiple *FvwmForm: Line and *FvwmForm: Text
+options.
+Blanks may be used to provide extra padding between items.
+.TP 4
+.B *FvwmForm: Title "\fIstring\fP"
+Displays \fIstring\fP as the window's title.  The string
+must be enclosed in double quotes.  Using this command with anything
+other than a string enclosed in quotes creates a blank title.
+If this command is not used, the window title is the form alias.
+.TP 4
+.B *FvwmForm: Input \fIname\fP \fIsize\fP "\fIinit_string\fP"
+Specifies a text input item with name \fIname\fP.
+A sub window of \fIsize\fP characters in width is used for editing.
+If \fIinit_string\fP is present, it is the initial string when
+FvwmForm starts or resets itself.
+The default initial string is "".
+
+You can mouse paste into an input field using button 2.
+Buttons 1 and 3 move the cursor in an input field.
+
+Input fields are always in insert mode, overtyping is not supported.
+
+Emacs type keystrokes are supported.
+
+Control-a, Home and Begin move to the front of an input field.
+Control-e and End move to the end of an input field.
+Control-b and Left move left in an input field.
+Control-f and Right move right in an input field.
+Control-p, Up, and Shift-Tab move to a previous input field if any,
+if the form has one input field, recall previous value.
+Control-n, Down, Return, Line-feed and Tab move to the next input field if any,
+if the form has one input field, for control-n and Down, restore previous
+input value.
+Control-h moves backward in an input field erasing a character.
+Control-d and Delete delete the next character in an input field.
+Control-k erases for the cursor to the end of an input field.
+Control-u erases the entire input field.
+
+When a form executes a command, all the input values are saved in
+a ring of input history 50 items deep.
+
+Meta(mod2)-"<" retrieves the previous value of an input field.
+Meta(mod2)-">" retrieves the next value of an input field.
+
+(For forms with one input field, use the much easier arrow keys.)
+
+.TP 4
+.B *FvwmForm: Selection \fIname\fP \fItype\fP
+This option starts a selection item with name \fIname\fP.
+Its choices are specified in following configuration commands.
+The option \fItype\fP is one of the following:
+.TP 16
+.B \fIsingle\fP
+The selections are mutually exclusive.
+.TP 16
+.B \fImultiple\fP
+This is a multiple-choice selection.
+
+.TP 4
+.B *FvwmForm: Separator
+Draws a 2 pixel shaded line across the form as a visual indication
+of a separate area.
+
+.TP 4
+.B *FvwmForm: Choice \fIname\fP \fIvalue\fP "on | off" "\fIstring\fP"
+Specifies a choice for a proceeding selection.
+The choice item has a \fIname\fP and a \fIvalue\fP these are used in
+commands.  See *FvwmForm: Command.
+The \fIstring\fP is displayed to the right of the choice button
+as a label.
+
+The choice assumes the specified initial state ("on" means selected)
+when FvwmForm starts or resets.
+If the selections are mutually exclusive,
+FvwmForm does NOT detect inconsistencies in the initial states of the choices,
+i.e. two or none of the choices can be selected.
+However, once the user selects a choice,
+FvwmForm  assures only one is selected.
+.TP 4
+.B *FvwmForm: Button \fItype\fP "\fIstring\fP" [\fIkey\fP]
+This option specifies an action button.
+The button has \fIstring\fP as a label,
+and executes a set of Fvwm \fIcommand\fP when it is activated.
+The commands are the following *FvwmForm: Commands.
+
+The optional \fIkey\fP specifies a keyboard shortcut that activates
+the button.
+It is in either a control character, specified as ^@, ^A, ..., ^_,
+or a function key, specified as F1, F2, ..., F35.
+Control keys that are used for cursor movement in text input fields
+cannot activate any buttons, with the exception of
+TAB (^I), RETURN (^M), LINEFEED (^J),
+which can activate a button when the cursor is in the last text input field.
+
+The behavior of the button is determined by \fItype\fP:
+.TP 16
+continue
+FvwmForm continues execution after sending the commands.
+.TP 16
+restart
+After sending the commands,
+FvwmForm resets all the values to the initial ones,
+and then continues execution.
+.TP 16
+quit
+FvwmForm quits after sending the commands.
+.TP 4
+.B *FvwmForm: Command \fIcommand\fP
+This option specifies an Fvwm command associated with the current button.
+There can be more than one command attached to a button.
+Commands that appear before any *FvwmForm: Button option are executed
+at start-up time.  This is usually a beep that gets the user's attention.
+
+Commands starting with an exclamation mark (!) are executed by FvwmForm,
+all other commands are sent to Fvwm for execution.
+Before sending each command to Fvwm, FvwmForm recognizes variables of the
+following forms, and supply values to them.
+.TP 16
+.B $(\fIname\fP)
+If \fIname\fP corresponds to a text input field,
+the result is the user's input string.
+The special chars single-quote, double-quote and backslash
+are preceded by a backslash.
+
+If \fIname\fP corresponds to a choice,
+the result is the value of the choice (as specified in *FvwmForm: Choice)
+if the choice is selected.
+If the choice is not selected, the result is a blank string.
+
+If \fIname\fP corresponds to a selection,
+the result will be a list of the selected values of all its choices
+separated by spaces.
+.TP 16
+.B $(\fIname\fP?\fIstring\fP)
+If \fIname\fP is a text input field and its value is not an empty string,
+the result is \fIstring\fP,
+with recursive variable substitution applied.
+If the input value is empty, the result is empty.
+
+If \fIname\fP is a choice and it is selected,
+the result is \fIstring\fP,
+with recursive variable substitution applied.
+If the choice is not selected, the result is empty.
+.TP 16
+.B $(\fIname\fP!\fIstring\fP)
+The same as the above, except that the converse conditions are taken.
+
+When using the "?" and "!" forms to pass a string, the string is delimited
+by a right parenthesis.  If you need to put a right parenthesis in a string,
+precede the right parenthesis with a backslash.
+
+.TP 4
+.B *FvwmForm: UseData \fIdatafile\fP \fIleading\fP
+Tells FvwmForm to read a data file and extract data from module
+commands that match the "leading" argument and an input,
+choice, or selection variable in a form.
+
+This lets a form display current fvwm module configuration data.
+For an example of how this works, examine the file "FvwmForm-Rlogin"
+which is installed in read-only architecture-independent data directory,
+[PREFIX/share/fvwm] and shown below.
+
+For choices, the setting of the button is represented as the
+word "on",  all other values for a setting are treated as off.
+
+For selections, the setting of each choice button is determined
+by matching the current value of the selection against each
+choice.  Currently, this only works correctly for selections
+that allow a single choice.
+.TP 4
+.B *FvwmForm: ButtonPointer \fIpointername\fP
+Change the default mouse pointer (hand2) used when hovering over a button.
+The pointername must be one of the names defined in
+the include file X11/cursorfont.h (without the XC_ prefix).
+See DEFAULTS.
+
+.TP 4
+.B *FvwmForm: ButtonInPointer \fIpointername\fP
+Change the default mouse pointer (hand1) used
+while a button is pressed in.
+The pointername must be one of the names defined in
+the include file X11/cursorfont.h (without the XC_ prefix).
+See DEFAULTS.
+
+.TP 4
+.B *FvwmForm: InputPointer \fIpointername\fP
+Change the default mouse pointer (xterm) used
+while the pointer is over a text field.
+The pointername must be one of the names defined in
+the include file X11/cursorfont.h (without the XC_ prefix).
+See DEFAULTS.
+
+.TP 4
+.B *FvwmForm: ButtonPointerFore|Back \fIcolor\fP
+Change the default mouse pointer foreground and background colors
+used when hovering over a button.
+See DEFAULTS.
+
+.TP 4
+.B *FvwmForm: ButtonInPointerFore|Back \fIcolor\fP
+Change the default mouse pointer foreground and background colors
+used while a button is pressed in.
+See DEFAULTS.
+
+.TP 4
+.B *FvwmForm: InputPointerFore|Back \fIcolor\fP
+Change the default mouse pointer foreground and background colors
+used while the pointer is over a text field.
+See DEFAULTS.
+
+.TP 4
+.B *FvwmForm: Timeout \fIseconds\fP \fIcommand\fP \fI"text"\fP
+Set up FvwmForm to time out after the amount of \fIseconds\fP
+specified.  When the timer hits zero, \fIcommand\fP executes.  The
+\fItext\fP field is displayed much like a \fIText\fP
+field, except that a '%%' in the line is replaced automatically by
+the amount of time left on the timer.  The value gets updated every
+second as the timer counts down.
+There can only be one timeout field per form.
+
+.SH EXAMPLES
+All of the following "examples" are installed in the
+read-only architecture-independent data directory,
+[PREFIX/share/fvwm], during fvwm installation.
+
+The following commands create a menu to invoke the examples:
+
+.EX
+DestroyMenu Forms
+AddToMenu Forms "&Q. QuitVerify" Module FvwmForm FvwmForm-QuitVerify
+AddToMenu Forms "&C. Capture"    Module FvwmForm FvwmForm-Capture
+AddToMenu Forms "&R. Rlogin"     Module FvwmForm FvwmForm-Rlogin
+AddToMenu Forms "&T. Talk"       Module FvwmForm FvwmForm-Talk
+.EE
+.SH EXAMPLE 1 - Quit Verify
+This example simulates the mwm way of confirming logout.
+Return does the logout, Escape cancels logout.  It times out after 20
+seconds and performs the equivalent of the 'Logout' button.
+.EX
+DestroyModuleConfig  FvwmForm-QuitVerify: *
+*FvwmForm-QuitVerify: GrabServer
+*FvwmForm-QuitVerify: WarpPointer
+*FvwmForm-QuitVerify: Command     Beep
+*FvwmForm-QuitVerify: Line        center
+*FvwmForm-QuitVerify: Text        "Do you really want to logout?"
+*FvwmForm-QuitVerify: Line        expand
+*FvwmForm-QuitVerify: Button      quit "Logout" ^M
+*FvwmForm-QuitVerify: Command     Quit
+*FvwmForm-QuitVerify: Button      restart   "Restart" ^R
+*FvwmForm-QuitVerify: Command     Restart
+*FvwmForm-QuitVerify: Button      quit "Cancel" ^[
+*FvwmForm-QuitVerify: Command     Nop
+*FvwmForm-QuitVerify: Timeout     20 Quit "Automatic logout will occur in %% seconds."
+.EE
+
+.SH EXAMPLE 2 - Remote Login
+This example lets the user type in a host name,
+an optional user name,
+and opens an xterm window from the remote host.
+.EX
+DestroyModuleConfig  FvwmForm-Rlogin: *
+*FvwmForm-Rlogin: WarpPointer
+*FvwmForm-Rlogin: Line         center
+*FvwmForm-Rlogin: Text         "Login to Remote Host"
+*FvwmForm-Rlogin: Line         center
+*FvwmForm-Rlogin: Text         "Host:"
+*FvwmForm-Rlogin: Input        HostName        20      ""
+*FvwmForm-Rlogin: Line         center
+*FvwmForm-Rlogin: Selection    UserSel single
+*FvwmForm-Rlogin: Choice       Default Default on      "same user"
+*FvwmForm-Rlogin: Choice       Custom  Custom  off     "user:"
+*FvwmForm-Rlogin: Input        UserName        10      ""
+*FvwmForm-Rlogin: Line         expand
+*FvwmForm-Rlogin: Button       quit    "Login"         ^M
+*FvwmForm-Rlogin: Command      Exec exec ssh $(Custom?-l $(UserName)) $(HostName) xterm -T xterm@$(HostName) -display $HOSTDISPLAY &
+# Before saving the data, remove any previously saved data:
+*FvwmForm-Rlogin: Command DestroyModuleConfig FvwmForm-RloginDefault: *
+# The "Login" button causes a login and a saving of the current data:
+*FvwmForm-Rlogin: Command !(                        /bin/echo \\
+  "# Created by FvwmForm-Rlogin on: `/bin/date`.";  /bin/echo \\
+  '*FvwmForm-RloginDefault: HostName $(HostName)';  /bin/echo \\
+  '*FvwmForm-RloginDefault: UserName $(UserName)';  /bin/echo \\
+  '*FvwmForm-RloginDefault: Default $(Default?on)'; /bin/echo \\
+  '*FvwmForm-RloginDefault: Custom $(Custom?on)' \\
+) > ${FVWM_USERDIR}/.FvwmForm-Rlogin
+*FvwmForm-Rlogin: Button       restart "Reset"
+*FvwmForm-Rlogin: Button       quit    "Cancel"        ^[
+*FvwmForm-Rlogin: Command      Nop
+# Tell FvwmForm to read vars from the .FvwmForm-RloginDefault file:
+*FvwmForm-Rlogin: UseData .FvwmForm-Rlogin *FvwmForm-RloginDefault
+.EE
+
+.SH EXAMPLE 3 - Capture Window
+This example provides a front-end to xwd, xwud, and xpr.
+.EX
+DestroyModuleConfig  FvwmForm-Capture: *
+*FvwmForm-Capture: Line       center
+*FvwmForm-Capture: Text       "Capture Window"
+*FvwmForm-Capture: Line       left
+*FvwmForm-Capture: Text       "File: "
+*FvwmForm-Capture: Input      file            25      "/tmp/Capture"
+*FvwmForm-Capture: Line       left
+*FvwmForm-Capture: Text       "Printer: "
+*FvwmForm-Capture: Input      printer         20      "$PRINTER"
+*FvwmForm-Capture: Line       expand
+*FvwmForm-Capture: Selection  PtrType single
+*FvwmForm-Capture: Choice     PS      ps      on      "PostScript"
+*FvwmForm-Capture: Choice     Ljet    ljet    off     "HP LaserJet"
+*FvwmForm-Capture: Line       left
+*FvwmForm-Capture: Text       "xwd options:"
+*FvwmForm-Capture: Line       expand
+*FvwmForm-Capture: Selection  Options multiple
+*FvwmForm-Capture: Choice     Brd     -nobdrs off     "No border"
+*FvwmForm-Capture: Choice     Frm     -frame  on      "With frame"
+*FvwmForm-Capture: Choice     XYZ     -xy     off     "XY format"
+*FvwmForm-Capture: Line       expand
+*FvwmForm-Capture: Button     continue        "Capture"       ^M
+*FvwmForm-Capture: Command    Exec exec xwd -out $(file) $(Options) &
+*FvwmForm-Capture: Button     continue        "Preview"
+*FvwmForm-Capture: Command    Exec exec xwud -in $(file) &
+*FvwmForm-Capture: Button     continue        "Print"
+*FvwmForm-Capture: Command    Exec exec xpr -device $(PtrType) $(file) | lpr -P $(printer) &
+*FvwmForm-Capture: Button     quit            "Quit"
+.EE
+
+.SH EXAMPLE 4 - Talk Form
+This example provides a replacement for the module FvwmTalk.
+There are 2 forms, "FvwmForm-Talk." which executes commands,
+or sends commands to fvwm for execution, and "FvwmForm-TalkHelp."
+which is a help form.
+
+In the help form, notice how vertical line
+spacing is changed.  Normal FvwmForm line spacing assumes text is
+intermixed with buttons, help forms require different spacing.
+
+.EX
+# FvwmForm-Talk - Basic replacement for FvwmTalk
+DestroyModuleConfig  FvwmForm-Talk: *
+*FvwmForm-Talk: WarpPointer
+# Layout
+*FvwmForm-Talk: Line         center
+*FvwmForm-Talk: Text         "Talk to Fvwm"
+*FvwmForm-Talk: Line         left
+*FvwmForm-Talk: Text         "Command:"
+*FvwmForm-Talk: Input        Command 80 ""
+*FvwmForm-Talk: Line         left
+*FvwmForm-Talk: Text         "Msg:"
+*FvwmForm-Talk: Message
+*FvwmForm-Talk: Line         center
+# Buttons
+*FvwmForm-Talk: Button       restart    "Return - Execute"         ^M
+*FvwmForm-Talk: Command        $(Command)
+*FvwmForm-Talk: Button       continue    "F1 - Help" F1
+*FvwmForm-Talk: Command        Module FvwmForm FvwmForm-TalkHelp
+*FvwmForm-Talk: Button       restart     "F3 - Reset input" F3
+*FvwmForm-Talk: Command        Nop
+*FvwmForm-Talk: Button       quit        "F4 - Dismiss"  F4
+*FvwmForm-Talk: Command        Nop
+.EE
+
+.EX
+# FvwmForm-TalkHelp - Help Text for FvwmForm-Talk
+DestroyModuleConfig  FvwmForm-TalkHelp: *
+*FvwmForm-TalkHelp: WarpPointer
+# Layout
+*FvwmForm-TalkHelp: Line    center
+*FvwmForm-TalkHelp: Text    "Talk to Fvwm - Help"
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    " "
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: PadVText 0
+*FvwmForm-TalkHelp: Text    "Enter commands in the \"Command:\" input field."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "Commands beginning with \"!\" are executed by the"
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "shell as a sub-process of the form."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "All other commands are sent to fvwm for execution."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    ""
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    "Fvwm error messages are shown on the \"Msg:\" line."
+*FvwmForm-TalkHelp: Line    left
+*FvwmForm-TalkHelp: Text    ""
+# Buttons
+*FvwmForm-TalkHelp: Line    center
+*FvwmForm-TalkHelp: Button  quit    "Return - Dismiss"         ^M
+*FvwmForm-TalkHelp: Command   Nop
+.EE
+
+.SH BUGS AND LIMITATIONS
+FvwmForm is a fairly simple method of providing input.
+There is no input validation facility.
+FvwmForm has no way of dealing with lists.
+
+Report bugs to the fvwm-workers list.
+
+.SH COPYRIGHTS
+FvwmForm is original work of Thomas Zuwei Feng
+(ztfeng@math.princeton.edu).
+
+Copyright Feb 1995, Thomas Zuwei Feng.  No guarantees or warranties are
+provided or implied in any way whatsoever.  Use this program at your own
+risk.  Permission to use, modify, and redistribute this program is hereby
+given, provided that this copyright is kept intact.
+
+.SH CHANGES
+During the fall of 1998, Dan Espen removed all form size limits,
+added unlimited font and color changing, form spacing control,
+configuration file reading, global control of appearance,
+synchronous command execution, Error message display,
+variable substitution,
+configurable pointers,
+and lots of other damage.
+No additional copyright is imposed.

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -1,0 +1,2825 @@
+/* -*-c-*- */
+/* FvwmForm is original work of Thomas Zuwei Feng.
+ *
+ * Copyright Feb 1995, Thomas Zuwei Feng.  No guarantees or warantees are
+ * provided or implied in any way whatsoever.  Use this program at your own
+ * risk.  Permission to use, modify, and redistribute this program is hereby
+ * given, provided that this copyright is kept intact. */
+
+/* This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <ctype.h>
+#include <signal.h>
+
+#include "libs/ftime.h"
+#include <fcntl.h>
+
+#include <X11/Xlib.h>
+#include <X11/X.h>
+#include <X11/Xutil.h>
+#include <X11/cursorfont.h>
+#define XK_MISCELLANY
+#include <X11/keysymdef.h>
+
+#include "libs/Module.h"		/* for headersize, etc. */
+#include "libs/fvwmlib.h"
+#include "libs/fvwmsignal.h"
+#include "libs/ColorUtils.h"
+#include "libs/Cursor.h"
+#include "libs/envvar.h"
+#include "libs/Graphics.h"
+#include "libs/Parse.h"
+#include "libs/Strings.h"
+#include "libs/System.h"
+#include "libs/XError.h"
+
+#include "libs/Flocale.h"               /* for font definition stuff */
+#include "libs/PictureBase.h"		 /* for PictureInitCMap */
+#include "libs/Colorset.h"
+#include "libs/FScreen.h"
+#include "libs/FShape.h"
+#include "libs/FRenderInit.h"
+#include "libs/Rectangles.h"
+
+#include "FvwmForm.h"			/* common FvwmForm stuff */
+
+/* globals that are exported, keep in sync with externs in FvwmForm.h */
+Form cur_form;			 /* current form */
+
+/* Link list roots */
+Item *root_item_ptr;		 /* pointer to root of item list */
+Line root_line = {&root_line,	 /* ->next */
+		  0,		 /* number of items */
+		  L_CENTER,0,0,	 /* justify, size x/y */
+		  0,		 /* current array size */
+		  0};		 /* items ptr */
+Line *cur_line = &root_line;		/* curr line in parse rtns */
+char preload_yorn='n';		 /* init to non-preload */
+Item *item;				/* current during parse */
+Item *cur_sel, *cur_button;		/* current during parse */
+Item *timer = NULL;			/* timeout tracking */
+Display *dpy;
+Atom wm_del_win;
+int fd_x;		   /* fd for X connection */
+Window root, ref;
+int screen;
+char *color_names[4];
+char bg_state = 'd';			/* in default state */
+  /* d = default state */
+  /* s = set by command (must be in "d" state for first "back" cmd to set it) */
+  /* u = used (color allocated, too late to accept "back") */
+char endDefaultsRead = 'n';
+char *font_names[4];
+char *screen_background_color;
+static ModuleArgs *module;
+int Channel[2];
+Bool Swallowed = False;
+
+/* Font/color stuff
+   The colors are:
+   . defaults are changed by commands during parse
+   . copied into items during parse
+   . displayed in the customization dialog
+   */
+int colorset = -1;
+int itemcolorset = 0;
+
+/* prototypes */
+static void RedrawSeparator(Item *item);
+static void AssignDrawTable(Item *);
+static void AddItem(void);
+static void PutDataInForm(char *);
+static void ReadFormData(void);
+static void FormVarsCheck(char **);
+static RETSIGTYPE TimerHandler(int);
+static int ErrorHandler(Display *dpy, XErrorEvent *error_event);
+static void SetupTimer(void)
+{
+#ifdef HAVE_SIGACTION
+  {
+    struct sigaction  sigact;
+
+#ifdef SA_INTERRUPT
+    sigact.sa_flags = SA_INTERRUPT;
+#else
+    sigact.sa_flags = 0;
+#endif
+    sigemptyset(&sigact.sa_mask);
+    sigaddset(&sigact.sa_mask, SIGALRM);
+    sigact.sa_handler = TimerHandler;
+
+    sigaction(SIGALRM, &sigact, NULL);
+  }
+#else
+#ifdef USE_BSD_SIGNALS
+  fvwmSetSignalMask( sigmask(SIGALRM) );
+#endif
+  signal(SIGALRM, TimerHandler);  /* Dead pipe == Fvwm died */
+#ifdef HAVE_SIGINTERRUPT
+  siginterrupt(SIGALRM, 1);
+#endif
+#endif
+
+  alarm(1);
+}
+
+/* copy a string until '"', or '\n', or '\0' */
+static char *CopyQuotedString (char *cp)
+{
+  char *dp, *bp, c;
+  bp = dp = fxmalloc(strlen(cp) + 1);
+  while (1) {
+    switch (c = *(cp++)) {
+    case '\\':
+      *(dp++) = *(cp++);
+      break;
+    case '\"':
+    case '\n':
+    case '\0':
+      *dp = '\0';
+      return bp;
+      break;
+    default:
+      *(dp++) = c;
+      break;
+    }
+  }
+}
+
+/* copy a string until the first space */
+static char *CopySolidString (char *cp)
+{
+  char *dp, *bp, c;
+  bp = dp = fxmalloc(strlen(cp) + 1);
+  while (1) {
+    c = *(cp++);
+    if (c == '\\') {
+      *(dp++) = '\\';
+      *(dp++) = *(cp++);
+    } else if (isspace((unsigned char)c) || c == '\0') {
+      *dp = '\0';
+      return bp;
+    } else
+      *(dp++) = c;
+  }
+}
+
+/* Command parsing section */
+
+/* FvwmAnimate++ type command table */
+typedef struct CommandTable
+{
+  char *name;
+  void (*function)(char *);
+} ct;
+static void ct_ActivateOnPress(char *);
+static void ct_Back(char *);
+static void ct_Button(char *);
+static void ct_ButtonFont(char *);
+static void ct_ButtonInPointer(char *);
+static void ct_ButtonInPointerBack(char *);
+static void ct_ButtonInPointerFore(char *);
+static void ct_ButtonPointer(char *);
+static void ct_ButtonPointerBack(char *);
+static void ct_ButtonPointerFore(char *);
+static void ct_Choice(char *);
+static void ct_Command(char *);
+static void ct_Font(char *);
+static void ct_Fore(char *);
+static void ct_GrabServer(char *);
+static void ct_Input(char *);
+static void ct_InputFont(char *);
+static void ct_ItemBack(char *);
+static void ct_ItemFore(char *);
+static void ct_Line(char *);
+static void ct_Message(char *);
+static void ct_Geometry(char *);
+static void ct_Position(char *);
+static void ct_Read(char *);
+static void ct_Selection(char *);
+static void ct_Separator(char *);
+static void ct_Text(char *);
+static void ct_InputPointer(char *);
+static void ct_InputPointerBack(char *);
+static void ct_InputPointerFore(char *);
+static void ct_Timeout(char *);
+static void ct_TimeoutFont(char *);
+static void ct_Title(char *);
+static void ct_UseData(char *);
+static void ct_padVText(char *);
+static void ct_WarpPointer(char *);
+static void ct_Colorset(char *);
+static void ct_ItemColorset(char *);
+
+/* Must be in Alphabetic order (caseless) */
+static struct CommandTable ct_table[] =
+{
+  {"ActivateOnPress",ct_ActivateOnPress},
+  {"Back",ct_Back},
+  {"Button",ct_Button},
+  {"ButtonFont",ct_ButtonFont},
+  {"ButtonInPointer",ct_ButtonInPointer},
+  {"ButtonInPointerBack",ct_ButtonInPointerBack},
+  {"ButtonInPointerFore",ct_ButtonInPointerFore},
+  {"ButtonPointer",ct_ButtonPointer},
+  {"ButtonPointerBack",ct_ButtonPointerBack},
+  {"ButtonPointerFore",ct_ButtonPointerFore},
+  {"Choice",ct_Choice},
+  {"Colorset",ct_Colorset},
+  {"Command",ct_Command},
+  {"Font",ct_Font},
+  {"Fore",ct_Fore},
+  {"Geometry",ct_Geometry},
+  {"GrabServer",ct_GrabServer},
+  {"Input",ct_Input},
+  {"InputFont",ct_InputFont},
+  {"InputPointer",ct_InputPointer},
+  {"InputPointerBack",ct_InputPointerBack},
+  {"InputPointerFore",ct_InputPointerFore},
+  {"ItemBack",ct_ItemBack},
+  {"ItemColorset",ct_ItemColorset},
+  {"ItemFore",ct_ItemFore},
+  {"Line",ct_Line},
+  {"Message",ct_Message},
+  {"PadVText",ct_padVText},
+  {"Position",ct_Position},
+  {"Selection",ct_Selection},
+  {"Separator",ct_Separator},
+  {"Text",ct_Text},
+  {"Timeout",ct_Timeout},
+  {"TimeoutFont",ct_TimeoutFont},
+  {"Title",ct_Title},
+  {"UseData",ct_UseData},
+  {"WarpPointer",ct_WarpPointer}
+};
+/* These commands are the default setting commands,
+   read before the other form defining commands. */
+static struct CommandTable def_table[] =
+{
+  {"ActivateOnPress",ct_ActivateOnPress},
+  {"Back",ct_Back},
+  {"ButtonFont",ct_ButtonFont},
+  {"ButtonInPointer",ct_ButtonInPointer},
+  {"ButtonInPointerBack",ct_ButtonInPointerBack},
+  {"ButtonInPointerFore",ct_ButtonInPointerFore},
+  {"ButtonPointer",ct_ButtonPointer},
+  {"ButtonPointerBack",ct_ButtonPointerBack},
+  {"ButtonPointerFore",ct_ButtonPointerFore},
+  {"Colorset",ct_Colorset},
+  {"Font",ct_Font},
+  {"Fore",ct_Fore},
+  {"InputFont",ct_InputFont},
+  {"InputPointer",ct_InputPointer},
+  {"InputPointerBack",ct_InputPointerBack},
+  {"InputPointerFore",ct_InputPointerFore},
+  {"ItemBack",ct_ItemBack},
+  {"ItemColorset",ct_ItemColorset},
+  {"ItemFore",ct_ItemFore},
+  {"Read",ct_Read},
+  {"TimeoutFont",ct_TimeoutFont}
+};
+
+/* If there were vars on the command line, do env var sustitution on
+   all input. */
+static void FormVarsCheck(char **p)
+{
+  if (CF.have_env_var) {		/* if cmd line vars */
+    if (strlen(*p) + 200 > CF.expand_buffer_size) { /* fast and loose */
+      CF.expand_buffer_size = strlen(*p) + 2000; /* new size */
+      if (CF.expand_buffer) {		/* already have one */
+	CF.expand_buffer = fxrealloc(CF.expand_buffer, CF.expand_buffer_size,
+			sizeof(CF.expand_buffer));
+      } else {				/* first time */
+	CF.expand_buffer = fxmalloc(CF.expand_buffer_size);
+      }
+    }
+    strcpy(CF.expand_buffer,*p);
+    *p = CF.expand_buffer;
+    envExpand(*p,CF.expand_buffer_size); /* expand the command in place */
+  }
+}
+
+static void ParseDefaults(char *buf)
+{
+  char *p;
+  struct CommandTable *e;
+  if (buf[strlen(buf)-1] == '\n') {	/* if line ends with newline */
+    buf[strlen(buf)-1] = '\0';	/* strip off \n */
+  }
+  /* Accept commands beginning with "*FvwmFormDefault".
+     This is to make sure defaults are read first.
+     Note the hack w. bg_state. */
+  if (strncasecmp(buf, "*FvwmFormDefault", 16) == 0) {
+    p=buf+16;
+    FormVarsCheck(&p);			 /* do var substitution if called for */
+    e = FindToken(p,def_table,struct CommandTable);/* find cmd in table */
+    if (e != 0) {			/* if its valid */
+      p=p+strlen(e->name);		/* skip over name */
+      while (isspace((unsigned char)*p)) p++;	       /* skip whitespace */
+      e->function(p);			/* call cmd processor */
+      bg_state = 'd';			/* stay in default state */
+    }
+  }
+} /* end function */
+
+
+static void ParseConfigLine(char *buf)
+{
+  char *p;
+  struct CommandTable *e;
+  if (buf[strlen(buf)-1] == '\n') {	/* if line ends with newline */
+    buf[strlen(buf)-1] = '\0';	/* strip off \n */
+  }
+
+#if 0
+  if (strncasecmp(buf, XINERAMA_CONFIG_STRING,
+		  sizeof(XINERAMA_CONFIG_STRING)-1) == 0)
+  {
+    FScreenConfigureModule(buf + sizeof(XINERAMA_CONFIG_STRING)-1);
+    return;
+  }
+#endif
+  if (strncasecmp(buf, "Colorset", 8) == 0) {
+    LoadColorset(&buf[8]);
+    return;
+  }
+  if (strncasecmp(buf, CatString3("*",module->name,0), module->namelen+1) != 0) {/* If its not for me */
+    return;
+  } /* Now I know its for me. */
+  p = buf+module->namelen+1;		      /* jump to end of my name */
+  /* at this point we have recognized "*FvwmForm" */
+  FormVarsCheck(&p);
+  e = FindToken(p,ct_table,struct CommandTable);/* find cmd in table */
+  if (e == 0) {			      /* if no match */
+    fprintf(stderr,"%s: unknown command: %s\n",module->name,buf);
+    return;
+  }
+
+  p=p+strlen(e->name);			/* skip over name */
+  while (isspace((unsigned char)*p)) p++;	       /* skip whitespace */
+
+  FormVarsCheck(&p);			 /* do var substitution if called for */
+
+  e->function(p);			/* call cmd processor */
+  return;
+} /* end function */
+
+/* Expands item array */
+static void ExpandArray(Line *this_line)
+{
+  if (this_line->n + 1 >= this_line->item_array_size) { /* no empty space */
+    this_line->item_array_size += ITEMS_PER_EXPANSION; /* get bigger */
+    this_line->items =
+      fxrealloc((void *)this_line->items,
+               (sizeof(Item *) * this_line->item_array_size),
+	       sizeof(this_line->items));
+  } /* end array full */
+}
+
+/* Function to add an item to the current line */
+static void AddToLine(Item *newItem)
+{
+  ExpandArray(cur_line);		/* expand item array if needed */
+  cur_line->items[cur_line->n++] = newItem; /* add to lines item array */
+  cur_line->size_x += newItem->header.size_x; /* incr lines width */
+  if (cur_line->size_y < newItem->header.size_y) { /* new item bigger */
+    cur_line->size_y = newItem->header.size_y; /* then line is bigger */
+  }
+}
+
+
+/* All the functions starting with "ct_" (command table) are called thru
+   their function pointers. Arg 1 is always the rest of the command. */
+static void ct_ActivateOnPress(char *cp)
+{
+  /* arg can be "on", "off", "0", 1", "true", "false", "" */
+  char option[6];
+  int i,j;
+  if (strlen(cp) > 5) {
+    fprintf(stderr,"%s: arg for ActivateOnPress (%s) too long\n",
+	    module->name,cp);
+    return;
+  }
+  for (i=0,j=0;i<strlen(cp);i++) {
+    if (cp[i] != ' ') {			  /* remove any spaces */
+      option[j++]=tolower(cp[i]);
+    }
+  }
+  option[j]=0;
+  if (strcmp(option,"on") == 0
+      || strcmp(option,"true") == 0
+      || strcmp(option,"1") == 0
+      || (cp == 0 || strcmp(option,"")) == 0) {
+    CF.activate_on_press = 1;
+  } else if (strcmp(option,"off") == 0
+	     || strcmp(option,"false") == 0
+	     || strcmp(option,"0") == 0) {
+    CF.activate_on_press = 0;
+  } else {
+    fprintf(stderr,"%s: arg for ActivateOnPress (%s/%s) invalid\n",
+	    module->name,option,cp);
+  }
+}
+static void ct_GrabServer(char *cp)
+{
+  CF.grab_server = 1;
+}
+static void ct_WarpPointer(char *cp)
+{
+  CF.warp_pointer = 1;
+}
+static void ct_Position(char *cp)
+{
+  CF.have_geom = 1;
+  CF.gx = atoi(cp);
+  CF.xneg = 0;
+  if (CF.gx < 0)
+  {
+    CF.gx = -1 - CF.gx;
+    CF.xneg = 1;
+  }
+  while (!isspace((unsigned char)*cp)) cp++;
+  while (isspace((unsigned char)*cp)) cp++;
+  CF.gy = atoi(cp);
+  CF.yneg = 0;
+  if (CF.gy < 0)
+  {
+    CF.gy = -1 - CF.gy;
+    CF.yneg = 1;
+  }
+  myfprintf((stderr, "Position @ (%c%d%c%d)\n",
+	     (CF.xneg)?'-':'+',CF.gx, (CF.yneg)?'-':'+',CF.gy));
+}
+static void ct_Geometry(char *cp)
+{
+  int x = 0;
+  int y = 0;
+  int flags;
+  unsigned int dummy;
+
+  CF.gx = 0;
+  CF.gy = 0;
+  CF.xneg = 0;
+  CF.yneg = 0;
+  while (isspace(*cp))
+    cp++;
+  flags = FScreenParseGeometry(cp, &x, &y, &dummy, &dummy);
+  if (flags&XValue)
+  {
+    CF.have_geom = 1;
+    CF.gx = x;
+    CF.xneg = (flags&XNegative);
+  }
+  if (flags&YValue)
+  {
+    CF.have_geom = 1;
+    CF.gy = y;
+    CF.yneg = (flags&YNegative);
+  }
+  myfprintf((stderr, "Geometry @ (%c%d%c%d)\n",
+	     (CF.xneg)?'-':'+',CF.gx, (CF.yneg)?'-':'+',CF.gy));
+}
+static void ct_Fore(char *cp)
+{
+  if (color_names[c_fg])
+    free(color_names[c_fg]);
+  color_names[c_fg] = fxstrdup(cp);
+  colorset = -1;
+  myfprintf((stderr, "ColorFore: %s\n", color_names[c_fg]));
+}
+static void ct_Back(char *cp)
+{
+  if (color_names[c_bg])
+    free(color_names[c_bg]);
+  color_names[c_bg] = fxstrdup(cp);
+  if (bg_state == 'd')
+  {
+    if (screen_background_color)
+      free(screen_background_color);
+    screen_background_color = fxstrdup(color_names[c_bg]);
+    bg_state = 's';			/* indicate set by command */
+  }
+  colorset = -1;
+  myfprintf((stderr, "ColorBack: %s, screen background %s, bg_state %c\n",
+	     color_names[c_bg],screen_background_color,(int)bg_state));
+}
+static void ct_Colorset(char *cp)
+{
+  sscanf(cp, "%d", &colorset);
+  AllocColorset(colorset);
+}
+static void ct_ItemFore(char *cp)
+{
+  if (color_names[c_item_fg])
+    free(color_names[c_item_fg]);
+  color_names[c_item_fg] = fxstrdup(cp);
+  itemcolorset = -1;
+  myfprintf((stderr, "ColorItemFore: %s\n", color_names[c_item_fg]));
+}
+static void ct_ItemBack(char *cp)
+{
+  if (color_names[c_item_bg])
+    free(color_names[c_item_bg]);
+  color_names[c_item_bg] = fxstrdup(cp);
+  itemcolorset = -1;
+  myfprintf((stderr, "ColorItemBack: %s\n", color_names[c_item_bg]));
+}
+static void ct_ItemColorset(char *cp)
+{
+  sscanf(cp, "%d", &itemcolorset);
+  AllocColorset(itemcolorset);
+}
+static void ct_Font(char *cp)
+{
+  if (font_names[f_text])
+    free(font_names[f_text]);
+  CopyStringWithQuotes(&font_names[f_text], cp);
+  myfprintf((stderr, "Font: %s\n", font_names[f_text]));
+}
+static void ct_TimeoutFont(char *cp)
+{
+  if (font_names[f_timeout])
+    free(font_names[f_timeout]);
+  CopyStringWithQuotes(&font_names[f_timeout], cp);
+  myfprintf((stderr, "TimeoutFont: %s\n", font_names[f_timeout]));
+}
+static void ct_ButtonFont(char *cp)
+{
+  if (font_names[f_button])
+    free(font_names[f_button]);
+  CopyStringWithQuotes(&font_names[f_button], cp);
+  myfprintf((stderr, "ButtonFont: %s\n", font_names[f_button]));
+}
+static void ct_ButtonInPointer(char *cp)
+{
+  int cursor;
+  cursor=fvwmCursorNameToIndex(cp);
+  if (cursor == -1) {
+    fprintf(stderr,"ButtonInPointer: invalid cursor name %s\n",cp);
+  } else {
+    CF.pointer[button_in_pointer] = XCreateFontCursor(dpy,cursor);
+  }
+}
+static void ct_ButtonPointer(char *cp)
+{
+  int cursor;
+  cursor=fvwmCursorNameToIndex(cp);
+  if (cursor == -1) {
+    fprintf(stderr,"ButtonPointer: invalid cursor name %s\n",cp);
+  } else {
+    CF.pointer[button_pointer] = XCreateFontCursor(dpy,cursor);
+  }
+}
+static void ct_InputFont(char *cp)
+{
+  if (font_names[f_input])
+    free(font_names[f_input]);
+  CopyStringWithQuotes(&font_names[f_input], cp);
+  myfprintf((stderr, "InputFont: %s\n", font_names[f_input]));
+}
+static void ct_InputPointer(char *cp)
+{
+  int cursor;
+  cursor=fvwmCursorNameToIndex(cp);
+  if (cursor == -1) {
+    fprintf(stderr,"InputPointer: invalid cursor name %s\n",cp);
+  } else {
+    CF.pointer[input_pointer] = XCreateFontCursor(dpy,cursor);
+  }
+}
+/* process buttons using an index to the ___ array */
+static void color_arg(Ptr_color *color_cell, char *color_name);
+static void color_arg(Ptr_color *color_cell, char *color_name) {
+  if (color_name && *color_name) {
+    color_cell->pointer_color.pixel = GetColor(color_name);
+    color_cell->used=1;
+  }
+}
+
+/* arg is a color name, alloc the color */
+static void ct_ButtonInPointerBack(char *cp) {
+  color_arg(&CF.p_c[button_in_back],cp);
+}
+static void ct_ButtonInPointerFore(char *cp) {
+  color_arg(&CF.p_c[button_in_fore],cp);
+}
+static void ct_ButtonPointerBack(char *cp) {
+  color_arg(&CF.p_c[button_back],cp);
+}
+static void ct_ButtonPointerFore(char *cp) {
+  color_arg(&CF.p_c[button_fore],cp);
+}
+static void ct_InputPointerBack(char *cp) {
+  color_arg(&CF.p_c[input_back],cp);
+}
+static void ct_InputPointerFore(char *cp) {
+  color_arg(&CF.p_c[input_fore],cp);
+}
+
+static void ct_Line(char *cp)
+{
+  /* malloc new line */
+  cur_line->next = fxmalloc(sizeof(struct _line));
+  memset(cur_line->next, 0, sizeof(struct _line));
+  cur_line = cur_line->next;		/* new current line */
+  cur_line->next = &root_line;		/* new next ptr, (actually root) */
+
+  if (strncasecmp(cp, "left", 4) == 0)
+    cur_line->justify = L_LEFT;
+  else if (strncasecmp(cp, "right", 5) == 0)
+    cur_line->justify = L_RIGHT;
+  else if (strncasecmp(cp, "center", 6) == 0)
+    cur_line->justify = L_CENTER;
+  else
+    cur_line->justify = L_LEFTRIGHT;
+}
+/* Define an area on the form that contains the current
+   fvwm error message.
+   syntax: *FFMessage Length nn, Font fn, Fore color, Back color
+   len default is 70
+   font,fg.bg default to text.
+  */
+
+static void ct_Message(char *cp)
+{
+  AddItem();
+  bg_state = 'u';			/* indicate b/g color now used. */
+  item->type = I_TEXT;
+  /* Item now added to list of items, now it needs a pointer
+     to the correct DrawTable. */
+  AssignDrawTable(item);
+  item->header.name = "FvwmMessage";	/* No purpose to this? dje */
+  item->text.value = fxmalloc(80);	/* point at last error recvd */
+  item->text.n = 80;
+  strcpy(item->text.value,"A mix of chars. MM20"); /* 20 mixed width chars */
+  item->header.size_x = (FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+					  item->text.value,
+					  item->text.n/4) * 4) + 2 * TEXT_SPC;
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height
+    + CF.padVText;
+  memset(item->text.value,' ',80);	/* Clear it out */
+  myfprintf((stderr, "Message area [%d, %d]\n",
+	     item->header.size_x, item->header.size_y));
+  AddToLine(item);
+  CF.last_error = item;			/* save location of message item */
+}
+
+/* allocate colors and fonts needed */
+static void CheckAlloc(Item *this_item,DrawTable *dt)
+{
+  XGCValues xgcv;
+  int xgcv_mask = GCForeground;
+
+  if (dt->dt_used == 2) {		/* fonts colors shadows */
+    return;
+  }
+  if (dt->dt_used == 0) {		/* if nothing allocated */
+    dt->dt_colors[c_fg] = (colorset < 0)
+      ? GetColor(dt->dt_color_names[c_fg])
+      : Colorset[colorset].fg;
+    dt->dt_colors[c_bg] = (colorset < 0)
+      ? GetColor(dt->dt_color_names[c_bg])
+      : Colorset[colorset].bg;
+    xgcv.foreground = dt->dt_colors[c_fg];
+    xgcv.background = dt->dt_colors[c_bg];
+    if (dt->dt_Ffont->font != NULL)
+    {
+      xgcv_mask |= GCFont;
+      xgcv.font = dt->dt_Ffont->font->fid;
+    }
+    xgcv_mask |= GCBackground;
+    dt->dt_GC = fvwmlib_XCreateGC(dpy, CF.frame, xgcv_mask, &xgcv);
+
+    dt->dt_used = 1;			/* fore/back font allocated */
+  }
+  if (this_item->type == I_TEXT
+      || this_item->type == I_TIMEOUT) {      /* If no shadows needed */
+    return;
+  }
+  dt->dt_colors[c_item_fg] = (itemcolorset < 0)
+    ? GetColor(dt->dt_color_names[c_item_fg])
+    : Colorset[itemcolorset].fg;
+  dt->dt_colors[c_item_bg] = (itemcolorset < 0)
+    ? GetColor(dt->dt_color_names[c_item_bg])
+    : Colorset[itemcolorset].bg;
+  xgcv.foreground = dt->dt_colors[c_item_fg];
+  xgcv.background = dt->dt_colors[c_item_bg];
+  xgcv_mask = GCForeground;
+  if (dt->dt_Ffont->font != NULL)
+  {
+    xgcv_mask |= GCFont;
+    xgcv.font = dt->dt_Ffont->font->fid;
+  }
+  dt->dt_item_GC = fvwmlib_XCreateGC(dpy, CF.frame, xgcv_mask, &xgcv);
+  if (Pdepth < 2) {
+    dt->dt_colors[c_itemlo] = PictureBlackPixel();
+    dt->dt_colors[c_itemhi] = PictureWhitePixel();
+  } else {
+    dt->dt_colors[c_itemlo] = (itemcolorset < 0)
+      ? GetShadow(dt->dt_colors[c_item_bg])
+      : Colorset[itemcolorset].shadow;
+    dt->dt_colors[c_itemhi] = (itemcolorset < 0)
+      ? GetHilite(dt->dt_colors[c_item_bg])
+      : Colorset[itemcolorset].hilite;
+  }
+  dt->dt_used = 2;		       /* fully allocated */
+}
+
+
+/* Input is the current item.  Assign a drawTable entry to it. */
+static void AssignDrawTable(Item *adt_item)
+{
+  DrawTable *find_dt, *last_dt;
+  char *match_text_fore;
+  char *match_text_back;
+  char *match_item_fore;
+  char *match_item_back;
+  char *match_font;
+  DrawTable *new_dt;			/* pointer to a new one */
+
+  match_text_fore = color_names[c_fg];
+  match_text_back = color_names[c_bg];
+  match_item_fore = color_names[c_item_fg];
+  match_item_back = color_names[c_item_bg];
+
+  switch(adt_item->type) {
+  case I_TEXT:
+  case I_SEPARATOR:			/* hack */
+    match_font = font_names[f_text];
+    break;
+  case	I_TIMEOUT:
+    match_font = font_names[f_timeout];
+    break;
+  case I_INPUT:
+    match_font = font_names[f_input];
+    break;
+  default:
+    match_font = font_names[f_button]; /* choices same as buttons */
+    break;
+  }
+  last_dt = 0;
+  for (find_dt = CF.roots_dt;		   /* start at front */
+       find_dt != 0;			/* until end */
+       find_dt = find_dt->dt_next) {	/* follow next pointer */
+    last_dt = find_dt;
+    if ((strcasecmp(match_text_fore,find_dt->dt_color_names[c_fg]) == 0) &&
+	(strcasecmp(match_text_back,find_dt->dt_color_names[c_bg]) == 0) &&
+	(strcasecmp(match_item_fore,find_dt->dt_color_names[c_item_fg]) == 0) &&
+	(strcasecmp(match_item_back,find_dt->dt_color_names[c_item_bg]) == 0) &&
+	(strcasecmp(match_font,find_dt->dt_font_name) == 0)) { /* Match */
+      adt_item->header.dt_ptr = find_dt;       /* point item to drawtable */
+      return;				/* done */
+    } /* end match */
+  } /* end all drawtables checked, no match */
+
+  /* Time to add a DrawTable */
+  /* get one */
+  new_dt = fxmalloc(sizeof(struct _drawtable));
+  memset(new_dt, 0, sizeof(struct _drawtable));
+  new_dt->dt_next = 0;			/* new end of list */
+  if (CF.roots_dt == 0) {		   /* If first entry in list */
+    CF.roots_dt = new_dt;		   /* set root pointer */
+  } else {				/* not first entry */
+    last_dt->dt_next = new_dt;		/* link old to new */
+  }
+
+  new_dt->dt_font_name = fxstrdup(match_font);
+  new_dt->dt_color_names[c_fg]	    = fxstrdup(match_text_fore);
+  new_dt->dt_color_names[c_bg]	    = fxstrdup(match_text_back);
+  new_dt->dt_color_names[c_item_fg] = fxstrdup(match_item_fore);
+  new_dt->dt_color_names[c_item_bg] = fxstrdup(match_item_back);
+  new_dt->dt_used = 0;			/* show nothing allocated */
+  new_dt->dt_Ffont = FlocaleLoadFont(dpy, new_dt->dt_font_name, module->name);
+  FlocaleAllocateWinString(&new_dt->dt_Fstr);
+
+  myfprintf((stderr,"Created drawtable with %s %s %s %s %s\n",
+	     new_dt->dt_color_names[c_fg], new_dt->dt_color_names[c_bg],
+	     new_dt->dt_color_names[c_item_fg],
+	     new_dt->dt_color_names[c_item_bg],
+	     new_dt->dt_font_name));
+  adt_item->header.dt_ptr = new_dt;	       /* point item to new drawtable */
+}
+
+/* input/output is global "item" - currently allocated last item */
+static void AddItem(void)
+{
+  Item *save_item;
+  save_item = (Item *)item;		/* save current item */
+  item = fxcalloc(sizeof(Item), 1); /* get a new item */
+  if (save_item == 0) {			/* if first item */
+    root_item_ptr = item;		/* save root item */
+  } else {				/* else not first item */
+    save_item->header.next = item;	/* link prior to new */
+  }
+}
+
+static void ct_Separator(char *cp)
+{
+  AddItem();
+  item->header.name = "";		/* null = create no variables in form */
+  item->type = I_SEPARATOR;
+  item->header.size_y = 2;		/* 2 pixels high */
+  AssignDrawTable(item);
+  AddToLine(item);
+  myfprintf((stderr, "ct_separator command set max width %d\n",(int)item->header.size_x));
+}
+
+static void ct_Text(char *cp)
+{
+  /* syntax: *FFText "<text>" */
+  AddItem();
+  bg_state = 'u';			/* indicate b/g color now used. */
+  item->type = I_TEXT;
+  /* Item now added to list of items, now it needs a pointer
+     to the correct DrawTable. */
+  AssignDrawTable(item);
+  item->header.name = "";
+  if (*cp == '\"')
+    item->text.value = CopyQuotedString(++cp);
+  else
+    item->text.value = "";
+  item->text.n = strlen(item->text.value);
+
+  item->header.size_x = FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+				   item->text.value,
+				   item->text.n) + 2 * TEXT_SPC;
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height
+     + CF.padVText;
+  myfprintf((stderr, "Text \"%s\" [%d, %d]\n", item->text.value,
+	     item->header.size_x, item->header.size_y));
+  AddToLine(item);
+}
+/* Set the form's title.
+   The default is the aliasname.
+   If there is no quoted string, create a blank title. */
+static void ct_Title(char *cp)
+{
+  /* syntax: *FFTitle "<text>" */
+  if (*cp == '\"')
+    CF.title = CopyQuotedString(++cp);
+  else
+    CF.title = "";
+  myfprintf((stderr, "Title \"%s\"\n", CF.title));
+}
+static void ct_Timeout(char *cp)
+{
+  /* syntax: *FFTimeout seconds <Command> "Text" */
+  char *tmpcp, *tmpbuf;
+
+  if (timer != NULL) {
+    fprintf(stderr,"Only one timeout per form allowed, skipped %s.\n",cp);
+    return;
+  }
+  AddItem();
+  bg_state = 'u';			/* indicate b/g color now used. */
+  item->type = I_TIMEOUT;
+  /* Item now added to list of items, now it needs a pointer
+     to the correct DrawTable. */
+  AssignDrawTable(item);
+  item->header.name = "";
+
+  item->timeout.timeleft = atoi(cp);
+  if (item->timeout.timeleft < 0)
+  {
+    item->timeout.timeleft = 0;
+  }
+  else if (item->timeout.timeleft > 99999)
+  {
+    item->timeout.timeleft = 99999;
+  }
+  timer = item;
+
+  while (*cp && *cp != '\n' && !isspace((unsigned char)*cp)) cp++;
+							/* skip timeout */
+  while (*cp && *cp != '\n' && isspace((unsigned char)*cp)) cp++;
+							/* move up to command */
+
+  if (!*cp || *cp == '\n') {
+    fprintf(stderr,"Improper arguments specified for FvwmForm Timeout.\n");
+    return;
+  }
+
+  if (*cp == '\"') {
+    item->timeout.command = CopyQuotedString(++cp);
+    /* skip over the whole quoted string to continue parsing */
+    cp += strlen(item->timeout.command) + 1;
+  }
+  else {
+    tmpbuf = fxstrdup(cp);
+    tmpcp = tmpbuf;
+    while (!isspace((unsigned char)*tmpcp)) tmpcp++;
+    *tmpcp = '\0';			  /* cutoff command at first word */
+    item->timeout.command = fxstrdup(tmpbuf);
+    free(tmpbuf);
+    while (!isspace((unsigned char)*cp)) cp++; /* move past command again */
+  }
+
+  while (*cp && *cp != '\n' && isspace((unsigned char)*cp)) cp++;
+						/* move up to next arg */
+
+  if (!*cp || *cp == '\n') {
+    fprintf(stderr,"Improper arguments specified for FvwmForm Timeout.\n");
+    return;
+  }
+
+  if (*cp == '\"') {
+    item->timeout.text = CopyQuotedString(++cp);
+  } else
+    item->timeout.text = "";
+  item->timeout.len = strlen(item->timeout.text);
+
+  item->header.size_x = FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+				   item->timeout.text,
+				   item->timeout.len) + 2 * TEXT_SPC;
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height
+     + CF.padVText;
+  myfprintf((stderr, "Timeout %d \"%s\" [%d, %d]\n", item->timeout.timeleft,
+		item->timeout.text, item->header.size_x, item->header.size_y));
+  AddToLine(item);
+}
+static void ct_padVText(char *cp)
+{
+  /* syntax: *FFText "<padVText pixels>" */
+  CF.padVText = atoi(cp);
+  myfprintf((stderr, "Text Vertical Padding %d\n", CF.padVText));
+}
+static void ct_Input(char *cp)
+{
+  int j;
+  /* syntax: *FFInput <name> <size> "<init_value>" */
+  AddItem();
+  item->type = I_INPUT;
+  AssignDrawTable(item);
+  item->header.name = CopySolidString(cp);
+  cp += strlen(item->header.name);
+  while (isspace((unsigned char)*cp)) cp++;
+  item->input.size = atoi(cp);
+  while (!isspace((unsigned char)*cp)) cp++;
+  while (isspace((unsigned char)*cp)) cp++;
+  item->input.init_value = fxstrdup("");	    /* init */
+  if (*cp == '\"') {
+    free(item->input.init_value);
+    item->input.init_value = CopyQuotedString(++cp);
+  }
+  item->input.blanks = fxmalloc(item->input.size);
+  for (j = 0; j < item->input.size; j++)
+    item->input.blanks[j] = ' ';
+  item->input.buf = strlen(item->input.init_value) + 1;
+  item->input.value = fxmalloc(item->input.buf);
+  item->input.value[0] = 0;		/* avoid reading unitialized data */
+
+  item->header.size_x = item->header.dt_ptr->dt_Ffont->max_char_width
+    * item->input.size + 2 * TEXT_SPC + 2 * BOX_SPC;
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height
+    + 3 * TEXT_SPC + 2 * BOX_SPC;
+  myfprintf((stderr,"Input size_y is %d\n",item->header.size_y));
+
+  if (CF.cur_input == 0) {		   /* first input field */
+    item->input.next_input = item;	/* ring, next field is first field */
+    item->input.prev_input = item;	/* ring, prev field is first field */
+    CF.first_input = item;		   /* save loc of first item */
+  } else {				/* not first field */
+    CF.cur_input->input.next_input = item; /* old next ptr point to this item */
+    item->input.prev_input = CF.cur_input; /* current items prev is old item */
+    item->input.next_input = CF.first_input; /* next is first item */
+    CF.first_input->input.prev_input = item; /* prev in first is this item */
+  }
+  CF.cur_input = item;			   /* new current input item */
+  myfprintf((stderr, "Input, %s, [%d], \"%s\"\n", item->header.name,
+	  item->input.size, item->input.init_value));
+  AddToLine(item);
+}
+static void ct_Read(char *cp)
+{
+  /* syntax: *FFRead 0 | 1 */
+  myfprintf((stderr,"Got read command, char is %c\n",(int)*cp));
+  endDefaultsRead = *cp;		/* copy whatever it is */
+}
+/* read and save vars from a file for later use in form
+   painting.
+*/
+static void ct_UseData(char *cp)
+{
+  /* syntax: *FFUseData filename cmd_prefix */
+  CF.file_to_read = CopySolidString(cp);
+  if (*CF.file_to_read == 0) {
+    fprintf(stderr,"UseData command missing first arg, File to read\n");
+    return;
+  }
+  cp += strlen(CF.file_to_read);
+  while (isspace((unsigned char)*cp)) cp++;
+  CF.leading = CopySolidString(cp);
+  if (*CF.leading == 0) {
+    fprintf(stderr,"UseData command missing second arg, Leading\n");
+    CF.file_to_read = 0;		   /* stop read */
+    return;
+  }
+  /* Cant do the actual reading of the data file here,
+     we are already in a readconfig loop. */
+}
+static void ReadFormData(void)
+{
+  int leading_len;
+  char *line_buf;			/* ptr to curr config line */
+  char cmd_buffer[200];
+  sprintf(cmd_buffer,"read %s Quiet",CF.file_to_read);
+  SendText(Channel,cmd_buffer,0);	/* read data */
+  leading_len = strlen(CF.leading);
+  InitGetConfigLine(Channel, CF.leading); /* ask for certain lines */
+  while (GetConfigLine(Channel,&line_buf),line_buf) { /* while there is some */
+    if (strncasecmp(line_buf, CF.leading, leading_len) == 0) { /* leading = */
+      if (line_buf[strlen(line_buf)-1] == '\n') { /* if line ends with nl */
+	line_buf[strlen(line_buf)-1] = '\0'; /* strip off \n */
+      }
+      PutDataInForm(line_buf+leading_len); /* pass arg, space, value */
+    } /* end match on arg 2, "leading" */
+  } /* end while there is config data */
+  free(CF.file_to_read);		/* dont need it anymore */
+  free(CF.leading);
+  CF.file_to_read = 0;
+  CF.leading = 0;
+}
+/*
+  Input is a line with varname space value.
+  Search form for matching input fields and set values.
+  If you don't get a match on an input field, try a choice.
+*/
+static void PutDataInForm(char *cp)
+{
+  char *var_name;
+  char *var_value;
+  int var_len, i;
+  Item *item;
+  Line *line;
+
+  var_name = CopySolidString(cp);	/* var */
+  if (*var_name == 0) {
+    return;
+  }
+  cp += strlen(var_name);
+  while (isspace((unsigned char)*cp)) cp++;
+  var_value = cp;
+  if (CF.cur_input != 0) {
+    item = CF.cur_input;
+    do {
+      if (strcasecmp(var_name,item->header.name) == 0) {
+	var_len = strlen(cp);
+	if (item->input.init_value)
+	  free(item->input.init_value);
+	item->input.init_value = fxmalloc(var_len + 1);
+	strcpy(item->input.init_value,cp); /* new initial value in field */
+	if (item->input.value)
+	  free(item->input.value);
+	item->input.buf = var_len+1;
+	item->input.value = fxmalloc(item->input.buf);
+	strcpy(item->input.value,cp);	  /* new value in field */
+	free(var_name);			/* goto's have their uses */
+	return;
+      }
+      item=item->input.next_input;	  /* next input field */
+    } while (item != CF.cur_input);	  /* while not end of ring */
+  }
+  /* You have a matching line, but it doesn't match an input
+     field.  What to do?  I know, try a choice. */
+  line = &root_line;			 /* start at first line */
+  do {					/* for all lines */
+    for (i = 0; i < line->n; i++) {	/* all items on line */
+      item = line->items[i];
+      if (item->type == I_CHOICE) {	/* choice is good */
+	if (strcasecmp(var_name,item->header.name) == 0) { /* match */
+	  item->choice.init_on = 0;
+	  if (strncasecmp(cp, "on", 2) == 0) {
+	    item->choice.init_on = 1;	/* set default state */
+	    free(var_name);		/* goto's have their uses */
+	    return;
+	  }
+	}
+      }
+    } /* end all items in line */
+    line = line->next;			/* go to next line */
+  } while (line != &root_line);		/* do all lines */
+  /* You have a matching line, it didn't match an input field,
+     and it didn't match a choice.  I've got it, it may match a
+     selection, in which case we should use the value to
+     set the choices! */
+  for (item = root_item_ptr; item != 0;
+       item = item->header.next) {/* all items */
+    if (item->type == I_SELECT) {     /* selection is good */
+      if (strcasecmp(var_name,item->header.name) == 0) { /* match */
+	/* Now find the choices for this selection... */
+	Item *choice_ptr;
+	for (i = 0;
+	     i<item->selection.n;
+	     i++) {
+	  choice_ptr=item->selection.choices[i];
+	  /* if the choice value matches the selection */
+	  if (strcmp(choice_ptr->choice.value,var_value) == 0) {
+	    choice_ptr->choice.init_on = 1;
+	  } else {
+	    choice_ptr->choice.init_on = 0;
+	  }
+	} /* end all choices */
+      } /* end match */
+    } /* end selection */
+  } /* end all items */
+  free(var_name);			/* not needed now */
+}
+static void ct_Selection(char *cp)
+{
+  /* syntax: *FFSelection <name> single | multiple */
+  AddItem();
+  cur_sel = item;			/* save ptr as cur_sel */
+  cur_sel->type = I_SELECT;
+  cur_sel->header.name = CopySolidString(cp);
+  cp += strlen(cur_sel->header.name);
+  while (isspace((unsigned char)*cp)) cp++;
+  if (strncasecmp(cp, "multiple", 8) == 0)
+    cur_sel->selection.key = IS_MULTIPLE;
+  else
+    cur_sel->selection.key = IS_SINGLE;
+}
+static void ct_Choice(char *cp)
+{
+  /* syntax: *FFChoice <name> <value> [on | _off_] ["<text>"] */
+  /* This next edit is a liitle weak, the selection should be right
+     before the choice. At least a core dump is avoided. */
+  if (cur_sel == 0) {			/* need selection for a choice */
+    fprintf(stderr,"%s: Need selection for choice %s\n",
+	    module->name, cp);
+    return;
+  }
+  bg_state = 'u';			/* indicate b/g color now used. */
+  AddItem();
+  item->type = I_CHOICE;
+  AssignDrawTable(item);
+  item->header.name = CopySolidString(cp);
+  cp += strlen(item->header.name);
+  while (isspace((unsigned char)*cp)) cp++;
+  item->choice.value = CopySolidString(cp);
+  cp += strlen(item->choice.value);
+  while (isspace((unsigned char)*cp)) cp++;
+  if (strncasecmp(cp, "on", 2) == 0)
+    item->choice.init_on = 1;
+  else
+    item->choice.init_on = 0;
+  while (!isspace((unsigned char)*cp)) cp++;
+  while (isspace((unsigned char)*cp)) cp++;
+  if (*cp == '\"')
+    item->choice.text = CopyQuotedString(++cp);
+  else
+    item->choice.text = "";
+  item->choice.n = strlen(item->choice.text);
+  item->choice.sel = cur_sel;
+
+  if (cur_sel->selection.choices_array_count
+      <= cur_sel->selection.n) {	   /* no room */
+    cur_sel->selection.choices_array_count += CHOICES_PER_SEL_EXPANSION;
+    cur_sel->selection.choices =
+      fxrealloc((void *)cur_sel->selection.choices,
+               sizeof(Item *) * cur_sel->selection.choices_array_count,
+	       sizeof(cur_sel->selection.choices)); /* expand */
+  }
+
+  cur_sel->selection.choices[cur_sel->selection.n++] = item;
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height
+     + 2 * TEXT_SPC;
+  /* this is weird, the x dimension is the sum of the height and width? */
+  item->header.size_x = item->header.dt_ptr->dt_Ffont->height
+     + 4 * TEXT_SPC +
+     FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+       item->choice.text, item->choice.n);
+  myfprintf((stderr, "Choice %s, \"%s\", [%d, %d]\n", item->header.name,
+	  item->choice.text, item->header.size_x, item->header.size_y));
+  AddToLine(item);
+}
+static void ct_Button(char *cp)
+{
+  /* syntax: *FFButton continue | restart | quit "<text>" */
+  AddItem();
+  item->type = I_BUTTON;
+  AssignDrawTable(item);
+  item->header.name = "";
+  if (strncasecmp(cp, "restart", 7) == 0)
+    item->button.key = IB_RESTART;
+  else if (strncasecmp(cp, "quit", 4) == 0)
+    item->button.key = IB_QUIT;
+  else
+    item->button.key = IB_CONTINUE;
+  while (!isspace((unsigned char)*cp)) cp++;
+  while (isspace((unsigned char)*cp)) cp++;
+  if (*cp == '\"') {
+    item->button.text = CopyQuotedString(++cp);
+    cp += strlen(item->button.text) + 1;
+    while (isspace((unsigned char)*cp)) cp++;
+  } else
+    item->button.text = "";
+  if (*cp == '^')
+    item->button.keypress = *(++cp) - '@';
+  else if (*cp == 'F')
+    item->button.keypress = 256 + atoi(++cp);
+  else
+    item->button.keypress = -1;
+  item->button.len = strlen(item->button.text);
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height
+     + 2 * TEXT_SPC + 2 * BOX_SPC;
+  item->header.size_x = 2 * TEXT_SPC + 2 * BOX_SPC
+  + FlocaleTextWidth(item->header.dt_ptr->dt_Ffont, item->button.text,
+    item->button.len);
+  AddToLine(item);
+  cur_button = item;
+  myfprintf((stderr,"Created button, fore %s, bg %s, text %s\n",
+	     item->header.dt_ptr->dt_color_names[c_item_fg],
+	     item->header.dt_ptr->dt_color_names[c_item_bg],
+	     item->button.text));
+}
+static void ct_Command(char *cp)
+{
+  /* syntax: *FFCommand <command> */
+  if (cur_button->button.button_array_size <= cur_button->button.n)
+  {
+    cur_button->button.button_array_size += BUTTON_COMMAND_EXPANSION;
+    cur_button->button.commands =
+      fxrealloc((void *)cur_button->button.commands,
+               sizeof(char *) * cur_button->button.button_array_size,
+	       sizeof(cur_button->button.commands));
+  }
+  cur_button->button.commands[cur_button->button.n++] = fxstrdup(cp);
+}
+
+/* End of ct_ routines */
+
+/* Init constants with values that can be freed later. */
+static void InitConstants(void) {
+  color_names[0]=fxstrdup("Light Gray");
+  color_names[1]=fxstrdup("Black");
+  color_names[2]=fxstrdup("Gray50");
+  color_names[3]=fxstrdup("Wheat");
+  font_names[0]=fxstrdup("8x13bold");
+  font_names[1]=fxstrdup("8x13bold");
+  font_names[2]=fxstrdup("8x13bold");
+  font_names[3]=fxstrdup("8x13bold");
+  screen_background_color=fxstrdup("Light Gray");
+  CF.p_c[input_fore].pointer_color.pixel = PictureWhitePixel();
+  CF.p_c[input_back].pointer_color.pixel = PictureBlackPixel();
+  CF.p_c[button_fore].pointer_color.pixel = PictureBlackPixel();
+  CF.p_c[button_back].pointer_color.pixel = PictureWhitePixel();
+  /* The in pointer is the reverse of the hover pointer. */
+  CF.p_c[button_in_fore].pointer_color.pixel = PictureWhitePixel();
+  CF.p_c[button_in_back].pointer_color.pixel = PictureBlackPixel();
+}
+
+/* read the configuration file */
+static void ReadDefaults(void)
+{
+  char *line_buf;			/* ptr to curr config line */
+
+  /* default button is for initial functions */
+  cur_button = &CF.def_button;
+  CF.def_button.button.key = IB_CONTINUE;
+
+   /*
+    * Reading .FvwmFormDefault for every form seems slow.
+    *
+    * This next bit puts a command at the end of the module command
+    * queue in fvwm that indicates whether the file has to be read.
+    *
+    * Read defaults looking for "*FvwmFormDefaultRead"
+    * if not there, send read,
+    * then "*FvwmFormDefaultRead y",
+    * then look thru defaults again.
+    * The customization dialog sends "*FvwmFormDefaultRead n"
+    * to start over.
+    */
+  InitGetConfigLine(Channel,"*FvwmFormDefault");
+  while (GetConfigLine(Channel,&line_buf),line_buf) { /* get config from fvwm */
+    ParseDefaults(line_buf);		 /* process default config lines 1st */
+  }
+  if (endDefaultsRead == 'y') {		/* defaults read already */
+    myfprintf((stderr,"Defaults read, no need to read file.\n"));
+    return;
+  } /* end defaults read already */
+  SendText(Channel,"read .FvwmForm Quiet",0); /* read default config */
+  SendText(Channel,"*FvwmFormDefaultRead y",0); /* remember you read it */
+
+  InitGetConfigLine(Channel,"*FvwmFormDefault");
+  while (GetConfigLine(Channel,&line_buf),line_buf) { /* get config from fvwm */
+    ParseDefaults(line_buf);		 /* process default config lines 1st */
+  }
+} /* done */
+
+static void ReadConfig(void)
+{
+  char *line_buf;			/* ptr to curr config line */
+
+  InitGetConfigLine(Channel,CatString3("*",module->name,0));
+  while (GetConfigLine(Channel,&line_buf),line_buf) { /* get config from fvwm */
+    ParseConfigLine(line_buf);		/* process config lines */
+  }
+} /* done */
+
+/* After this config is read, figure it out */
+static void MassageConfig(void)
+{
+  int i, extra;
+  Line *line;				/* for scanning form lines */
+
+  if (CF.file_to_read) {		/* if theres a data file to read */
+    ReadFormData();			/* go read it */
+  }
+  /* get the geometry right */
+  CF.max_width = 0;
+  CF.total_height = ITEM_VSPC;
+  line = &root_line;			 /* start at first line */
+  do {					/* for all lines */
+    for (i = 0; i < line->n; i++) {
+      line->items[i]->header.pos_y = CF.total_height;
+      if (line->items[i]->header.size_y < line->size_y)
+	line->items[i]->header.pos_y +=
+	  (line->size_y - line->items[i]->header.size_y) / 2 + 1 ;
+    } /* end all items in line */
+    CF.total_height += ITEM_VSPC + line->size_y;
+    line->size_x += (line->n + 1) * ITEM_HSPC;
+    if (line->size_x > CF.max_width)
+      CF.max_width = line->size_x;
+    line = line->next;			/* go to next line */
+  } while (line != &root_line);		/* do all lines */
+  do {					/* note, already back at root_line */
+    int width;
+    switch (line->justify) {
+    case L_LEFT:
+      width = ITEM_HSPC;
+      for (i = 0; i < line->n; i++) {
+	line->items[i]->header.pos_x = width;
+	width += ITEM_HSPC + line->items[i]->header.size_x;
+      }
+      break;
+    case L_RIGHT:
+      width = CF.max_width - line->size_x + ITEM_HSPC;
+      for (i = 0; i < line->n; i++) {
+	line->items[i]->header.pos_x = width;
+	width += ITEM_HSPC + line->items[i]->header.size_x;
+      }
+      break;
+    case L_CENTER:
+      width = (CF.max_width - line->size_x) / 2 + ITEM_HSPC;
+      for (i = 0; i < line->n; i++) {
+	line->items[i]->header.pos_x = width;
+	myfprintf((stderr, "Line Item[%d] @ (%d, %d)\n", i,
+	       line->items[i]->header.pos_x, line->items[i]->header.pos_y));
+	width += ITEM_HSPC + line->items[i]->header.size_x;
+      }
+      break;
+    case L_LEFTRIGHT:
+    /* count the number of inputs on the line - the extra space will be
+     * shared amongst these if there are any, otherwise it will be added
+     * as space in between the elements
+     */
+      extra = 0 ;
+      for (i = 0 ; i < line->n ; i++) {
+	if (line->items[i]->type == I_INPUT)
+	  extra++ ;
+      }
+      if (extra == 0) {
+	if (line->n < 2) {  /* same as L_CENTER */
+	  width = (CF.max_width - line->size_x) / 2 + ITEM_HSPC;
+	  for (i = 0; i < line->n; i++) {
+	    line->items[i]->header.pos_x = width;
+	    width += ITEM_HSPC + line->items[i]->header.size_x;
+	  }
+	} else {
+	  extra = (CF.max_width - line->size_x) / (line->n - 1);
+	  width = ITEM_HSPC;
+	  for (i = 0; i < line->n; i++) {
+	    line->items[i]->header.pos_x = width;
+	    width += ITEM_HSPC + line->items[i]->header.size_x + extra;
+	  }
+	}
+      } else {
+	extra = (CF.max_width - line->size_x) / extra ;
+	width = ITEM_HSPC ;
+	for (i = 0 ; i < line->n ; i++) {
+	  line->items[i]->header.pos_x = width ;
+	  if (line->items[i]->type == I_INPUT)
+	    line->items[i]->header.size_x += extra ;
+	  width += ITEM_HSPC + line->items[i]->header.size_x ;
+	}
+      }
+      break;
+    }
+    line = line->next;			/* go to next line */
+  } while (line != &root_line);		 /* do all lines */
+}
+
+/* reset all the values (also done on first display) */
+static void Restart(void)
+{
+  Item *item;
+
+  CF.cur_input = NULL;
+  CF.abs_cursor = CF.rel_cursor = 0;
+  for (item = root_item_ptr; item != 0;
+       item = item->header.next) {/* all items */
+    switch (item->type) {
+    case I_INPUT:
+      if (!CF.cur_input)
+	CF.cur_input = item;
+
+      /* save old input values in a recall ring. */
+      if (item->input.value && item->input.value[0] != 0) { /* ? to save */
+	if (item->input.value_history_ptr == 0) {  /* no history yet */
+	  item->input.value_history_ptr =
+	    fxcalloc(sizeof(char *), 50);
+	  item->input.value_history_ptr[0] = fxstrdup(item->input.value);
+	  item->input.value_history_count = 1; /* next insertion point */
+	  myfprintf((stderr,"Initial save of %s in slot 0\n",
+		     item->input.value_history_ptr[0]));
+	} else {			/* we have a history */
+	  int prior;
+	  prior = item->input.value_history_count - 1;
+	  if (prior < 0) {
+	    for (prior = VH_SIZE - 1;
+		 CF.cur_input->input.value_history_ptr[prior] == 0;
+		 --prior);		/* find last used slot */
+	  }
+	  myfprintf((stderr,"Prior is %d, compare %s to %s\n",
+		     prior, item->input.value,
+		     item->input.value_history_ptr[prior]));
+
+	  if ( strcmp(item->input.value, item->input.value_history_ptr[prior])
+	       != 0) {			/* different value */
+	    if (item->input.value_history_ptr[item->input.value_history_count])
+	    {
+	      free(item->input.value_history_ptr[
+			   item->input.value_history_count]);
+	      myfprintf((stderr,"Freeing old item in slot %d\n",
+			 item->input.value_history_count));
+	    }
+	    item->input.value_history_ptr[item->input.value_history_count] =
+	      fxstrdup(item->input.value); /* save value ptr in array */
+	    myfprintf((stderr,"Save of %s in slot %d\n",
+		       item->input.value,
+		       item->input.value_history_count));
+
+	    /* leave count pointing at the next insertion point. */
+	    if (item->input.value_history_count < VH_SIZE - 1) { /* not full */
+	      ++item->input.value_history_count;    /* next slot */
+	    } else {
+	      item->input.value_history_count = 0;  /* wrap around */
+	    }
+	  } /* end something different */
+	} /* end have a history */
+	myfprintf((stderr,"New history yankat %d\n",
+		   item->input.value_history_yankat));
+      } /* end something to save */
+      item->input.value_history_yankat = item->input.value_history_count;
+      item->input.n = strlen(item->input.init_value);
+      strcpy(item->input.value, item->input.init_value);
+      item->input.left = 0;
+      break;
+    case I_CHOICE:
+      item->choice.on = item->choice.init_on;
+      break;
+    }
+  }
+}
+
+/* redraw the frame */
+void RedrawFrame(XEvent *pev)
+{
+	Item *item;
+	Region region = None;
+
+	Bool clear = False;
+	if (FftSupport)
+	{
+		item = root_item_ptr;
+		while(item != 0 && !clear)
+		{
+			if ((item->type == I_TEXT || item->type == I_CHOICE) &&
+			    item->header.dt_ptr->dt_Ffont->fftf.fftfont != NULL)
+				clear = True;
+			item = item->header.next;
+		}
+		if (clear && pev)
+		{
+			XClearArea(
+				dpy, CF.frame,
+				pev->xexpose.x, pev->xexpose.y,
+				pev->xexpose.width, pev->xexpose.height,
+				False);
+		}
+		else
+		{
+			XClearWindow(dpy, CF.frame);
+		}
+	}
+	if (pev)
+	{
+		XRectangle r;
+
+		r.x = pev->xexpose.x;
+		r.y =  pev->xexpose.y;
+		r.width = pev->xexpose.width;
+		r.height = pev->xexpose.height;
+		region = XCreateRegion();
+		XUnionRectWithRegion (&r, region, region);
+	}
+	for (item = root_item_ptr; item != 0;
+	     item = item->header.next) {      /* all items */
+		DrawTable *dt_ptr = item->header.dt_ptr;
+
+		if (dt_ptr && dt_ptr->dt_Fstr)
+		{
+			if (region)
+			{
+				dt_ptr->dt_Fstr->flags.has_clip_region = True;
+				dt_ptr->dt_Fstr->clip_region = region;
+			}
+			else
+			{
+				dt_ptr->dt_Fstr->flags.has_clip_region = False;
+			}
+		}
+		switch (item->type) {
+		case I_TEXT:
+			RedrawText(item);
+			break;
+		case I_TIMEOUT:
+			RedrawTimeout(item);
+			break;
+		case I_CHOICE:
+			dt_ptr->dt_Fstr->win = CF.frame;
+			dt_ptr->dt_Fstr->gc  = dt_ptr->dt_GC;
+			dt_ptr->dt_Fstr->str = item->choice.text;
+			dt_ptr->dt_Fstr->x   = item->header.pos_x
+				+ TEXT_SPC + item->header.size_y;
+			dt_ptr->dt_Fstr->y   = item->header.pos_y
+				+ TEXT_SPC + dt_ptr->dt_Ffont->ascent;
+			dt_ptr->dt_Fstr->len = item->choice.n;
+			dt_ptr->dt_Fstr->flags.has_colorset = False;
+			if (itemcolorset >= 0)
+			{
+				dt_ptr->dt_Fstr->colorset =
+					&Colorset[itemcolorset];
+				dt_ptr->dt_Fstr->flags.has_colorset
+					= True;
+			}
+			FlocaleDrawString(dpy,
+					  dt_ptr->dt_Ffont,
+					  dt_ptr->dt_Fstr,
+					  FWS_HAVE_LENGTH);
+			break;
+		case I_SEPARATOR:
+			myfprintf((stderr, "redraw_frame calling RedrawSeparator\n"));
+			RedrawSeparator(item);
+			break;
+		}
+		if (dt_ptr && dt_ptr->dt_Fstr)
+		{
+			dt_ptr->dt_Fstr->flags.has_clip_region = False;
+		}
+	}
+	if (region)
+	{
+		XDestroyRegion(region);
+	}
+}
+
+void RedrawText(Item *item)
+{
+  char *p;
+
+  CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+  item->header.dt_ptr->dt_Fstr->len = item->text.n;
+  if ((p = memchr(item->text.value, '\0', item->header.dt_ptr->dt_Fstr->len))
+      != NULL)
+    item->header.dt_ptr->dt_Fstr->len = p - item->text.value;
+  item->header.dt_ptr->dt_Fstr->win = CF.frame;
+  item->header.dt_ptr->dt_Fstr->gc  = item->header.dt_ptr->dt_GC;
+  item->header.dt_ptr->dt_Fstr->str = item->text.value;
+  item->header.dt_ptr->dt_Fstr->x   = item->header.pos_x + TEXT_SPC;
+  item->header.dt_ptr->dt_Fstr->y   = item->header.pos_y + ( CF.padVText / 2 ) +
+    item->header.dt_ptr->dt_Ffont->ascent;
+  item->header.dt_ptr->dt_Fstr->flags.has_colorset = False;
+  if (colorset >= 0)
+  {
+    item->header.dt_ptr->dt_Fstr->colorset = &Colorset[colorset];
+    item->header.dt_ptr->dt_Fstr->flags.has_colorset = True;
+  }
+  FlocaleDrawString(dpy,
+		    item->header.dt_ptr->dt_Ffont,
+		    item->header.dt_ptr->dt_Fstr, FWS_HAVE_LENGTH);
+  return;
+}
+
+/*
+ *  Draw horizontal lines to form a separator
+ *
+ */
+static void RedrawSeparator(Item *item)
+{
+
+  item->header.size_x = CF.max_width - 6;
+  CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+  if ( item->header.dt_ptr && item->header.dt_ptr->dt_colors[c_itemlo] ) { /* safety */
+    XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,item->header.dt_ptr->dt_colors[c_itemlo]);
+    XDrawLine(dpy, item->header.win,item->header.dt_ptr->dt_item_GC, 0, 0, item->header.size_x, 0);
+    XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,item->header.dt_ptr->dt_colors[c_itemhi]);
+    XDrawLine(dpy, item->header.win,item->header.dt_ptr->dt_item_GC, 0, 1, item->header.size_x, 1);
+
+  } else {
+    fprintf(stderr,"%s: Separators, no colors %p\n",module->name,item->header.dt_ptr);
+  }
+  return;
+}
+
+void RedrawTimeout(Item *item)
+{
+  char *p;
+  char *tmpbuf, *tmpptr, *tmpbptr;
+  int reallen;
+
+  XClearArea(dpy, CF.frame,
+	       item->header.pos_x, item->header.pos_y,
+	       item->header.size_x, item->header.size_y,
+	       False);
+
+  tmpbuf = fxmalloc(item->timeout.len + 6);
+  tmpbptr = tmpbuf;
+  for (tmpptr = item->timeout.text; *tmpptr != '\0' &&
+		!(tmpptr[0] == '%' && tmpptr[1] == '%'); tmpptr++) {
+    *tmpbptr = *tmpptr;
+    tmpbptr++;
+  }
+  if (tmpptr[0] == '%') {
+    tmpptr++; tmpptr++;
+    sprintf(tmpbptr, "%d", item->timeout.timeleft);
+    tmpbptr += strlen(tmpbptr);
+  }
+  for (; *tmpptr != '\0'; tmpptr++) {
+    *tmpbptr = *tmpptr;
+    tmpbptr++;
+  }
+  *tmpbptr = '\0';
+
+  reallen = strlen(tmpbuf);
+  item->header.size_x = FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+				   tmpbuf, reallen) + 2 * TEXT_SPC;
+  item->header.size_y = item->header.dt_ptr->dt_Ffont->height + CF.padVText;
+
+  CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+  item->header.dt_ptr->dt_Fstr->len = reallen;
+  if ((p = memchr(item->timeout.text, '\0', item->header.dt_ptr->dt_Fstr->len))
+      != NULL)
+    item->header.dt_ptr->dt_Fstr->len = p - tmpbuf;
+  item->header.dt_ptr->dt_Fstr->win = CF.frame;
+  item->header.dt_ptr->dt_Fstr->gc  = item->header.dt_ptr->dt_GC;
+  item->header.dt_ptr->dt_Fstr->flags.has_colorset = False;
+  if (colorset >= 0)
+  {
+    item->header.dt_ptr->dt_Fstr->colorset = &Colorset[colorset];
+    item->header.dt_ptr->dt_Fstr->flags.has_colorset = True;
+  }
+  if (item->header.dt_ptr->dt_Fstr->str != NULL)
+    free(item->header.dt_ptr->dt_Fstr->str);
+  item->header.dt_ptr->dt_Fstr->str = fxstrdup(tmpbuf);
+  item->header.dt_ptr->dt_Fstr->x   = item->header.pos_x + TEXT_SPC;
+  item->header.dt_ptr->dt_Fstr->y   = item->header.pos_y + ( CF.padVText / 2 ) +
+    item->header.dt_ptr->dt_Ffont->ascent;
+  FlocaleDrawString(dpy,
+		    item->header.dt_ptr->dt_Ffont,
+		    item->header.dt_ptr->dt_Fstr, FWS_HAVE_LENGTH);
+  free(tmpbuf);
+  return;
+}
+
+/* redraw an item */
+void RedrawItem (Item *item, int click, XEvent *pev)
+{
+  int dx, dy, len, x;
+  static XSegment xsegs[4];
+  XRectangle r,inter;
+  Region region = None;
+  Bool text_inter = True;
+  DrawTable *dt_ptr = item->header.dt_ptr;
+
+  /* Init intersection to size of the item. */
+  inter.x = BOX_SPC + TEXT_SPC - 1;
+  inter.y = BOX_SPC;
+  inter.width = item->header.size_x - (2 * BOX_SPC) - 2 - TEXT_SPC;
+  inter.height = (item->header.size_y - 1) - 2 * BOX_SPC + 1;
+
+  myfprintf((stderr,"%s: RedrawItem expose x=%d/y=%d h=%d/w=%d\n",module->name,
+	     (int)pev->xexpose.x,
+	     (int)pev->xexpose.y,
+	     (int)pev->xexpose.width,
+	     (int)pev->xexpose.height));
+
+  /* This is a slightly altered expose event from ReadXServer. */
+  if (pev)
+  {
+	  r.x = pev->xexpose.x;
+	  r.y =	 pev->xexpose.y;
+	  r.width = pev->xexpose.width;
+	  r.height = pev->xexpose.height;
+	  text_inter = frect_get_intersection(
+		  r.x, r.y, r.width, r.height,
+		  inter.x,inter.y,inter.width,inter.height,
+		  &inter);
+  }
+  else
+  {
+	  /* If its not an expose event, the area assume the
+	     whole item is intersected. */
+	  r.x = inter.x;
+	  r.y = inter.y;
+	  r.width = inter.width;
+	  r.height = inter.height;
+  }
+  if (pev && text_inter && dt_ptr && dt_ptr->dt_Fstr)
+  {
+	  region = XCreateRegion();
+	  XUnionRectWithRegion (&r, region, region);
+	  if (region)
+	  {
+		  dt_ptr->dt_Fstr->flags.has_clip_region = True;
+		  dt_ptr->dt_Fstr->clip_region = region;
+	  }
+	  else
+	  {
+		  dt_ptr->dt_Fstr->flags.has_clip_region = False;
+	  }
+  }
+
+  switch (item->type) {
+  case I_INPUT:
+    if (!text_inter)
+    {
+	    return;
+    }
+    /* Create frame (pressed in): */
+    dx = item->header.size_x - 1;
+    dy = item->header.size_y - 1;
+    /*fprintf(stderr,"GC: %lu\n", item->header.dt_ptr->dt_item_GC);*/
+    XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		   item->header.dt_ptr->dt_colors[c_itemlo]);
+
+    /* around 12/26/99, added XClearArea to this function.
+       this was done to deal with display corruption during
+       multifield paste.  dje */
+    if (frect_get_intersection(
+	    r.x, r.y, r.width, r.height,
+	    inter.x, inter.y, inter.width, inter.height,
+	    &inter))
+    {
+	    XClearArea(
+		       dpy, item->header.win,
+		       inter.x, inter.y, inter.width, inter.height, False);
+    }
+
+    xsegs[0].x1 = 0, xsegs[0].y1 = 0;
+    xsegs[0].x2 = 0, xsegs[0].y2 = dy;
+    xsegs[1].x1 = 0, xsegs[1].y1 = 0;
+    xsegs[1].x2 = dx, xsegs[1].y2 = 0;
+    xsegs[2].x1 = 1, xsegs[2].y1 = 1;
+    xsegs[2].x2 = 1, xsegs[2].y2 = dy - 1;
+    xsegs[3].x1 = 1, xsegs[3].y1 = 1;
+    xsegs[3].x2 = dx - 1, xsegs[3].y2 = 1;
+    XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		  xsegs, 4);
+    XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		   item->header.dt_ptr->dt_colors[c_itemhi]);
+    xsegs[0].x1 = 1, xsegs[0].y1 = dy;
+    xsegs[0].x2 = dx, xsegs[0].y2 = dy;
+    xsegs[1].x1 = 2, xsegs[1].y1 = dy - 1;
+    xsegs[1].x2 = dx, xsegs[1].y2 = dy - 1;
+    xsegs[2].x1 = dx, xsegs[2].y1 = 1;
+    xsegs[2].x2 = dx, xsegs[2].y2 = dy;
+    xsegs[3].x1 = dx - 1, xsegs[3].y1 = 2;
+    xsegs[3].x2 = dx - 1, xsegs[3].y2 = dy;
+    XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		  xsegs, 4);
+
+    if (click) {
+      x = BOX_SPC + TEXT_SPC +
+	      FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+			       item->input.value, CF.abs_cursor) - 1;
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_item_bg]);
+      XDrawLine(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		x, BOX_SPC, x, dy - BOX_SPC);
+      myfprintf((stderr,"Line %d/%d - %d/%d (first)\n",
+		     x, BOX_SPC, x, dy - BOX_SPC));
+    }
+    len = item->input.n - item->input.left;
+    XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		   item->header.dt_ptr->dt_colors[c_item_fg]);
+    item->header.dt_ptr->dt_Fstr->win = item->header.win;
+    item->header.dt_ptr->dt_Fstr->gc  = item->header.dt_ptr->dt_item_GC;
+    item->header.dt_ptr->dt_Fstr->flags.has_colorset = False;
+    if (itemcolorset >= 0)
+    {
+      item->header.dt_ptr->dt_Fstr->colorset = &Colorset[itemcolorset];
+      item->header.dt_ptr->dt_Fstr->flags.has_colorset = True;
+    }
+    if (len > item->input.size)
+      len = item->input.size;
+    else
+    {
+      item->header.dt_ptr->dt_Fstr->str = item->input.blanks;
+      item->header.dt_ptr->dt_Fstr->x  = BOX_SPC + TEXT_SPC +
+	      FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+			       item->input.blanks, len);
+      item->header.dt_ptr->dt_Fstr->y	= BOX_SPC + TEXT_SPC
+		  + item->header.dt_ptr->dt_Ffont->ascent;
+      item->header.dt_ptr->dt_Fstr->len = item->input.size - len;
+      FlocaleDrawString(dpy,
+			item->header.dt_ptr->dt_Ffont,
+			item->header.dt_ptr->dt_Fstr, FWS_HAVE_LENGTH);
+    }
+    item->header.dt_ptr->dt_Fstr->str = item->input.value;
+    item->header.dt_ptr->dt_Fstr->x   = BOX_SPC + TEXT_SPC;
+    item->header.dt_ptr->dt_Fstr->y   = BOX_SPC + TEXT_SPC
+      + item->header.dt_ptr->dt_Ffont->ascent;
+    item->header.dt_ptr->dt_Fstr->len = len;
+    FlocaleDrawString(dpy,
+		      item->header.dt_ptr->dt_Ffont,
+		      item->header.dt_ptr->dt_Fstr, FWS_HAVE_LENGTH);
+    if (item == CF.cur_input && !click) {
+      x = BOX_SPC + TEXT_SPC +
+	FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+			 item->input.value,CF.abs_cursor)
+	- 1;
+      XDrawLine(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		x, BOX_SPC, x, dy - BOX_SPC);
+      myfprintf((stderr,"Line %d/%d - %d/%d\n",
+		 x, BOX_SPC, x, dy - BOX_SPC));
+    }
+    myfprintf((stderr,"Just drew input field. click %d\n",(int)click));
+    break;
+  case I_CHOICE:
+    dx = dy = item->header.size_y - 1;
+    if (item->choice.on) {
+	XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		       item->header.dt_ptr->dt_colors[c_item_fg]);
+      if (item->choice.sel->selection.key == IS_MULTIPLE) {
+	xsegs[0].x1 = 5, xsegs[0].y1 = 5;
+	xsegs[0].x2 = dx - 5, xsegs[0].y2 = dy - 5;
+	xsegs[1].x1 = 5, xsegs[1].y1 = dy - 5;
+	xsegs[1].x2 = dx - 5, xsegs[1].y2 = 5;
+	XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		      xsegs, 2);
+      } else {
+	XDrawArc(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		 5, 5, dx - 10, dy - 10, 0, 360 * 64);
+      }
+    } else
+      XClearWindow(dpy, item->header.win);
+    if (item->choice.on)
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemlo]);
+    else
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemhi]);
+    xsegs[0].x1 = 0, xsegs[0].y1 = 0;
+    xsegs[0].x2 = 0, xsegs[0].y2 = dy;
+    xsegs[1].x1 = 0, xsegs[1].y1 = 0;
+    xsegs[1].x2 = dx, xsegs[1].y2 = 0;
+    xsegs[2].x1 = 1, xsegs[2].y1 = 1;
+    xsegs[2].x2 = 1, xsegs[2].y2 = dy - 1;
+    xsegs[3].x1 = 1, xsegs[3].y1 = 1;
+    xsegs[3].x2 = dx - 1, xsegs[3].y2 = 1;
+    XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		  xsegs, 4);
+    if (item->choice.on)
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemhi]);
+    else
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemlo]);
+    xsegs[0].x1 = 1, xsegs[0].y1 = dy;
+    xsegs[0].x2 = dx, xsegs[0].y2 = dy;
+    xsegs[1].x1 = 2, xsegs[1].y1 = dy - 1;
+    xsegs[1].x2 = dx, xsegs[1].y2 = dy - 1;
+    xsegs[2].x1 = dx, xsegs[2].y1 = 1;
+    xsegs[2].x2 = dx, xsegs[2].y2 = dy;
+    xsegs[3].x1 = dx - 1, xsegs[3].y1 = 2;
+    xsegs[3].x2 = dx - 1, xsegs[3].y2 = dy;
+    XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		  xsegs, 4);
+    break;
+  case I_BUTTON:
+    if (!text_inter)
+    {
+	    return;
+    }
+    dx = item->header.size_x - 1;
+    dy = item->header.size_y - 1;
+    if (click)
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemlo]);
+    else
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemhi]);
+    xsegs[0].x1 = 0, xsegs[0].y1 = 0;
+    xsegs[0].x2 = 0, xsegs[0].y2 = dy;
+    xsegs[1].x1 = 0, xsegs[1].y1 = 0;
+    xsegs[1].x2 = dx, xsegs[1].y2 = 0;
+    xsegs[2].x1 = 1, xsegs[2].y1 = 1;
+    xsegs[2].x2 = 1, xsegs[2].y2 = dy - 1;
+    xsegs[3].x1 = 1, xsegs[3].y1 = 1;
+    xsegs[3].x2 = dx - 1, xsegs[3].y2 = 1;
+    XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		  xsegs, 4);
+    if (click)
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemhi]);
+    else
+      XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		     item->header.dt_ptr->dt_colors[c_itemlo]);
+    xsegs[0].x1 = 1, xsegs[0].y1 = dy;
+    xsegs[0].x2 = dx, xsegs[0].y2 = dy;
+    xsegs[1].x1 = 2, xsegs[1].y1 = dy - 1;
+    xsegs[1].x2 = dx, xsegs[1].y2 = dy - 1;
+    xsegs[2].x1 = dx, xsegs[2].y1 = 1;
+    xsegs[2].x2 = dx, xsegs[2].y2 = dy;
+    xsegs[3].x1 = dx - 1, xsegs[3].y1 = 2;
+    xsegs[3].x2 = dx - 1, xsegs[3].y2 = dy;
+    XDrawSegments(dpy, item->header.win, item->header.dt_ptr->dt_item_GC,
+		  xsegs, 4);
+    XSetForeground(dpy, item->header.dt_ptr->dt_item_GC,
+		   item->header.dt_ptr->dt_colors[c_item_fg]);
+    item->header.dt_ptr->dt_Fstr->win = item->header.win;
+    item->header.dt_ptr->dt_Fstr->gc  = item->header.dt_ptr->dt_item_GC;
+    item->header.dt_ptr->dt_Fstr->flags.has_colorset = False;
+    if (itemcolorset >= 0)
+    {
+      item->header.dt_ptr->dt_Fstr->colorset = &Colorset[itemcolorset];
+      item->header.dt_ptr->dt_Fstr->flags.has_colorset = True;
+    }
+    item->header.dt_ptr->dt_Fstr->str = item->button.text;
+    item->header.dt_ptr->dt_Fstr->x   = BOX_SPC + TEXT_SPC;
+    item->header.dt_ptr->dt_Fstr->y   = BOX_SPC + TEXT_SPC
+      + item->header.dt_ptr->dt_Ffont->ascent;
+    item->header.dt_ptr->dt_Fstr->len = item->button.len;
+    if (FftSupport)
+    {
+      if (item->header.dt_ptr->dt_Ffont->fftf.fftfont != NULL)
+	XClearArea(dpy, item->header.win,
+		   inter.x, inter.y, inter.width, inter.height, False);
+    }
+    FlocaleDrawString(dpy,
+		      item->header.dt_ptr->dt_Ffont,
+		      item->header.dt_ptr->dt_Fstr, FWS_HAVE_LENGTH);
+    myfprintf((stderr,"Just put %s into a button\n",
+	       item->button.text));
+    break;
+  case I_SEPARATOR:
+    RedrawSeparator(item);
+    break;
+  }
+  if (dt_ptr && dt_ptr->dt_Fstr)
+  {
+	  dt_ptr->dt_Fstr->flags.has_clip_region = False;
+  }
+  if (region)
+  {
+	  XDestroyRegion(region);
+  }
+  XFlush(dpy);
+}
+
+/* update transparency if background colorset is transparent */
+/* window has moved redraw the background if it is transparent */
+void UpdateRootTransapency(Bool pr_only, Bool do_draw)
+{
+	Item *item;
+
+	if (CSET_IS_TRANSPARENT(colorset))
+	{
+		if (CSET_IS_TRANSPARENT_PR_PURE(colorset))
+		{
+			XClearArea(dpy, CF.frame, 0,0,0,0, False);
+			if (do_draw)
+			{
+				RedrawFrame(NULL);
+			}
+		}
+		else if (!pr_only || CSET_IS_TRANSPARENT_PR(colorset))
+		{
+			SetWindowBackground(
+				dpy, CF.frame, CF.max_width, CF.total_height,
+				&Colorset[(colorset)], Pdepth,
+				root_item_ptr->header.dt_ptr->dt_GC, False);
+			if (do_draw)
+			{
+				XClearArea(dpy, CF.frame, 0,0,0,0, False);
+				RedrawFrame(NULL);
+			}
+		}
+	}
+	if (!root_item_ptr->header.next || !CSET_IS_TRANSPARENT(itemcolorset))
+	{
+		return;
+	}
+	for (item = root_item_ptr->header.next; item != NULL;
+	     item = item->header.next)
+	{
+		if (item->header.win != None)
+		{
+			if (CSET_IS_TRANSPARENT_PR(itemcolorset) &&
+			    !CSET_IS_TRANSPARENT(colorset))
+			{
+				continue;
+			}
+			if (CSET_IS_TRANSPARENT_PR_PURE(itemcolorset))
+			{
+				XClearArea(
+					dpy, item->header.win, 0,0,0,0, False);
+				if (do_draw)
+				{
+					RedrawItem(item, 0, NULL);
+				}
+			}
+			else if (!pr_only ||
+				 CSET_IS_TRANSPARENT_PR(itemcolorset))
+			{
+				SetWindowBackground(
+					dpy, item->header.win,
+					item->header.size_x, item->header.size_y,
+					&Colorset[(itemcolorset)], Pdepth,
+					item->header.dt_ptr->dt_GC, False);
+				XClearArea(
+					dpy, item->header.win, 0,0,0,0, False);
+				if (do_draw)
+				{
+					RedrawItem(item, 0, NULL);
+				}
+			}
+		}
+	}
+}
+
+/* execute a command */
+void DoCommand (Item *cmd)
+{
+  int k, dn;
+  char *sp;
+  Item *item;
+
+  /* pre-command */
+  if (cmd->button.key == IB_QUIT)
+  {
+    if (!XWithdrawWindow(dpy, CF.frame, screen))
+    {
+      /* hm, what can we do now? just ignore this situation. */
+    }
+  }
+
+  for (k = 0; k < cmd->button.n; k++) {
+    char *parsed_command;
+    /* construct command */
+    parsed_command = ParseCommand(0, cmd->button.commands[k], '\0', &dn, &sp);
+    myfprintf((stderr, "Final command[%d]: [%s]\n", k, parsed_command));
+
+    /* send command */
+    if ( parsed_command[0] == '!') {	/* If command starts with ! */
+      int n;
+
+      n = system(parsed_command+1);		/* Need synchronous execution */
+      (void)n;
+    } else {
+      SendText(Channel,parsed_command, ref);
+    }
+  }
+
+  /* post-command */
+  if (CF.last_error) {			/* if form has last_error field */
+    memset(CF.last_error->text.value, ' ', CF.last_error->text.n); /* clear */
+    /* To do this more elegantly, the window resize logic should recalculate
+       size_x for the Message as the window resizes.  Right now, just clear
+       a nice wide area. dje */
+    XClearArea(dpy,CF.frame,
+	       CF.last_error->header.pos_x,
+	       CF.last_error->header.pos_y,
+	       /* CF.last_error->header.size_x, */
+	       2000,
+	       CF.last_error->header.size_y, False);
+  } /* end form has last_error field */
+  if (cmd->button.key == IB_QUIT) {
+    if (CF.grab_server)
+      XUngrabServer(dpy);
+    /* This is a temporary bug workaround for the pipe drainage problem */
+    SendQuitNotification(Channel);    /* let commands complete */
+    /* Note how the window is withdrawn, but execution continues until
+       the quit notifcation catches up with this module...
+       Should not be a problem, there shouldn't be any more commands
+       coming into FvwmForm.  dje */
+  }
+  else if (cmd->button.key == IB_RESTART) {
+    Restart();
+    for (item = root_item_ptr; item != 0;
+	 item = item->header.next) {	/* all items */
+      if (item->type == I_INPUT) {
+	XClearWindow(dpy, item->header.win);
+	RedrawItem(item, 0, NULL);
+      }
+      if (item->type == I_CHOICE)
+	RedrawItem(item, 0, NULL);
+    }
+  }
+}
+
+/* open the windows */
+static void OpenWindows(void)
+{
+  int x, y;
+  int gravity = NorthWestGravity;
+  Item *item;
+  static XSetWindowAttributes xswa;
+  static XWMHints wmh = { InputHint, True };
+  static XSizeHints sh =
+    { PPosition | PSize | USPosition | USSize | PWinGravity};
+  XClassHint myclasshints;
+
+  if (!CF.pointer[input_pointer]) {
+    CF.pointer[input_pointer] = XCreateFontCursor(dpy, XC_xterm);
+  }
+  if (!CF.pointer[button_in_pointer]) {
+    CF.pointer[button_in_pointer] = XCreateFontCursor(dpy, XC_hand2);
+  }
+  if (!CF.pointer[button_pointer]) {
+    CF.pointer[button_pointer] = XCreateFontCursor(dpy,XC_hand2);
+  }
+  CF.screen_background = (colorset < 0)
+    ? GetColor(screen_background_color)
+    : Colorset[colorset].bg;
+
+  if (!CF.p_c[input_back].used) {  /* if not set, use screen b/g */
+    CF.p_c[input_back].pointer_color.pixel = CF.screen_background;
+  }
+  myfprintf((stderr,
+	     "screen bg %X, getcolor bg %X, colorset bg %X colorset %d\n",
+	     (int)CF.screen_background,
+	     (int)GetColor(screen_background_color),
+	     (int)Colorset[colorset].bg,
+	     (int)colorset));
+  XQueryColor(dpy, Pcmap, &CF.p_c[input_fore].pointer_color);
+  XQueryColor(dpy, Pcmap, &CF.p_c[input_back].pointer_color);
+  XRecolorCursor(dpy, CF.pointer[input_pointer],
+		 &CF.p_c[input_fore].pointer_color,
+		 &CF.p_c[input_back].pointer_color);
+  myfprintf((stderr,"input fore %X, back %X\n",
+	  (int)CF.p_c[input_fore].pointer_color.pixel,
+	  (int)CF.p_c[input_back].pointer_color.pixel));
+  /* The input cursor is handled differently than the 2 button cursors. */
+  XQueryColor(dpy, Pcmap, &CF.p_c[button_fore].pointer_color);
+  XQueryColor(dpy, Pcmap, &CF.p_c[button_back].pointer_color);
+  XRecolorCursor(dpy, CF.pointer[button_pointer],
+		 &CF.p_c[button_fore].pointer_color,
+		 &CF.p_c[button_back].pointer_color);
+  myfprintf((stderr,"button fore %X, back %X\n",
+	  (int)CF.p_c[button_fore].pointer_color.pixel,
+	  (int)CF.p_c[button_back].pointer_color.pixel));
+  XQueryColor(dpy, Pcmap, &CF.p_c[button_in_fore].pointer_color);
+  XQueryColor(dpy, Pcmap, &CF.p_c[button_in_back].pointer_color);
+  XRecolorCursor(dpy, CF.pointer[button_in_pointer],
+		 &CF.p_c[button_in_fore].pointer_color,
+		 &CF.p_c[button_in_back].pointer_color);
+  myfprintf((stderr,"button in fore %X, back %X\n",
+	  (int)CF.p_c[button_in_fore].pointer_color.pixel,
+	  (int)CF.p_c[button_in_back].pointer_color.pixel));
+  /* the frame window first */
+  if (CF.have_geom)
+  {
+    if (CF.xneg)
+    {
+      x = DisplayWidth(dpy, screen) - CF.max_width + CF.gx;
+      gravity = NorthEastGravity;
+    }
+    else
+    {
+      x = CF.gx;
+    }
+    if (CF.yneg)
+    {
+      y = DisplayHeight(dpy, screen) - CF.total_height + CF.gy;
+      gravity = SouthWestGravity;
+    }
+    else
+    {
+      y = CF.gy;
+    }
+    if (CF.xneg && CF.yneg)
+    {
+      gravity = SouthEastGravity;
+    }
+  } else {
+    FScreenCenterOnScreen(
+      NULL, FSCREEN_CURRENT, &x, &y, CF.max_width, CF.total_height);
+  }
+  /* hack to prevent mapping on wrong screen with StartsOnScreen */
+  FScreenMangleScreenIntoUSPosHints(FSCREEN_CURRENT, &sh);
+  xswa.background_pixel = CF.screen_background;
+  xswa.border_pixel = 0;
+  xswa.colormap = Pcmap;
+  myfprintf((stderr,
+	  "going to create window w. bg %s, b/g pixel %X, black pixel %X\n",
+	     screen_background_color,
+	     (int)xswa.background_pixel,
+	     (int)BlackPixel(dpy, screen)));
+  CF.frame = XCreateWindow(dpy, root, x, y, CF.max_width, CF.total_height, 0,
+			   Pdepth, InputOutput, Pvisual,
+			   CWColormap | CWBackPixel | CWBorderPixel, &xswa);
+  wm_del_win = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
+  XSetWMProtocols(dpy, CF.frame, &wm_del_win, 1);
+  XSelectInput(dpy, CF.frame,
+	       KeyPressMask | ExposureMask | StructureNotifyMask |
+	       VisibilityChangeMask);
+  if (!CF.title) {
+    CF.title = module->name;
+  }
+  XStoreName(dpy, CF.frame, CF.title);
+  XSetWMHints(dpy, CF.frame, &wmh);
+  myclasshints.res_name = module->name;
+  myclasshints.res_class = "FvwmForm";
+  XSetClassHint(dpy,CF.frame,&myclasshints);
+  sh.width = CF.max_width;
+  sh.height = CF.total_height;
+  sh.win_gravity = gravity;
+  XSetWMNormalHints(dpy, CF.frame, &sh);
+
+  for (item = root_item_ptr; item != 0;
+       item = item->header.next) {	/* all items */
+    switch (item->type) {
+    case I_INPUT:
+      myfprintf((stderr,"Checking alloc during OpenWindow on input\n"));
+      CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+      item->header.win =
+	XCreateSimpleWindow(dpy, CF.frame,
+			    item->header.pos_x, item->header.pos_y,
+			    item->header.size_x, item->header.size_y,
+			    0, CF.screen_background,
+			    item->header.dt_ptr->dt_colors[c_item_bg]);
+      XSelectInput(dpy, item->header.win, ButtonPressMask | ExposureMask);
+      xswa.cursor = CF.pointer[input_pointer];
+      XChangeWindowAttributes(dpy, item->header.win, CWCursor, &xswa);
+      if (itemcolorset >= 0)
+      {
+	SetWindowBackground(dpy, item->header.win,
+			    item->header.size_x, item->header.size_y,
+			    &Colorset[(itemcolorset)], Pdepth,
+			    item->header.dt_ptr->dt_GC, True);
+      }
+      break;
+    case I_CHOICE:
+      myfprintf((stderr,"Checking alloc during Openwindow on choice\n"));
+      CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+      item->header.win =
+	XCreateSimpleWindow(dpy, CF.frame,
+			    item->header.pos_x, item->header.pos_y,
+			    item->header.size_y, item->header.size_y,
+			    0, CF.screen_background,
+			    item->header.dt_ptr->dt_colors[c_item_bg]);
+      XSelectInput(dpy, item->header.win, ButtonPressMask | ExposureMask);
+      xswa.cursor = CF.pointer[button_pointer];
+      XChangeWindowAttributes(dpy, item->header.win, CWCursor, &xswa);
+      if (itemcolorset >= 0)
+      {
+	SetWindowBackground(dpy, item->header.win,
+			    item->header.size_x, item->header.size_y,
+			    &Colorset[(itemcolorset)], Pdepth,
+			    item->header.dt_ptr->dt_GC, True);
+      }
+      break;
+    case I_BUTTON:
+      myfprintf((stderr,"Checking alloc during Openwindow on button\n"));
+      CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+      item->header.win =
+	XCreateSimpleWindow(dpy, CF.frame,
+			    item->header.pos_x, item->header.pos_y,
+			    item->header.size_x, item->header.size_y,
+			    0, CF.screen_background,
+			    item->header.dt_ptr->dt_colors[c_item_bg]);
+      XSelectInput(dpy, item->header.win,
+		   ButtonPressMask | ExposureMask);
+      xswa.cursor = CF.pointer[button_pointer];
+      XChangeWindowAttributes(dpy, item->header.win, CWCursor, &xswa);
+      if (itemcolorset >= 0)
+      {
+	SetWindowBackground(dpy, item->header.win,
+			    item->header.size_x, item->header.size_y,
+			    &Colorset[(itemcolorset)], Pdepth,
+			    item->header.dt_ptr->dt_GC, True);
+      }
+      break;
+    case I_SEPARATOR:
+      myfprintf((stderr,"Checking alloc during OpenWindow on separator\n"));
+      CheckAlloc(item,item->header.dt_ptr); /* alloc colors and fonts needed */
+      item->header.size_x = CF.max_width - 6;
+      myfprintf((stderr,"Create win %d/%d %d/%d\n",3,item->header.pos_y,
+			    item->header.size_x, 2));
+      item->header.win =
+	XCreateSimpleWindow(dpy, CF.frame,
+			    3, item->header.pos_y,
+			    item->header.size_x, 2,
+			    0, CF.screen_background,
+			    item->header.dt_ptr->dt_colors[c_bg]);
+      XSelectInput(dpy, item->header.win, ExposureMask);
+      if (itemcolorset >= 0)
+      {
+	SetWindowBackground(dpy, item->header.win,
+			    item->header.size_x, 2,
+			    &Colorset[(itemcolorset)], Pdepth,
+			    item->header.dt_ptr->dt_GC, True);
+      }
+      break;
+    }
+  }
+  Restart();
+  if (colorset >= 0)
+  {
+    CheckAlloc(root_item_ptr,root_item_ptr->header.dt_ptr);
+    SetWindowBackground(dpy, CF.frame, CF.max_width, CF.total_height,
+			&Colorset[(colorset)], Pdepth,
+			root_item_ptr->header.dt_ptr->dt_GC, True);
+  }
+  if (preload_yorn != 'y') {		/* if not a preload */
+    XMapRaised(dpy, CF.frame);
+    XMapSubwindows(dpy, CF.frame);
+    if (CF.warp_pointer) {
+      FWarpPointer(dpy, None, CF.frame, 0, 0, 0, 0,
+		   CF.max_width / 2, CF.total_height - 1);
+    }
+  }
+  DoCommand(&CF.def_button);
+}
+
+static void process_message(unsigned long, unsigned long *); /* proto */
+static void ParseActiveMessage(char *); /* proto */
+
+/* read something from Fvwm */
+static void ReadFvwm(void)
+{
+
+    FvwmPacket* packet = ReadFvwmPacket(Channel[1]);
+    if ( packet == NULL )
+	exit(0);
+    else
+	process_message( packet->type, packet->body );
+}
+static void process_message(unsigned long type, unsigned long *body)
+{
+  switch (type) {
+  case M_CONFIG_INFO:			/* any module config command */
+    myfprintf((stderr,"process_message: Got command: %s\n", (char *)&body[3]));
+    ParseActiveMessage((char *)&body[3]);
+    break;
+  case MX_PROPERTY_CHANGE:
+    if (body[0] == MX_PROPERTY_CHANGE_BACKGROUND &&
+	((!Swallowed && body[2] == 0) || (Swallowed && body[2] == CF.frame)))
+    {
+      UpdateRootTransapency(True, True);
+    }
+    else if  (body[0] == MX_PROPERTY_CHANGE_SWALLOW && body[2] == CF.frame)
+    {
+	Swallowed = body[1];
+    }
+    break;
+  case M_ERROR:
+  case M_STRING:
+    if (CF.last_error) {		/* if form has message area */
+      /* ignore form size, its OK to write outside the window boundary */
+      int msg_len;
+      char *msg_ptr;
+      /* Clear old message first */
+      memset(CF.last_error->text.value, ' ', CF.last_error->text.n); /* clear */
+      XClearArea(dpy,CF.frame,
+		 CF.last_error->header.pos_x,
+		 CF.last_error->header.pos_y,
+		 2000,
+		 CF.last_error->header.size_y, False);
+      msg_ptr = (char *)&body[3];
+      msg_len = strlen(msg_ptr);
+      if (msg_ptr[msg_len-1] == '\n') { /* line ends w newline */
+	msg_ptr[msg_len-1] = '\0'; /* strip off \n */
+      }
+      if (CF.last_error->text.n <= msg_len) { /* if message wont fit */
+	CF.last_error->text.value = fxrealloc(CF.last_error->text.value,
+                                             msg_len * 2,
+					     sizeof(CF.last_error->text.value));
+	CF.last_error->text.n = msg_len * 2;
+      }
+      strncpy(CF.last_error->text.value,msg_ptr,
+	      CF.last_error->text.n);
+      RedrawText(CF.last_error);
+      break;
+    } /* module has last_error field */
+  } /* end switch header */
+}
+
+/* These are the message from fvwm FvwmForm understands after form is
+   active. */
+static void am_Map(char *);
+static void am_UnMap(char *);
+static void am_Stop(char *);
+static struct CommandTable am_table[] =
+{
+  {"Map",am_Map},
+  {"Stop",am_Stop},
+  {"UnMap",am_UnMap}
+};
+
+/* This is similar to the other 2 "Parse" functions. */
+static void ParseActiveMessage(char *buf)
+{
+	char *p;
+	struct CommandTable *e;
+	if (buf[strlen(buf)-1] == '\n')
+	{     /* if line ends with newline */
+		buf[strlen(buf)-1] = '\0';  /* strip off \n */
+	}
+
+	if (strncasecmp(buf, "Colorset", 8) == 0)
+	{
+		Item *item;
+		int n = LoadColorset(&buf[8]);
+		if(n == colorset || n == itemcolorset)
+		{
+			for (item = root_item_ptr; item != 0;
+			     item = item->header.next)
+			{
+				DrawTable *dt_ptr = item->header.dt_ptr;
+				if (dt_ptr)
+				{
+					dt_ptr->dt_used = 0;
+					if(dt_ptr->dt_GC)
+					{
+						XFreeGC(dpy, dt_ptr->dt_GC);
+						dt_ptr->dt_GC = None;
+					}
+					if(dt_ptr->dt_item_GC)
+					{
+						XFreeGC(
+							dpy,
+							dt_ptr->dt_item_GC);
+						dt_ptr->dt_item_GC = None;
+					}
+				}
+			}
+			for (item = root_item_ptr; item != 0;
+			     item = item->header.next)
+			{
+				DrawTable *dt_ptr = item->header.dt_ptr;
+				if (dt_ptr)
+				{
+					CheckAlloc(item, dt_ptr);
+				}
+			}
+			if (colorset >= 0)
+			{
+				SetWindowBackground(
+					dpy, CF.frame, CF.max_width,
+					CF.total_height,
+					&Colorset[(colorset)], Pdepth,
+					root_item_ptr->header.dt_ptr->dt_GC,
+					False);
+				RedrawFrame(NULL);
+			}
+			for (item = root_item_ptr->header.next; item != 0;
+			     item = item->header.next)
+			{
+				DrawTable *dt_ptr = item->header.dt_ptr;
+				if (dt_ptr && itemcolorset >= 0 &&
+				    item->header.win != 0)
+				{
+					SetWindowBackground(
+						dpy, item->header.win,
+						item->header.size_x,
+						item->header.size_y,
+						&Colorset[(itemcolorset)],
+						Pdepth, dt_ptr->dt_GC, True);
+					RedrawItem(item, 0, NULL);
+				} /* end item has a drawtable */
+			} /* end all items */
+		}
+		return;
+	} /* end colorset command */
+#if 0
+	if (strncasecmp(
+		buf, XINERAMA_CONFIG_STRING, sizeof(XINERAMA_CONFIG_STRING)-1)
+	    == 0)
+	{
+		FScreenConfigureModule(buf + sizeof(XINERAMA_CONFIG_STRING)-1);
+		return;
+	}
+#endif
+	if (
+		strncasecmp(
+			buf, CatString3("*",module->name,0),
+			module->namelen+1) != 0)
+	{
+		/* If its not for me */
+		return;
+	} /* Now I know its for me. */
+	p = buf+module->namelen+1;		    /* jump to end of my name */
+	/* at this point we have recognized "*FvwmForm" */
+	e = FindToken(p,am_table,struct CommandTable);/* find cmd in table */
+	if (e == 0)
+	{
+		/* if no match */
+		/* this may be a configuration command of another same form */
+		if (FindToken(p, ct_table, struct CommandTable) == 0)
+			fprintf(
+				stderr,"%s: Active command unknown: %s\n",
+				module->name,buf);
+		return;				    /* ignore it */
+	}
+
+	p=p+strlen(e->name);			/* skip over name */
+	while (isspace((unsigned char)*p)) p++; /* skip whitespace */
+
+	FormVarsCheck(&p);
+	e->function(p);			      /* call cmd processor */
+	return;
+} /* end function */
+
+static void am_Map(char *cp)
+{
+  XMapRaised(dpy, CF.frame);
+  XMapSubwindows(dpy, CF.frame);
+  if (CF.warp_pointer) {
+    FWarpPointer(dpy, None, CF.frame, 0, 0, 0, 0,
+		 CF.max_width / 2, CF.total_height - 1);
+  }
+  myfprintf((stderr, "Map: got it\n"));
+}
+static void am_UnMap(char *cp)
+{
+  XUnmapWindow(dpy, CF.frame);
+  myfprintf((stderr, "UnMap: got it\n"));
+}
+static void am_Stop(char *cp)
+{
+  /* syntax: *FFStop */
+  myfprintf((stderr,"Got stop command.\n"));
+  exit (0);				/* why bother, just exit. */
+}
+
+/* main event loop */
+static void MainLoop(void)
+{
+  fd_set fds;
+  fd_set_size_t fd_width = GetFdWidth();
+
+  while ( !isTerminated ) {
+    /* TA:  20091219:  Automatically flush the buffer from the XServer and
+     * process each request as we receive them.
+     */
+    while(FPending(dpy))
+	    ReadXServer();
+
+    FD_ZERO(&fds);
+    FD_SET(Channel[1], &fds);
+    FD_SET(fd_x, &fds);
+
+    /* TA:  20091219:  Using XFlush() here was always a nasty hack!  See
+     * comments above.
+     */
+    /*XFlush(dpy);*/
+    if (fvwmSelect(fd_width, &fds, NULL, NULL, NULL) > 0) {
+      if (FD_ISSET(Channel[1], &fds))
+	ReadFvwm();
+      if (FD_ISSET(fd_x, &fds))
+	ReadXServer();
+    }
+  }
+}
+
+
+/* signal-handler to make the application quit */
+static RETSIGTYPE
+TerminateHandler(int sig)
+{
+  fvwmSetTerminate(sig);
+  SIGNAL_RETURN;
+}
+
+/* signal-handler to make the timer work */
+static RETSIGTYPE
+TimerHandler(int sig)
+{
+  int dn;
+  char *sp;
+  char *parsed_command;
+
+  timer->timeout.timeleft--;
+  if (timer->timeout.timeleft <= 0) {
+    /* pre-command */
+    if (!XWithdrawWindow(dpy, CF.frame, screen))
+    {
+      /* hm, what can we do now? just ignore this situation. */
+    }
+
+    /* construct command */
+    parsed_command = ParseCommand(0, timer->timeout.command, '\0', &dn, &sp);
+    myfprintf((stderr, "Final command: %s\n", parsed_command));
+
+    /* send command */
+    if ( parsed_command[0] == '!') {	/* If command starts with ! */
+      int n;
+
+      n = system(parsed_command+1);		/* Need synchronous execution */
+      (void)n;
+    } else {
+      SendText(Channel,parsed_command, ref);
+    }
+
+    /* post-command */
+    if (CF.last_error) {		  /* if form has last_error field */
+      memset(CF.last_error->text.value, ' ', CF.last_error->text.n); /* clear */
+      /* To do this more elegantly, the window resize logic should recalculate
+	 size_x for the Message as the window resizes.	Right now, just clear
+	 a nice wide area. dje */
+      XClearArea(dpy,CF.frame,
+		 CF.last_error->header.pos_x,
+		 CF.last_error->header.pos_y,
+		 /* CF.last_error->header.size_x, */
+		 2000,
+		 CF.last_error->header.size_y, False);
+    } /* end form has last_error field */
+    if (CF.grab_server)
+      XUngrabServer(dpy);
+    /* This is a temporary bug workaround for the pipe drainage problem */
+    SendQuitNotification(Channel);    /* let commands complete */
+    /* Note how the window is withdrawn, but execution continues until
+       the quit notifcation catches up with this module...
+       Should not be a problem, there shouldn't be any more commands
+       coming into FvwmForm.  dje */
+  }
+  else {
+    RedrawTimeout(timer);
+    alarm(1);
+  }
+
+  SIGNAL_RETURN;
+}
+
+
+/* main procedure */
+int main (int argc, char **argv)
+{
+  int i;
+  char cmd[200];
+
+#ifdef DEBUGTOFILE
+  freopen(".FvwmFormDebug","w",stderr);
+#endif
+
+  FlocaleInit(LC_CTYPE, "", "", "FvwmForm");
+
+  module = ParseModuleArgs(argc,argv,1); /* allow an alias */
+  if (module == NULL)
+  {
+    fprintf(
+	    stderr,
+	    "FvwmForm Version "VERSION" should only be executed by fvwm!\n");
+    exit(1);
+  }
+
+#ifdef HAVE_SIGACTION
+  {
+    struct sigaction  sigact;
+
+#ifdef SA_INTERRUPT
+    sigact.sa_flags = SA_INTERRUPT;
+#else
+    sigact.sa_flags = 0;
+#endif
+    sigemptyset(&sigact.sa_mask);
+    sigaddset(&sigact.sa_mask, SIGTERM);
+    sigaddset(&sigact.sa_mask, SIGPIPE);
+    sigaddset(&sigact.sa_mask, SIGINT);
+    sigact.sa_handler = TerminateHandler;
+
+    sigaction(SIGPIPE, &sigact, NULL);
+    sigaction(SIGTERM, &sigact, NULL);
+    sigaction(SIGINT, &sigact, NULL);
+  }
+#else
+#ifdef USE_BSD_SIGNALS
+  fvwmSetSignalMask( sigmask(SIGPIPE) | sigmask(SIGTERM) | sigmask(SIGINT) );
+#endif
+  signal(SIGPIPE, TerminateHandler);  /* Dead pipe == Fvwm died */
+  signal(SIGTERM, TerminateHandler);
+  signal(SIGINT, TerminateHandler);
+#ifdef HAVE_SIGINTERRUPT
+  siginterrupt(SIGPIPE, 1);
+  siginterrupt(SIGTERM, 1);
+  siginterrupt(SIGINT, 1);
+#endif
+#endif
+
+  Channel[0] = module->to_fvwm;
+  Channel[1] = module->from_fvwm;
+
+  dpy = XOpenDisplay("");
+  if (dpy==NULL) {
+    fprintf(stderr,"%s: could not open display\n",module->name);
+    exit(1);
+  }
+  /* From FvwmAnimate end */
+
+  i = 7;
+  if (argc >= 8) {			/* if have arg 7 */
+    if (strcasecmp(argv[7],"preload") == 0) { /* if its preload */
+      preload_yorn = 'y';		/* remember that. */
+      i = 8;
+    }
+  }
+  for (;i<argc;i++) {			/* look at remaining args */
+    if (strchr(argv[i],'=')) {		/* if its a candidate */
+      putenv(argv[i]);			/* save it away */
+      CF.have_env_var = 'y';		/* remember we have at least one */
+    }
+  }
+  ref = strtol(argv[4], NULL, 16);	/* capture reference window */
+  if (ref == 0) ref = None;
+  myfprintf((stderr, "ref == %d\n", (int)ref));
+
+  flib_init_graphics(dpy);
+
+  fd_x = XConnectionNumber(dpy);
+
+  screen = DefaultScreen(dpy);
+  root = RootWindow(dpy, screen);
+
+  InitConstants();
+  ReadDefaults();			/* get config from fvwm */
+
+  if (strcasecmp(module->name,"FvwmForm") != 0) { /* if not already read */
+    sprintf(cmd,"read %s Quiet",module->name); /* read quiet modules config */
+    SendText(Channel,cmd,0);
+  }
+
+  ReadConfig();				/* get config from fvwm */
+
+  MassageConfig();			/* add data, calc window x/y */
+
+  /* tell fvwm about our mask */
+  SetMessageMask(Channel, M_SENDCONFIG|M_CONFIG_INFO|M_ERROR|M_STRING);
+  SetMessageMask(Channel, MX_PROPERTY_CHANGE);
+  XSetErrorHandler(ErrorHandler);
+  OpenWindows();			/* create initial window */
+  SendFinishedStartupNotification(Channel);/* tell fvwm we're running */
+  if (timer != NULL) {
+     SetupTimer();
+  }
+  MainLoop();				/* start */
+
+  return 0;				/* */
+}
+
+
+RETSIGTYPE DeadPipe(int nonsense)
+{
+  exit(0);
+  SIGNAL_RETURN;
+}
+
+/*
+  X Error Handler
+*/
+static int
+ErrorHandler(Display *dpy, XErrorEvent *event)
+{
+  /* some errors are OK=ish */
+  if (event->error_code == BadPixmap)
+    return 0;
+  if (event->error_code == BadDrawable)
+    return 0;
+  if (FRenderGetErrorCodeBase() + FRenderBadPicture == event->error_code)
+    return 0;
+
+  PrintXErrorAndCoredump(dpy, event, module->name);
+  return 0;
+}
+/*  Local Variables: */
+/*  c-basic-offset: 8 */
+/*  indent-tabs-mode: t */
+/*  End: */

--- a/modules/FvwmForm/FvwmForm.h
+++ b/modules/FvwmForm/FvwmForm.h
@@ -1,0 +1,269 @@
+/* -*-c-*- */
+#ifndef FVWMFORM_H
+#define FVWMFORM_H
+
+/*  Modification History
+
+ Created 12/20/98 Dan Espen:
+
+ - FvwmForm.c got too big for my home machine to deal with.
+
+ */
+
+#include "libs/Flocale.h"               /* for font definition stuff */
+/*
+ * This next stuff should be more specific and customizable.
+ * For example padVText (above) was one of the things TXT_SPC
+ * controlled. (dje)
+ */
+#define TEXT_SPC    3
+/* This one, box_spc would have to be saved as part of an "item".
+   It's used for input boxes, buttons, and I think, choices.
+   dje */
+#define BOX_SPC     3
+/* Item_hspc is only used during the "massage phase"
+   has to be saved in items. */
+#define ITEM_HSPC   10
+#define ITEM_VSPC   5
+
+/* Control the areas that are realloced in chunks: */
+#define ITEMS_PER_EXPANSION 32
+#define CHOICES_PER_SEL_EXPANSION 8
+#define BUTTON_COMMAND_EXPANSION 8
+#define TIMEOUT_COMMAND_EXPANSION 8
+
+#define I_TEXT          1
+#define I_INPUT         2
+#define I_SELECT        3
+#define I_CHOICE        4
+#define I_BUTTON        5
+#define I_TIMEOUT       6
+#define I_SEPARATOR     7
+
+#define IS_SINGLE       1
+#define IS_MULTIPLE     2
+
+#define IB_CONTINUE     1
+#define IB_RESTART      2
+#define IB_QUIT         3
+
+/* There is a "drawtable" for each item drawn in a form */
+typedef struct _drawtable {
+  struct _drawtable *dt_next;           /* link list, circle */
+  char *dt_font_name;                   /* font name */
+  char *dt_color_names[4];
+  int dt_used;                          /* 1=used as text, 2 used as item */
+  unsigned long dt_colors[6];             /* text fore/back
+					   button/choice/input fore/back
+					   hilite and shadow (item only)
+					   Note, need all 6 because choices
+					   use them all */
+  GC dt_GC;                             /* graphic ctx used for text */
+  GC dt_item_GC;                        /* graphic ctx used for graphics */
+  FlocaleFont *dt_Ffont;                /* Fvwm font structure */
+  FlocaleWinString *dt_Fstr;            /* Fvwm string (handles multibyte) */
+} DrawTable;
+
+/* An "item" is something in a form. Part of the structure is common
+   for all item types, the rest of the structure is a union. */
+typedef union _item {
+  int type;                /* item type, one of I_TEXT .. I_BUTTON */
+  struct _head {           /* common header */
+    int type;
+    union _item *next;                  /* for all items linklist */
+    int win;               /* X window id */
+    char *name;            /* identifier name */
+    int size_x, size_y;    /* size of bounding box */
+    int pos_x, pos_y;      /* position of top-left corner */
+    DrawTable *dt_ptr;                  /* only used for items that need it */
+  } header;
+
+  struct {                 /* I_TEXT */
+    struct _head head;
+    int n;                 /* string length */
+    char *value;           /* string to display */
+    unsigned long color;                /* color of text */
+  } text;
+
+  struct {                 /* I_INPUT */
+    struct _head head;
+    int buf;               /* input string buffer */
+    int n;                 /* string length */
+    char *value;           /* input string */
+    char *init_value;      /* default string */
+    char *blanks;          /* blank string */
+    int size;              /* input field size */
+    int left;              /* position of the left-most displayed char */
+    union _item *next_input;            /* a ring of input fields */
+    union _item *prev_input;            /* for tabbing */
+    int value_history_count;            /* count of input history */
+    int value_history_yankat;           /* yank point between restarts */
+    char **value_history_ptr;           /* curr insertion point */
+  } input;
+  struct {                 /* I_SELECT */
+    struct _head head;
+    int key;               /* one of IS_MULTIPLE, IS_SINGLE */
+    int n;                 /* number of choices */
+    int choices_array_count;             /* current choices array size */
+    union _item **choices; /* list of choices */
+  } selection;
+  struct {                 /* I_CHOICE */
+    struct _head head;
+    int on;                /* selected or not */
+    int init_on;           /* initially selected or not */
+    char *value;           /* value if selected */
+    int n;                 /* text string length */
+    char *text;            /* text string */
+    union _item *sel;      /* selection it belongs to */
+  } choice;
+  struct {                 /* I_BUTTON */
+    struct _head head;
+    int key;               /* one of IB_CONTINUE, IB_RESTART, IB_QUIT */
+    int n;                 /* # of commands */
+    int len;               /* text length */
+    char *text;            /* text string */
+    int keypress;          /* short cut */
+    int button_array_size;              /* current size of next array */
+    char **commands;    /* Fvwm command to execute */
+  } button;
+  struct {              /* I_TIMEOUT */
+    struct _head head;
+    int timeleft;       /* seconds left on timer */
+    int len;            /* text length */
+    char *text;         /* text string */
+    char *command;    /* Fvwm command(s) to execute */
+  } timeout;
+  struct {              /* I_SEPARATOR */
+    struct _head head;
+  } separator;
+} Item;
+
+#define L_LEFT        1
+#define L_RIGHT       2
+#define L_CENTER      3
+#define L_LEFTRIGHT   4
+#define MICRO_S_FOR_10MS 10000
+#define VH_SIZE 50                      /* size of value history */
+
+/* There is one "line" structure for each line in the form.
+   "Lines" point at an array of "items". */
+typedef struct _line {
+  struct _line *next;                   /* Pointer to next line */
+  int n;                                /* number of items on the line */
+  int justify;                          /* justification */
+  int size_x, size_y;                   /* size of bounding rectangle */
+  int item_array_size;                  /* track size */
+  Item **items;                         /* ptr to array of items */
+} Line;
+
+/* Need a struct for the pointer color.
+   Since colors are unsigned, we need a flag to indicate whether
+   the color was ever set. */
+typedef struct _ptrc {
+  XColor pointer_color;
+  char used;
+} Ptr_color;
+
+/* There is one "form". Start of attempt to change that. */
+typedef struct _form {
+#if 0
+  struct _form *next;                   /* dje hmm. a linklist of forms? */
+#endif
+  Item def_button;
+  int grab_server;                      /* set during parse used on display */
+  int server_grabbed;                   /* first time switch */
+  int gx, gy, have_geom;
+  int xneg, yneg;
+  int warp_pointer;
+  int max_width, total_height;          /* frame size */
+  unsigned long screen_background;
+  Item *cur_input;                      /* current input during parse and run */
+  Item *first_input;                    /* forms first input item during parse*/
+  Item *last_error;                     /* fvwm error message display area */
+  DrawTable *roots_dt;                  /* root draw tables linklist */
+  int abs_cursor;
+  int rel_cursor;
+  Window frame;
+  int padVText;                         /* vert space for text item */
+  char *leading;                        /* part of command to match for data */
+  char *file_to_read;                   /* file to read for data */
+  char *title;                          /* form title, NULL, use alias */
+  char *expand_buffer;                  /* buffer to expand commands in */
+  int expand_buffer_size;               /* current size */
+  char have_env_var;                    /* at least one env var on cmd line */
+  Cursor pointer[3];
+  Ptr_color p_c[6];                     /* fg/bg for pointers, used flag */
+  int activate_on_press;                /* activate button on press */
+} Form;
+
+enum {input_pointer,button_pointer,button_in_pointer};
+enum {input_fore,input_back,
+      button_fore,button_back,
+      button_in_fore,button_in_back};
+
+extern Form cur_form;                   /* current form */
+#define CF cur_form                     /* I may want to undo this... */
+
+  /* Globals: */
+
+/* Link list roots */
+extern Item *root_item_ptr;             /* pointer to root of item list */
+extern Line root_line;
+extern Line *cur_line;
+extern char preload_yorn;
+extern Item *item;                             /* current during parse */
+extern Item *cur_sel, *cur_button;             /* current during parse */
+extern Display *dpy;
+extern Atom wm_del_win;
+extern int fd_x;                  /* fd for X connection */
+extern Window root, ref;
+extern int screen;
+
+enum { c_bg, c_fg, c_item_bg, c_item_fg, c_itemlo, c_itemhi };
+extern char *color_names[4];
+extern char bg_state;
+extern char endDefaultsRead;
+enum { f_text, f_input, f_button, f_timeout };
+extern char *font_names[4];
+extern char *screen_background_color;
+
+extern int colorset;
+extern int itemcolorset;
+
+/* From FvwmAnimate start */
+extern char *MyName;
+extern int MyNameLen;
+/* here is the old double parens trick. */
+/* #define DEBUG */
+#ifdef DEBUG
+#define myfprintf(X) \
+  fprintf X;\
+  fflush (stderr);
+#else
+#define myfprintf(X)
+#endif
+
+#define tempmyfprintf(X) \
+  fprintf X;\
+  fflush (stderr);
+
+extern int Channel[2];
+
+/* From FvwmAnimate end */
+
+/* prototypes */
+void ReadXServer(void);                  /* ReadXServer.c */
+void RedrawText(Item *item);             /* FvwmForm.c */
+void RedrawTimeout(Item *item);          /* FvwmForm.c */
+void RedrawItem (
+	Item *item, int click, XEvent *pev); /* FvwmForm.c */
+void UpdateRootTransapency(
+	Bool pr_only, Bool do_draw);     /* FvwmForm.c */
+void DoCommand (Item *cmd);              /* FvwmForm.c */
+int FontWidth (XFontStruct *xfs);        /* FvwmForm.c */
+void RedrawFrame (XEvent *pev);          /* FvwmForm.c */
+char * ParseCommand (int, char *, char, int *, char **s); /* ParseCommand.c */
+
+RETSIGTYPE DeadPipe(int nonsense);            /* FvwmForm.c */
+
+#endif

--- a/modules/FvwmForm/Makefile.am
+++ b/modules/FvwmForm/Makefile.am
@@ -1,0 +1,59 @@
+## Process this file with automake to create Makefile.in
+
+program_transform_name =
+
+moduledir = @FVWM_MODULEDIR@
+configdir = @FVWM_DATADIR@
+
+module_PROGRAMS = FvwmForm
+man_MANS = FvwmForm.1
+
+## FvwmTalk was made obsolete in March 1999.
+## This provides compatibility.
+module_SCRIPTS = FvwmTalk
+
+FvwmTalk: ../../config.h Makefile
+	echo "#!/bin/sh" > $@
+	echo exec ${moduledir}/FvwmForm '$$@' FvwmForm-Talk>> $@
+
+## NB: Neither _MANS nor _DATA are included by default in
+## distributions!
+EXTRA_DIST = $(man_MANS) Changes \
+  FvwmForm-Form           \
+  FvwmForm-Capture        \
+  FvwmForm-Desktop        \
+  FvwmForm-QuitVerify     \
+  FvwmForm-Rlogin         \
+  FvwmForm-RootCursor     \
+  FvwmForm-Talk           \
+  FvwmForm-TalkHelp       \
+  FvwmForm-XDGOptionsHelp \
+  FvwmForm-XDGMenuHelp
+
+FvwmForm_SOURCES = FvwmForm.c FvwmForm.h ReadXServer.c ParseCommand.c
+
+FvwmForm_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
+
+config_DATA =             \
+  FvwmForm-Form           \
+  FvwmForm-Capture        \
+  FvwmForm-Desktop        \
+  FvwmForm-QuitVerify     \
+  FvwmForm-Rlogin         \
+  FvwmForm-RootCursor     \
+  FvwmForm-Talk           \
+  FvwmForm-TalkHelp       \
+  FvwmForm-XDGOptionsHelp \
+  FvwmForm-XDGMenuHelp
+
+## Xpm note: while this module may not depend on Xpm explicitly,
+## there are sometimes dependencies through functions in libfvwm
+## so we might as well link against libXpm, if present.
+LDADD = -L$(top_builddir)/libs -lfvwm3 $(Xft_LIBS) $(X_LIBS)  \
+	$(X_PRE_LIBS) $(XRandR_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) \
+	-lm $(Xrender_LIBS) $(rsvg_LIBS) $(iconv_LIBS) $(Bidi_LIBS)
+
+AM_CPPFLAGS = -I$(top_srcdir) $(Xft_CFLAGS) $(X_CFLAGS) $(iconv_CFLAGS) \
+	$(Bidi_CFLAGS) $(Xrender_CFLAGS)
+
+CLEANFILES = $(module_SCRIPTS)

--- a/modules/FvwmForm/ParseCommand.c
+++ b/modules/FvwmForm/ParseCommand.c
@@ -1,0 +1,147 @@
+/* -*-c-*- */
+/*
+ * ParseComand.c was originally part of FvwmForm.c.
+ *
+ * Turned into separate file 02/27/99, Dan Espen.
+ *
+ * FvwmForm is original work of Thomas Zuwei Feng.
+ *
+ * Copyright Feb 1995, Thomas Zuwei Feng.  No guarantees or warantees are
+ * provided or implied in any way whatsoever.  Use this program at your own
+ * risk.  Permission to use, modify, and redistribute this program is hereby
+ * given, provided that this copyright is kept intact.
+ */
+
+/* This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>
+ */
+
+#include "config.h"
+#include "libs/fvwmlib.h"
+#include <stdio.h>
+#include <ctype.h>
+#include <sys/types.h>
+#include <FvwmForm.h>                   /* common FvwmForm stuff */
+
+static char *buf;
+static int N = 8;
+
+/* Macro used in following functions */
+#define AddChar(chr) \
+ { if (dn >= N) {\
+     N *= 2;\
+     buf = fxrealloc(buf, N, sizeof(buf));\
+   }\
+   buf[dn++] = (chr);\
+ }
+
+/* do var substitution for command string */
+char * ParseCommand (int dn, char *sp, char end, int *dn1, char **sp1)
+{
+  static char var[256];
+  char c, x, *cp, *vp;
+  int j, dn2;
+  int added_sel;
+  Item *item;
+
+  if (buf == 0) {                       /* if no buffer yet */
+    buf = (char *)malloc(N);
+  }
+  while (1) {
+    c = *(sp++);
+    if (c == '\0' || c == end) {  /* end of substitution */
+      *dn1 = dn;
+      *sp1 = sp;
+      if (end == 0) {                   /* if end of command reached */
+	AddChar('\0');                  /* make sure theres a null */
+      }
+      return(buf);
+    }
+    if (c == '$') {  /* variable */
+      if (*sp != '(')
+	goto normal_char;
+      ++sp;
+      vp = var;
+      while (1) {
+	x = *(sp++);
+	if (x == '\\') {
+	  *(vp++) = '\\';
+	  *(vp++) = *(sp++);
+	}
+	else if (x == ')' || x == '?' || x == '!') {
+	  *(vp++) = '\0';
+	  break;
+	}
+	else if (!isspace(x))
+	  *(vp++) = x;
+      }
+      for (item = root_item_ptr; item != 0;
+	   item = item->header.next) {/* all items */
+	if (strcmp(var, item->header.name) == 0) {
+	  switch (item->type) {
+	  case I_INPUT:
+	    if (x == ')') {
+	      for (cp = item->input.value; *cp != '\0'; cp++) {
+		AddChar(*cp);
+	      }
+	    } else {
+	      ParseCommand(dn, sp, ')', &dn2, &sp);
+	      if ((x == '?' && strlen(item->input.value) > 0) ||
+		  (x == '!' && strlen(item->input.value) == 0))
+		dn = dn2;
+	    }
+	    break;
+	  case I_CHOICE:
+	    if (x == ')') {
+	      for (cp = item->choice.value; *cp != '\0'; cp++)
+		AddChar(*cp);
+	    } else {
+	      ParseCommand(dn, sp, ')', &dn2, &sp);
+	      if ((x == '?' && item->choice.on) ||
+		  (x == '!' && !item->choice.on))
+		dn = dn2;
+	    }
+	    break;
+	  case I_SELECT:
+	    if (x != ')')
+	      ParseCommand(dn, sp, ')', &dn2, &sp);
+	    added_sel=0;
+	    for (j = 0; j < item->selection.n; j++) {
+	      if (item->selection.choices[j]->choice.on) {
+		if (added_sel) {        /* if not first sel added */
+		  AddChar(' ');         /* insert space before next value */
+		}
+		added_sel=1;
+		for (cp = item->selection.choices[j]->choice.value;
+		     *cp != '\0'; cp++) {
+		  AddChar(*cp);
+		}
+	      }
+	    }
+	    break;
+	  }
+	  goto next_loop;
+	}
+      }
+      goto next_loop;
+    } /* end char is $, not followed by ( */
+    /* if char is \, followed by ), want to pass thru the paren literally */
+    if (c == '\\' && *sp == ')') {
+      c = *(sp++);                      /* skip to the paren */
+    }
+  normal_char:
+    AddChar(c);
+  next_loop:
+      ;
+  }
+}

--- a/modules/FvwmForm/ReadXServer.c
+++ b/modules/FvwmForm/ReadXServer.c
@@ -1,0 +1,766 @@
+/* -*-c-*- */
+/*
+ * This file  is  partly derived from   FvwmForm.c, this is  the original
+ * copyright:
+ *
+ * FvwmForm is original work of Thomas Zuwei Feng.
+ *
+ * Copyright Feb 1995, Thomas Zuwei Feng.  No guarantees or warantees are
+ * provided or implied in any way whatsoever.  Use this program at your own
+ * risk.  Permission to use, modify, and redistribute this program is hereby
+ * given, provided that this copyright is kept intact.
+ *
+ * And the same goes for me, Dan Espen, March 10, 1999.
+ */
+
+/* This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see: <http://www.gnu.org/licenses/>
+ */
+
+/*  Modification History */
+
+/*  Changed on 03/19/99 by DanEspen (dje): */
+/*  - paste tab as space if there is one input field. */
+
+/*  Changed on 03/10/99 by DanEspen (dje): */
+/*  - Make button 2 paste work. */
+
+/*  Changed on 02/27/99 by DanEspen (dje): */
+/*  - Add logic to allow international characters, bug id 179 */
+/*  - Split into separate file. */
+
+#include "config.h"
+#include "libs/fvwmlib.h"
+#include "libs/Colorset.h"
+
+#include <stdio.h>
+#include <ctype.h>
+
+#include <X11/Xlib.h>
+#include <X11/X.h>
+#include <X11/Xutil.h>
+#include <X11/cursorfont.h>
+#define XK_MISCELLANY
+#include <X11/keysymdef.h>
+#include <X11/Xatom.h>                  /* for XA_CUT_BUFFER0 */
+
+#include <FvwmForm.h>
+
+static void process_regular_char_input(unsigned char *buf);
+static int process_tabtypes(unsigned char * buf);
+static void process_history(int direction);
+static void process_paste_request (XEvent *event, Item *item);
+static void ToggleChoice (Item *item);
+static void ResizeFrame (void);
+
+/* read an X event */
+void ReadXServer (void)
+{
+  static XEvent event;
+  int keypress;
+  Item *item, *old_item;
+  KeySym ks;
+  char *sp, *dp;
+  static unsigned char buf[10];         /* unsigned for international */
+  static int n;
+
+  while (FEventsQueued(dpy, QueuedAfterReading)) {
+    FNextEvent(dpy, &event);
+    if (event.xany.window == CF.frame) {
+      switch (event.type) {
+      case ClientMessage:
+      {
+	      if(event.xclient.format == 32 &&
+		 event.xclient.data.l[0] == wm_del_win)
+	      {
+		      exit(0);
+	      }
+      }
+      break;
+      case ConfigureNotify:             /* has window be reconfigured */
+      {
+	      XEvent tmpe;
+
+	      fev_sanitise_configure_notify(&event.xconfigure);
+	      while (FCheckTypedWindowEvent(
+		      dpy, CF.frame, ConfigureNotify, &tmpe))
+	      {
+		      fev_sanitise_configure_notify(&tmpe.xconfigure);
+		      if (!tmpe.xconfigure.send_event)
+			      continue;
+		      event.xconfigure.x = tmpe.xconfigure.x;
+		      event.xconfigure.y = tmpe.xconfigure.y;
+		      event.xconfigure.send_event = True;
+	      }
+	      if (CF.max_width != event.xconfigure.width ||
+		  CF.total_height != event.xconfigure.height)
+	      {
+		      /* adjust yourself... do noting */
+		      ResizeFrame();
+		      CF.max_width = event.xconfigure.width;
+		      CF.total_height = event.xconfigure.height;
+		      UpdateRootTransapency(False, True);
+		      if (!CSET_IS_TRANSPARENT(colorset))
+		      {
+			  RedrawFrame(NULL);
+		      }
+	      }
+	      else if (event.xconfigure.send_event)
+	      {
+		      UpdateRootTransapency(False, True);
+	      }
+      }
+      break;
+#if 0
+      case SelectionClear:
+	 selection_clear ();
+	break;
+      case SelectionNotify:
+	selection_paste ();
+	break;
+      case SelectionRequest:
+	 selection_send ();
+	break;
+#endif
+      case Expose:
+      {
+	      int ex = event.xexpose.x;
+	      int ey = event.xexpose.y;
+	      int ex2 = event.xexpose.x + event.xexpose.width;
+	      int ey2 = event.xexpose.y + event.xexpose.height;
+	      while (FCheckTypedWindowEvent(dpy, CF.frame, Expose, &event))
+	      {
+		      ex = min(ex, event.xexpose.x);
+		      ey = min(ey, event.xexpose.y);
+		      ex2 = max(ex2, event.xexpose.x + event.xexpose.width);
+		      ey2 = max(ey2 , event.xexpose.y + event.xexpose.height);
+	      }
+	      event.xexpose.x = ex;
+	      event.xexpose.y = ey;
+	      event.xexpose.width = ex2 - ex;
+	      event.xexpose.height = ey2 - ey;
+	      RedrawFrame(&event);
+	      if (CF.grab_server && !CF.server_grabbed)
+	      {
+		      if (GrabSuccess ==
+			  XGrabPointer(dpy, CF.frame, True, 0,
+				       GrabModeAsync, GrabModeAsync,
+				       None, None, CurrentTime))
+			      CF.server_grabbed = 1;
+	      }
+      }
+      break;
+      case VisibilityNotify:
+	if (CF.server_grabbed &&
+	    event.xvisibility.state != VisibilityUnobscured)
+	{
+	  /* raise our window to the top */
+	  XRaiseWindow(dpy, CF.frame);
+	  XSync(dpy, 0);
+	}
+	break;
+      case KeyPress:  /* we do text input here */
+	n = XLookupString(&event.xkey, (char *)buf, sizeof(buf), &ks, NULL);
+	keypress = buf[0];
+	myfprintf((stderr, "Keypress [%s]\n", buf));
+	if (n == 0) {  /* not a regular key, translate it into one */
+	  switch (ks) {
+	  case XK_Home:
+	  case XK_Begin:
+	    buf[0] = '\001';  /* ^A */
+	    break;
+	  case XK_End:
+	    buf[0] = '\005';  /* ^E */
+	    break;
+	  case XK_Left:
+	    buf[0] = '\002';  /* ^B */
+	    break;
+	  case XK_Right:
+	    buf[0] = '\006';  /* ^F */
+	    break;
+	  case XK_Up:
+	    buf[0] = '\020';            /* ^P */
+	    break;
+	  case XK_Down:
+	    buf[0] = '\016';  /* ^N */
+	    break;
+	  default:
+	    if (ks >= XK_F1 && ks <= XK_F35) {
+	      buf[0] = '\0';
+	      keypress = 257 + ks - XK_F1;
+	    } else
+	      goto no_redraw;  /* no action for this event */
+	  }
+	}
+	switch (ks) {                   /* regular key, may need adjustment */
+	case XK_Tab:
+#ifdef XK_XKB_KEYS
+	case XK_ISO_Left_Tab:
+#endif
+	  if (event.xkey.state & ShiftMask) { /* shifted key */
+	    buf[0] = '\020';          /* chg shift tab to ^P */
+	  }
+	  break;
+	case '>':
+	  if (event.xkey.state & Mod1Mask) { /* Meta, shift > */
+	    process_history(1);
+	    goto redraw_newcursor;
+	  }
+	  break;
+	case '<':
+	  if (event.xkey.state & Mod1Mask) { /* Meta, shift < */
+	    process_history(-1);
+	    goto redraw_newcursor;
+	  }
+	  break;
+	}
+	if (!CF.cur_input) {  /* no text input fields */
+	  for (item = root_item_ptr; item != 0;
+	       item = item->header.next) {/* all items */
+	    if (item->type == I_BUTTON && item->button.keypress == keypress) {
+	      RedrawItem(item, 1, NULL);
+	      usleep(MICRO_S_FOR_10MS);
+	      RedrawItem(item, 0, NULL);
+	      DoCommand(item);
+	      goto no_redraw;
+	    }
+	  }
+	  break;
+	} else if (CF.cur_input == CF.cur_input->input.next_input) {
+	  /* 1 ip field */
+	  switch (buf[0]) {
+	  case '\020':                  /* ^P previous field */
+	    process_history(-1);
+	    goto redraw_newcursor;
+	    break;
+	  case '\016':                  /* ^N  next field */
+	    process_history(1);
+	    goto redraw_newcursor;
+	    break;
+	  } /* end switch */
+	} /* end one input field */
+	switch (buf[0]) {
+	case '\001':  /* ^A */
+	  CF.rel_cursor = 0;
+	  CF.abs_cursor = 0;
+	  CF.cur_input->input.left = 0;
+	  goto redraw_newcursor;
+	  break;
+	case '\005':  /* ^E */
+	  CF.rel_cursor = CF.cur_input->input.n;
+	  if ((CF.cur_input->input.left =
+	       CF.rel_cursor - CF.cur_input->input.size) < 0)
+	    CF.cur_input->input.left = 0;
+	  CF.abs_cursor = CF.rel_cursor - CF.cur_input->input.left;
+	  goto redraw_newcursor;
+	  break;
+	case '\002':  /* ^B */
+	  if (CF.rel_cursor > 0) {
+	    CF.rel_cursor--;
+	    CF.abs_cursor--;
+	    if (CF.abs_cursor <= 0 && CF.rel_cursor > 0) {
+	      CF.abs_cursor++;
+	      CF.cur_input->input.left--;
+	    }
+	  }
+	  goto redraw_newcursor;
+	  break;
+	case '\006':  /* ^F */
+	  if (CF.rel_cursor < CF.cur_input->input.n) {
+	    CF.rel_cursor++;
+	    CF.abs_cursor++;
+	    if (CF.abs_cursor >= CF.cur_input->input.size &&
+		CF.rel_cursor < CF.cur_input->input.n) {
+	      CF.abs_cursor--;
+	      CF.cur_input->input.left++;
+	    }
+	  }
+	  goto redraw_newcursor;
+	  break;
+	case '\010':  /* ^H */
+	  if (CF.rel_cursor > 0) {
+	    sp = CF.cur_input->input.value + CF.rel_cursor;
+	    dp = sp - 1;
+	    for (; *dp = *sp, *sp != '\0'; dp++, sp++);
+	    CF.cur_input->input.n--;
+	    CF.rel_cursor--;
+	    if (CF.rel_cursor < CF.abs_cursor) {
+	      CF.abs_cursor--;
+	      if (CF.abs_cursor <= 0 && CF.rel_cursor > 0) {
+		CF.abs_cursor++;
+		CF.cur_input->input.left--;
+	      }
+	    } else
+	      CF.cur_input->input.left--;
+	  }
+	  goto redraw_newcursor;
+	  break;
+	case '\177':  /* DEL */
+	case '\004':  /* ^D */
+	  if (CF.rel_cursor < CF.cur_input->input.n) {
+	    sp = CF.cur_input->input.value + CF.rel_cursor + 1;
+	    dp = sp - 1;
+	    for (; *dp = *sp, *sp != '\0'; dp++, sp++);
+	    CF.cur_input->input.n--;
+	    goto redraw_newcursor;
+	  }
+	  break;
+	case '\013':  /* ^K */
+	  CF.cur_input->input.value[CF.rel_cursor] = '\0';
+	  CF.cur_input->input.n = CF.rel_cursor;
+	  goto redraw_newcursor;
+	case '\025':  /* ^U */
+	  CF.cur_input->input.value[0] = '\0';
+	  CF.cur_input->input.n = CF.cur_input->input.left = 0;
+	  CF.rel_cursor = CF.abs_cursor = 0;
+	  goto redraw_newcursor;
+	case '\020':                    /* ^P previous field */
+	  old_item = CF.cur_input;
+	  CF.cur_input = old_item->input.prev_input; /* new current input fld */
+	  RedrawItem(old_item, 1, NULL);
+	  CF.rel_cursor = CF.abs_cursor = 0; /* home cursor in new input field */
+	  goto redraw;
+	  break;
+	case '\t':
+	case '\n':
+	case '\015':
+	case '\016':  /* LINEFEED, TAB, RETURN, ^N, jump to the next field */
+	  switch (process_tabtypes(&buf[0])) {
+	    case 0: goto no_redraw;break;
+	    case 1: goto redraw;break;
+	  }
+	  break;
+	default:
+	  if((buf[0] >= ' ' &&
+	      buf[0] < '\177') ||
+	     (buf[0] >= 160)) {         /* regular or intl char */
+	    process_regular_char_input(&buf[0]); /* insert into input field */
+	    goto redraw_newcursor;
+	  }
+	  /* unrecognized key press, check for buttons */
+	  for (item = root_item_ptr; item != 0; item = item->header.next)
+	  {
+	    /* all items */
+	    myfprintf((stderr, "Button: keypress==%d\n",
+		    item->button.keypress));
+	    if (item->type == I_BUTTON && item->button.keypress == keypress) {
+	      RedrawItem(item, 1, NULL);
+	      usleep(MICRO_S_FOR_10MS);  /* .1 seconds */
+	      RedrawItem(item, 0, NULL);
+	      DoCommand(item);
+	      goto no_redraw;
+	    }
+	  }
+	  break;
+	}
+      redraw_newcursor:
+	{
+	  XSetForeground(dpy, CF.cur_input->header.dt_ptr->dt_item_GC,
+			 CF.cur_input->header.dt_ptr->dt_colors[c_item_bg]);
+	  /* Since DrawString is being used, I changed this to clear the
+	     entire input field.  dje 10/24/99. */
+	  XClearArea(dpy, CF.cur_input->header.win,
+		     BOX_SPC + TEXT_SPC - 1, BOX_SPC,
+		     CF.cur_input->header.size_x
+		     - (2 * BOX_SPC) - 2 - TEXT_SPC,
+		     (CF.cur_input->header.size_y - 1)
+		     - 2 * BOX_SPC + 1, False);
+	}
+      redraw:
+	{
+	  int len, x, dy;
+	  len = CF.cur_input->input.n - CF.cur_input->input.left;
+	  XSetForeground(dpy, CF.cur_input->header.dt_ptr->dt_item_GC,
+			 CF.cur_input->header.dt_ptr->dt_colors[c_item_fg]);
+	  if (len > CF.cur_input->input.size)
+	    len = CF.cur_input->input.size;
+	  CF.cur_input->header.dt_ptr->dt_Fstr->win = CF.cur_input->header.win;
+	  CF.cur_input->header.dt_ptr->dt_Fstr->gc  =
+	    CF.cur_input->header.dt_ptr->dt_item_GC;
+	  CF.cur_input->header.dt_ptr->dt_Fstr->flags.has_colorset = False;
+	  if (itemcolorset >= 0)
+	  {
+	    CF.cur_input->header.dt_ptr->dt_Fstr->colorset =
+		    &Colorset[itemcolorset];
+	    CF.cur_input->header.dt_ptr->dt_Fstr->flags.has_colorset = True;
+	  }
+	  CF.cur_input->header.dt_ptr->dt_Fstr->str = CF.cur_input->input.value;
+	  CF.cur_input->header.dt_ptr->dt_Fstr->x   = BOX_SPC + TEXT_SPC;
+	  CF.cur_input->header.dt_ptr->dt_Fstr->y   = BOX_SPC + TEXT_SPC
+	    + CF.cur_input->header.dt_ptr->dt_Ffont->ascent;
+	  CF.cur_input->header.dt_ptr->dt_Fstr->len = len;
+	  FlocaleDrawString(dpy,
+			    CF.cur_input->header.dt_ptr->dt_Ffont,
+			    CF.cur_input->header.dt_ptr->dt_Fstr,
+			    FWS_HAVE_LENGTH);
+	  x = BOX_SPC + TEXT_SPC +
+		  FlocaleTextWidth(CF.cur_input->header.dt_ptr->dt_Ffont,
+				   CF.cur_input->input.value,CF.abs_cursor)
+		  - 1;
+	  dy = CF.cur_input->header.size_y - 1;
+	  XDrawLine(dpy, CF.cur_input->header.win,
+		    CF.cur_input->header.dt_ptr->dt_item_GC,
+		    x, BOX_SPC, x, dy - BOX_SPC);
+	  myfprintf((stderr,"Line %d/%d - %d/%d (char)\n",
+		     x, BOX_SPC, x, dy - BOX_SPC));
+	}
+      no_redraw:
+	break;  /* end of case KeyPress */
+      }  /* end of switch (event.type) */
+      continue;
+    }  /* end of if (event.xany.window == CF.frame) */
+    for (item = root_item_ptr; item != 0;
+	 item = item->header.next) {    /* all items */
+      if (event.xany.window == item->header.win) {
+	switch (event.type) {
+	case Expose:
+	{
+		int ex = event.xexpose.x;
+		int ey = event.xexpose.y;
+		int ex2 = event.xexpose.x + event.xexpose.width;
+		int ey2 = event.xexpose.y + event.xexpose.height;
+		while (FCheckTypedWindowEvent(
+			dpy, item->header.win, Expose, &event))
+		{
+			ex = min(ex, event.xexpose.x);
+			ey = min(ey, event.xexpose.y);
+			ex2 = max(ex2, event.xexpose.x + event.xexpose.width);
+			ey2 = max(ey2 , event.xexpose.y + event.xexpose.height);
+		}
+		event.xexpose.x = ex;
+		event.xexpose.y = ey;
+		event.xexpose.width = ex2 - ex;
+		event.xexpose.height = ey2 - ey;
+		RedrawItem(item, 0, &event);
+	}
+	break;
+	case ButtonPress:
+	  if (item->type == I_INPUT) {
+	    old_item = CF.cur_input;
+	    CF.cur_input = item;
+	    RedrawItem(old_item, 1, NULL);
+	    {
+	      Bool done = False;
+
+	      CF.abs_cursor = 0;
+	      while(CF.abs_cursor <= item->input.size && !done)
+	      {
+		if (FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
+				     item->input.value,
+				     CF.abs_cursor) >=
+		    event.xbutton.x - BOX_SPC - TEXT_SPC)
+		{
+		  done = True;
+		  CF.abs_cursor--;
+		}
+		else
+		{
+		  CF.abs_cursor++;
+		}
+	      }
+	    }
+	    if (CF.abs_cursor < 0)
+	      CF.abs_cursor = 0;
+	    if (CF.abs_cursor > item->input.size)
+	      CF.abs_cursor = item->input.size;
+	    CF.rel_cursor = CF.abs_cursor + item->input.left;
+	    if (CF.rel_cursor < 0)
+	      CF.rel_cursor = 0;
+	    if (CF.rel_cursor > item->input.n)
+	      CF.rel_cursor = item->input.n;
+	    if (CF.rel_cursor > 0 && CF.rel_cursor == item->input.left)
+	      item->input.left--;
+	    if (CF.rel_cursor < item->input.n &&
+		CF.rel_cursor == item->input.left + item->input.size)
+	      item->input.left++;
+	    CF.abs_cursor = CF.rel_cursor - item->input.left;
+	    if (event.xbutton.button == Button2) { /* if paste request */
+	      process_paste_request (&event, item);
+	    }
+	    RedrawItem(item, 0, NULL);
+	  }
+	  if (item->type == I_CHOICE)
+	    ToggleChoice(item);
+	  if (item->type == I_BUTTON) {
+	    RedrawItem(item, 1, NULL);    /* push button in */
+	    if (CF.activate_on_press) {
+	      usleep(MICRO_S_FOR_10MS);   /* make sure its visible */
+	      RedrawItem(item, 0, NULL);  /* pop button out */
+	      DoCommand(item);            /* execute the button command */
+	    } else {
+	      XGrabPointer(dpy, item->header.win,
+			   False,         /* owner of events */
+			   ButtonReleaseMask, /* events to report */
+			   GrabModeAsync, /* keyboard mode */
+			   GrabModeAsync, /* pointer mode */
+			   None,          /* confine to */
+			   /* I sort of like this, the hand points in
+			      the other direction and the color is
+			      reversed. I don't know what other GUIs do,
+			      Java doesn't do anything, neither does anything
+			      else I can find...dje */
+			   CF.pointer[button_in_pointer],   /* cursor */
+			   CurrentTime);
+	    } /* end activate on press */
+	  }
+	  break;
+	case ButtonRelease:
+	  if (!CF.activate_on_press) {
+	    RedrawItem(item, 0, NULL);
+	    if (CF.grab_server && CF.server_grabbed) {
+	      /* You have to regrab the pointer, or focus
+		 can go to another window.
+		 grab...
+	      */
+	      XGrabPointer(dpy, CF.frame, True, 0, GrabModeAsync, GrabModeAsync,
+			   None, None, CurrentTime);
+	      XFlush(dpy);
+	    } else {
+	      XUngrabPointer(dpy, CurrentTime);
+	      XFlush(dpy);
+	    }
+	    if (event.xbutton.x >= 0 &&
+		event.xbutton.x < item->header.size_x &&
+		event.xbutton.y >= 0 &&
+		event.xbutton.y < item->header.size_y) {
+	      DoCommand(item);
+	    }
+	  }
+	  break;
+	}
+      }
+    }  /* end of for (i = 0) */
+  }  /* while loop */
+}
+
+/* Each input field has a history, depending on the passed
+   direction, get the desired history item into the input field.
+   After "Restart" the yank point is one entry beyond the last
+   inserted item.
+   Normal yanks, going backward, go down the array decrementing
+   yank count before extracting.
+   Forward yanks increment before extracting. */
+static void process_history(int direction) {
+  int count;
+  if (!CF.cur_input                     /* no input fields */
+      || !CF.cur_input->input.value_history_ptr) { /* or no history */
+    return;                             /* bail out */
+  }
+  /* yankat is always one beyond slot to yank from. */
+  count = CF.cur_input->input.value_history_yankat + direction;
+  if (count < 0 || count >= VH_SIZE ||
+	     CF.cur_input->input.value_history_ptr[count] == 0 ) {
+    if (direction <= 0) {               /* going down */
+      for (count = VH_SIZE - 1;
+	   CF.cur_input->input.value_history_ptr[count] == 0;
+	   --count);                    /* find last used slot */
+    } else {                            /* going up */
+      count = 0;                        /* up is the bottom */
+    }
+  }
+  CF.cur_input->input.value =
+    fxstrdup(CF.cur_input->input.value_history_ptr[count]);
+  CF.cur_input->input.n = strlen(CF.cur_input->input.value);
+  CF.cur_input->input.value_history_yankat = count; /* new yank point */
+  CF.cur_input->input.buf = CF.cur_input->input.n;
+  CF.rel_cursor = 0;
+  CF.abs_cursor = 0;
+  CF.cur_input->input.left = 0;
+  return;
+}
+
+/* Note that tab, return, linefeed, ^n, all do the same thing
+   except when it comes to matching a command button hotkey.
+
+   Return 1 to redraw, 0 for no redraw */
+static int process_tabtypes(unsigned char * buf) {
+  Item *item, *old_item;
+  /* Note: the input field ring used with ^P above
+	     could probably make this a lot simpler. dje 12/20/98 */
+	  /* Code tracks cursor. */
+  item = root_item_ptr;         /* init item ptr */
+  if (CF.cur_input != 0) {          /* if in text */
+    item = CF.cur_input->header.next; /* move to next item */
+  }
+  for ( ; item != 0;
+	item = item->header.next) {/* find next input item */
+    if (item->type == I_INPUT) {
+      old_item = CF.cur_input;
+      CF.cur_input = item;
+      RedrawItem(old_item, 1, NULL);
+      CF.rel_cursor = CF.abs_cursor = 0; /* home cursor in new input field */
+      return (1);                       /* cause redraw */
+    }
+  }
+  /* end of all text input fields, check for buttons */
+  for (item = root_item_ptr; item != 0;
+       item = item->header.next) {/* all items */
+    myfprintf((stderr, "Button: keypress==%d vs buf %d\n",
+	       item->button.keypress, buf[0]));
+    if (item->type == I_BUTTON && item->button.keypress == buf[0]) {
+      RedrawItem(item, 1, NULL);
+      usleep(MICRO_S_FOR_10MS);
+      RedrawItem(item, 0, NULL);
+      DoCommand(item);
+      return (0);                       /* cause no_redraw */
+    }
+  }
+  /* goto the first text input field */
+  for (item = root_item_ptr; item != 0;
+       item = item->header.next) {/* all items */
+    if (item->type == I_INPUT) {
+      old_item = CF.cur_input;
+      CF.cur_input = item;
+      RedrawItem(old_item, 1, NULL);
+      CF.abs_cursor = CF.rel_cursor - item->input.left;
+      return (1);                       /* goto redraw */
+    }
+  }
+  return (-1);
+}
+
+static void process_regular_char_input(unsigned char *buf) {
+  char *sp, *dp, *ep;
+  /* n is the space actually used.
+     buf is the size of the buffer
+     size is the size of the field on the screen
+     size is used as the increment, arbitrarily. */
+  if (++(CF.cur_input->input.n) >= CF.cur_input->input.buf) {
+    CF.cur_input->input.buf += CF.cur_input->input.size;
+    CF.cur_input->input.value =
+      fxrealloc(CF.cur_input->input.value, CF.cur_input->input.buf,
+		      sizeof(CF.cur_input->input.value));
+  }
+  dp = CF.cur_input->input.value + CF.cur_input->input.n;
+  sp = dp - 1;
+  ep = CF.cur_input->input.value + CF.rel_cursor;
+  for (; *dp = *sp, sp != ep; sp--, dp--);
+  *ep = buf[0];
+  CF.rel_cursor++;
+  CF.abs_cursor++;
+  if (CF.abs_cursor >= CF.cur_input->input.size) {
+    if (CF.rel_cursor < CF.cur_input->input.n)
+      CF.abs_cursor = CF.cur_input->input.size - 1;
+    else
+      CF.abs_cursor = CF.cur_input->input.size;
+    CF.cur_input->input.left = CF.rel_cursor - CF.abs_cursor;
+  }
+}
+/* Process a paste.  This can be any size.
+   Right now, the input loop can't just be fed characters.
+   Send plain text and newlines to the 2 subroutines that want them.
+   */
+static void process_paste_request (XEvent *event, Item *item) {
+  Atom actual_type;
+  int actual_format;
+  unsigned long nitems, bytes_after, nread;
+  unsigned char *data;
+  unsigned char *c;
+
+  nread = 0;                            /* init read offset */
+  do {
+    if (XGetWindowProperty (dpy,
+			    DefaultRootWindow (dpy),
+			    XA_CUT_BUFFER0,
+			    nread/4, 1024L,   /* offset, length */
+			    False,           /* delete */
+			    AnyPropertyType, /* request type */
+			    &actual_type,
+			    &actual_format, &nitems, &bytes_after,
+			    (unsigned char **)&data) != Success) {
+      return;                           /* didn't work, give up */
+    } /* end didn't work */
+    if (actual_type != XA_STRING) {     /* if something other than text */
+      return;                           /* give up */
+    }
+    for (c = data; c != data + nitems; c++) { /* each char */
+      switch (*c) {
+      case '\t':                        /* TAB */
+	if (CF.cur_input == CF.cur_input->input.next_input) { /* 1 ip field */
+	  process_regular_char_input((unsigned char *)" "); /* paste space */
+	} else {
+	  process_tabtypes(c);          /* jump to the next field */
+	}
+      case '\015':                      /* LINEFEED */
+      case '\016':                      /* ^N */
+	process_tabtypes(c);            /* jump to the next field */
+	break;
+      case '\n':
+	/* change \n to \r for pasting */
+	process_tabtypes((unsigned char *)"\r");
+	break;
+      default:
+	process_regular_char_input(c);
+	break;
+      } /* end swtich on char type */
+    } /* end each char */
+    myfprintf((stderr,"See paste data, %s, nread %d, nitems %d\n",
+	    data, (int)nread, (int)nitems));
+    nread += nitems;
+    XFree (data);
+  } while (bytes_after > 0);
+}
+static void ToggleChoice (Item *item)
+{
+  int i;
+  Item *sel = item->choice.sel;
+
+  if (sel->selection.key == IS_SINGLE) {
+    if (!item->choice.on) {
+      for (i = 0; i < sel->selection.n; i++) {
+	if (sel->selection.choices[i]->choice.on) {
+	  sel->selection.choices[i]->choice.on = 0;
+	  RedrawItem(sel->selection.choices[i], 0, NULL);
+	}
+      }
+      item->choice.on = 1;
+      RedrawItem(item, 0, NULL);
+    }
+  } else {  /* IS_MULTIPLE */
+    item->choice.on = !item->choice.on;
+    RedrawItem(item, 0, NULL);
+  }
+}
+static void ResizeFrame (void) {
+#if 0
+  /* unfinished dje. */
+  /* If you ever finish this, please make sure to check the return code of
+   * XGetGeometry below. dv */
+  Window root;
+  XEvent dummy;
+  int x, y;
+  unsigned int border, depth, width, height;
+  /* get anything queued */
+  while (FCheckTypedWindowEvent(dpy, CF.frame, ConfigureNotify, &dummy))
+    ;
+  XGetGeometry(dpy, CF.frame, &root, &x, &y, &width, &height, &border, &depth);
+  if (width != CF.max_width) {
+    if (CF.last_error != 0) {           /* if form has message area */
+      fprintf(stderr, "Frame was %d, is %d\n",CF.max_width,width);
+      /* RedrawText sets x = item->header.pos_x + TEXT_SPC;
+	 MassageConfig does :
+	   line->size_x += (line->n + 1) * ITEM_HSPC; =(10)=
+	   if (line->size_x > CF.max_width)
+	     CF.max_width = line->size_x;
+	   (70 + 1) * 10 = 700??
+      */
+      int delta;
+      int curr_x;
+      delta = width - CF.max_width;     /* new width - curr width */
+      curr_x = CF.last_error->header.pos_x + TEXT_SPC;
+      curr_end = curr_x + CF.last_error->size_x;
+
+    }
+  }
+#endif
+}

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -2,5 +2,5 @@
 
 SUBDIRS = \
 	FvwmAnimate FvwmAuto FvwmBacker FvwmButtons FvwmConsole FvwmEvent \
-	FvwmIconMan FvwmIdent FvwmPager FvwmPerl FvwmRearrange FvwmScript \
-	FvwmMFL
+	FvwmForm FvwmIconMan FvwmIdent FvwmPager FvwmPerl FvwmRearrange \
+	FvwmScript FvwmMFL


### PR DESCRIPTION
A few years ago, in conversation with various people on IRC and some via
email, it was clear then that FvwmForm could be deprecated in favour of
FvwmScript because that was the module which was being more widely used,
and had support for widgets which FvwmForm did not.

However, in speaking to Dan Espen (the primary author of FvwmForm), he
always had the idea to augment FvwmForm with better features than
FvwmScipt.  Indeed, Dan makes a good point that FvwmScript's comments
are in French which doesn't make it easier to non-French speakers to
understand them, *and* follow the code at the same time.

The default assumption in deprecating FvwmForm for FvwmScript -- because
FvwmScript was deemed a superset -- doesn't hold try any more.  If
anything, it's more likely to go the other way; removing FvwmScript for
FvwmForm.

Until we work out what do to about this, we'll need to reinstate
FvwmForm in order to start using it.

There's a few tweaks to the code to make it compile against newer APIs
introduced since FvwmForm was deprecated.

Thanks to Dan Espen for his patience!
