### PR TITLE
FvwmForm: change Timeout resolution to 100ms, instead of 1s

### DIFF
--- a/modules/FvwmForm/FvwmForm.1.in
+++ b/modules/FvwmForm/FvwmForm.1.in
@@ -582,13 +582,13 @@ used while the pointer is over a text field.
 See DEFAULTS.
 
 .TP 4
-.B *FvwmForm: Timeout \fIseconds\fP \fIcommand\fP \fI"text"\fP
-Set up FvwmForm to time out after the amount of \fIseconds\fP
+.B *FvwmForm: Timeout \fItenth_of_seconds\fP \fIcommand\fP \fI"text"\fP
+Set up FvwmForm to time out after the amount of \fItenth of seconds\fP
 specified.  When the timer hits zero, \fIcommand\fP executes.  The
 \fItext\fP field is displayed much like a \fIText\fP
 field, except that a '%%' in the line is replaced automatically by
 the amount of time left on the timer.  The value gets updated every
-second as the timer counts down.
+tenth of second as the timer counts down.
 There can only be one timeout field per form.
 
 .SH EXAMPLES
@@ -623,7 +623,7 @@ DestroyModuleConfig  FvwmForm-QuitVerify: *
 *FvwmForm-QuitVerify: Command     Restart
 *FvwmForm-QuitVerify: Button      quit "Cancel" ^[
 *FvwmForm-QuitVerify: Command     Nop
-*FvwmForm-QuitVerify: Timeout     20 Quit "Automatic logout will occur in %% seconds."
+*FvwmForm-QuitVerify: Timeout     200 Quit "Automatic logout will occur in %% tenth of seconds."
 .EE
 
 .SH EXAMPLE 2 - Remote Login

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -99,6 +99,9 @@ Bool Swallowed = False;
 int colorset = -1;
 int itemcolorset = 0;
 
+/* global not exported */
+const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} };
+
 /* prototypes */
 static void RedrawSeparator(Item *item);
 static void AssignDrawTable(Item *);
@@ -135,7 +138,7 @@ static void SetupTimer(void)
 #endif
 #endif
 
-  alarm(1);
+  setitimer(ITIMER_REAL, &itv_100ms, NULL);
 }
 
 /* copy a string until '"', or '\n', or '\0' */
@@ -878,7 +881,7 @@ static void ct_Title(char *cp)
 }
 static void ct_Timeout(char *cp)
 {
-  /* syntax: *FFTimeout seconds <Command> "Text" */
+  /* syntax: *FFTimeout tenth_of_seconds <Command> "Text" */
   char *tmpcp, *tmpbuf;
 
   if (timer != NULL) {
@@ -2674,7 +2677,7 @@ TimerHandler(int sig)
   }
   else {
     RedrawTimeout(timer);
-    alarm(1);
+    setitimer(ITIMER_REAL, &itv_100ms, NULL);
   }
 
   SIGNAL_RETURN;


### PR DESCRIPTION
Old patch for version 2.6, merged with no modification in 3.0.
Needs testing.