### PR TITLE
configure.ac: check for xt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,12 @@ AC_SUBST(DOC_SECTIONS)
 AC_SUBST(DOC_SECTIONS_XML)
 AC_SUBST(DOC_SECTIONS_XML_PATH)
 
+PKG_CHECK_MODULES([xt],[xt],
+[],
+[
+ AC_MSG_ERROR([*** libxt not found. ***])
+])
+
 problem_mandoc=""
 AC_CHECK_PROG(XSLTPROC, xsltproc, xsltproc, "")
 


### PR DESCRIPTION
Don't assume that libxt is installed as part of libx11.  On some
systems, libxt is a separate dependency.

Fixes #191
