### PR TITLE
FvwmMFL: libbson: guard for FreeBSD

### DIFF
--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -27,7 +27,11 @@
 #include <errno.h>
 #include <stdbool.h>
 
+#if defined(__FreeBSD__)
+#include <libbson-1.0/bson.h>
+#else
 #include <bson/bson.h>
+#endif
 
 #include <event2/event.h>
 /* FIXME: including event_struct.h won't be binary comaptible with future


### PR DESCRIPTION
FreeBSD has bson.h in a different location than pkg-config expects.  For
now, guard against this with #ifdef.

Fixes #200
