### PR TITLE
configure: default CFLAGS, add no-security guard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,7 +231,7 @@ AC_PROG_CPP
 
 # added -Wall for gcc, what about for others?
 if test "x$GCC" = "xyes"; then
-  CFLAGS="-Wall -Wno-implicit-int -fno-common $CFLAGS"
+  CFLAGS="-Wall -Wno-implicit-int -fno-common -Wno-error=format-security $CFLAGS"
 fi
 
 # Help finding POSIX functions on some systems


### PR DESCRIPTION
To comply with Debian Hardening rules, add "-Wno-error=format-security"
to the default CFLAGS rule.

format-security will typically warn about non-literal strings in str*()
functions which is generally harmless, and the compiler being too
helpful.
