### PR TITLE
Respect environment variable for MFL socket path

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1396,7 +1396,6 @@ static void SetRCDefaults(void)
 		{ "Key Up M A MenuMoveCursor -1", "", "" },
 		{ "Key Down M A MenuMoveCursor 1", "", "" },
 		{ "Mouse 1 MI A MenuSelectItem", "", "" },
-		{ "Module FvwmMFL", "", "" },
 		/* don't add anything below */
 		{ RC_DEFAULTS_COMPLETE, "", "" },
 		{ "Read "FVWM_DATADIR"/ConfigFvwmDefaults", "", "" },

--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -690,7 +690,6 @@ int main(int argc, char **argv)
 	memset(&sin, 0, sizeof(sin));
 	sin.sun_family = AF_LOCAL;
 	strcpy(sin.sun_path, sock_pathname);
-	free(sock_pathname);
 
 	/* Create a new listener */
 	fmd_cfd = evconnlistener_new_bind(base, accept_conn_cb, NULL,

--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -137,9 +137,6 @@ fvwm_msg_free(struct fvwm_msg *fm)
 static void
 HandleTerminate(int fd, short what, void *arg)
 {
-
-	sock_pathname = set_socket_pathname();
-
 	fprintf(stderr, "%s: dying...\n", __func__);
 	unlink(sock_pathname);
 	fvwmSetTerminate(fd);
@@ -629,7 +626,6 @@ static void
 fvwm_read(int efd, short ev, void *data)
 {
 	FvwmPacket	*packet;
-	sock_pathname = set_socket_pathname();
 
 	if ((packet = ReadFvwmPacket(efd)) == NULL) {
 		if (debug)
@@ -682,14 +678,14 @@ int main(int argc, char **argv)
 		return (1);
 	}
 
+	sock_pathname = set_socket_pathname();
+
 	/* Create new event base */
 	if ((base = event_base_new()) == NULL) {
 		fprintf(stderr, "Couldn't start libevent\n");
 		return (1);
 	}
 	setup_signal_handlers(base);
-
-	sock_pathname = set_socket_pathname();
 
 	memset(&sin, 0, sizeof(sin));
 	sin.sun_family = AF_LOCAL;

--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -47,7 +47,7 @@
 
 static int debug;
 struct fvwm_msg;
-static const char *sock_pathname;
+static char *sock_pathname;
 
 struct client {
 	struct bufferevent	*comms;
@@ -115,7 +115,7 @@ static struct fvwm_msg *fvwm_msg_new(void);
 static void fvwm_msg_free(struct fvwm_msg *);
 static void register_interest(void);
 static void send_version_info(struct client *);
-static const char *set_socket_pathname(void);
+static char *set_socket_pathname(void);
 
 static struct fvwm_msg *
 fvwm_msg_new(void)
@@ -139,6 +139,7 @@ HandleTerminate(int fd, short what, void *arg)
 {
 
 	sock_pathname = set_socket_pathname();
+
 	fprintf(stderr, "%s: dying...\n", __func__);
 	unlink(sock_pathname);
 	fvwmSetTerminate(fd);
@@ -628,7 +629,6 @@ static void
 fvwm_read(int efd, short ev, void *data)
 {
 	FvwmPacket	*packet;
-
 	sock_pathname = set_socket_pathname();
 
 	if ((packet = ReadFvwmPacket(efd)) == NULL) {
@@ -641,14 +641,15 @@ fvwm_read(int efd, short ev, void *data)
 	broadcast_to_client(packet);
 }
 
-static const char *
+static char *
 set_socket_pathname(void)
 {
-	char *mflsock_env;
-	const char      *unrolled_path;
+	char		*mflsock_env;
+	const char	*unrolled_path;
 
-	/* Figure out if we are using default MFL socket path or we should respect */
-	/* environment variable FVWMMFL_SOCKET for FvwmMFL socket path */
+	/* Figure out if we are using default MFL socket path or we should
+	 * respect environment variable FVWMMFL_SOCKET for FvwmMFL socket path
+	 */
 
 	mflsock_env = getenv("FVWMMFL_SOCKET");
 	if (mflsock_env == NULL) {
@@ -657,9 +658,11 @@ set_socket_pathname(void)
 
 	unrolled_path = expand_path(mflsock_env);
 	if (unrolled_path[0] == '/')
-	    sock_pathname = fxstrdup(unrolled_path);
-	else
-	    xasprintf(&sock_pathname, "%s/%s", getenv("FVWM_USERDIR"), unrolled_path);
+		sock_pathname = fxstrdup(unrolled_path);
+	else {
+		xasprintf(&sock_pathname, "%s/%s", getenv("FVWM_USERDIR"),
+			unrolled_path);
+	}
 
 	free((void *)unrolled_path);
 


### PR DESCRIPTION
Hi Thomas,

While reading man page for FvwmMFL, I saw reference to FVWMMFL_SOCKET, but this doesn't work because it was still in plan in modules/FvwmMFL/FvwmMFL.c.

I played a bit this evening and got this to work for me. Please see if this is ok, and if it can be merged. Thanks. :-)
