### PR TITLE
FvwmMFL: remove socket before opening

### DIFF
--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -679,6 +679,7 @@ int main(int argc, char **argv)
 	}
 
 	sock_pathname = set_socket_pathname();
+	unlink(sock_pathname);
 
 	/* Create new event base */
 	if ((base = event_base_new()) == NULL) {


### PR DESCRIPTION
Remove the socket FvwmMFL is about to open before establishing a
connection, otherwise FvwmMFL won't start cleanly.
