### PR TITLE
Add WindowName option to FvwmButtons

### DIFF
--- a/modules/FvwmButtons/FvwmButtons.1.in
+++ b/modules/FvwmButtons/FvwmButtons.1.in
@@ -181,6 +181,16 @@ double quotes) for a transparent background.
 Specifies the number of rows of buttons to be created. The default
 is 2 rows.
 
+.IP "*FvwmButtons: WindowName \fIname\fP"
+If FvwmButtons has a titlebar enabled with Title style, (for example,
+some transient subpanel), this option can set it's Window name and
+Icon name to a string provided with this parameter. If omitted, default
+for Window and Icon name is the window resource name which itself is
+simply "FvwmButtons", or is derived from the alias by which FvwmButtons
+configuration is referenced. This enables setting a title with spaces
+and larger number of non-ASCII characters which is not allowed as an
+alias for FvwmButtons module instance otherwise.
+
 .IP "*FvwmButtons: (\fIoptions\fP) [\fItitle icon command\fP]"
 Specifies the contents of a button in the buttonbox. The following
 \fIoptions\fP, separated by commas or whitespace, can be given a

--- a/modules/FvwmButtons/FvwmButtons.c
+++ b/modules/FvwmButtons/FvwmButtons.c
@@ -191,6 +191,7 @@ Bool do_allow_bad_access = False;
 Bool was_bad_access = False;
 Bool swallowed = False;
 Window swallower_win = 0;
+char windowname[128];
 
 /* ------------------------------ Misc functions ----------------------------*/
 
@@ -846,6 +847,11 @@ int main(int argc, char **argv)
 	 * will tell us the current desktop and paging status, needed to
 	 * indent buttons correctly */
 	SendText(fd, "Send_WindowList", 0);
+
+	if (UberButton->c->flags.b_WindowName == 1)
+	{
+		change_window_name(windowname);
+	}
 
 #ifdef DEBUG_INIT
 	fvwm_debug(__func__, "OK\n%s: Startup complete\n", MyName);
@@ -3419,4 +3425,23 @@ void exec_swallow(char *action, button_info *b)
 		my_sm_env, action, orig_sm_env);
 	SendText(fd, cmd, 0);
 	free(cmd);
+}
+
+/*
+ *  Change the window name displayed in the title bar.
+ *  Helper function borrowed from FvwmIdent for
+ *  WindowName FvwmButtons functionality
+ */
+void change_window_name(char *str)
+{
+	XTextProperty name;
+
+	if (XStringListToTextProperty(&str, 1, &name) == 0)
+	{
+		fprintf(stderr,"FvwmButtons: cannot allocate window name");
+		return;
+	}
+	XSetWMName(Dpy, MyWindow, &name);
+	XSetWMIconName(Dpy, MyWindow, &name);
+	XFree(name.value);
 }

--- a/modules/FvwmButtons/FvwmButtons.h
+++ b/modules/FvwmButtons/FvwmButtons.h
@@ -77,6 +77,7 @@ typedef struct
 	unsigned b_PressIcon      : 1; /* Use alternate Icon on press */
 	unsigned b_PressColorset  : 1; /* Use alternate Colorset on press */
 	unsigned b_PressTitle     : 1; /* Use alternate Title text on press */
+	unsigned b_WindowName     : 1; /* Use alternate Window and Icon name */
 } flags_type;
 
 /* Flags for b->swallow */
@@ -240,6 +241,7 @@ void exec_swallow(char *action, button_info *b);
 
 char *GetButtonAction(button_info*,int);
 void ButtonPressProcess(button_info *b, char **act);
+void change_window_name(char *str);
 
 /* ----------------------------- global variables -------------------------- */
 
@@ -257,6 +259,7 @@ extern int new_desk;
 extern GC NormalGC;
 extern GC ShadowGC;
 extern FlocaleWinString *FwinString;
+extern char windowname[128];
 
 /* ---------------------------------- misc --------------------------------- */
 

--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -1946,10 +1946,7 @@ static void ParseConfigLine(button_info **ubb, char *s)
 			ub->c->flags.b_WindowName = 0;
 		}
 #ifdef DEBUG_PARSER
-		if (windowname == 0)
-		{
-			fprintf(stderr, "%s\n", windowname);
-		}
+		fprintf(stderr, "%s\n", windowname);
 #endif
 		break;
 	}

--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -1785,6 +1785,7 @@ static void ParseConfigLine(button_info **ubb, char *s)
 		"colorset",
 		"activecolorset",
 		"presscolorset",
+		"windowname",
 		NULL
 	};
 	int i, j, k;
@@ -1932,6 +1933,26 @@ static void ParseConfigLine(button_info **ubb, char *s)
 			ub->c->flags.b_PressColorset = 0;
 		}
 		break;
+
+	case 15: /* WindowName */
+	{
+		i = sscanf(s, "%126[^\n]", windowname);
+		if (i > 0)
+		{
+			ub->c->flags.b_WindowName = 1;
+		}
+		else
+		{
+			ub->c->flags.b_WindowName = 0;
+		}
+#ifdef DEBUG_PARSER
+		if (windowname == 0)
+		{
+			fprintf(stderr, "%s\n", windowname);
+		}
+#endif
+		break;
+	}
 
 	default:
 		s = trimleft(s);


### PR DESCRIPTION
Hi,

Today I have adapted "WindowName" FvwmButtons patch for FVWM3, together with man page entry.
I have been using it with FVWM2 for 1-2 years already.

This adds functionality for subpanels which intentionally have Title (like CDE Front Panel
and it's subpanels as you can guess) with non-ASCCI characters and spaces, which cannot be
accomplished with FvwmButtons module alias.
