### PR TITLE
FvwmMFL: honour TMPDIR for socket

### DIFF
--- a/bin/FvwmPrompt/FvwmPrompt.go
+++ b/bin/FvwmPrompt/FvwmPrompt.go
@@ -15,8 +15,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	fmdSocket = "/tmp/fvwm_mfl.sock"
+var (
+	fmdSocket = os.Getenv("FVWMMFL_SOCKET")
 )
 
 // getopt parsing

--- a/modules/FvwmMFL/FvwmMFL.1.in
+++ b/modules/FvwmMFL/FvwmMFL.1.in
@@ -35,7 +35,7 @@ The information from Fvwm3 is in the form of JSON packets.  Each JSON packet
 has different fields, depending on the type requested.
 
 .SH COMMUNICATION
-The default unix-domain socket for \fIFvwmMFL\fP is \fI/tmp/fvwm_mfl.sock\fP,
+The default unix-domain socket for \fIFvwmMFL\fP is \fI$TMPDIR/fvwm_mfl.sock\fP,
 although this can be overriden via an environment variable \fIFVWMMFL_SOCKET\fP.
 
 .SH REGISTERING INTEREST


### PR DESCRIPTION
Allow for the FvwmMFL socket to be predicated via TMPDIR.  Additionally,
expose the actual FVWMMFL_SOCKET env var via Fvwm3 and make FvwmPrompt
use it.
