### PR TITLE
Add support for triangle indicator in/out sub options

### DIFF
--- a/modules/FvwmButtons/FvwmButtons.1.in
+++ b/modules/FvwmButtons/FvwmButtons.1.in
@@ -455,7 +455,11 @@ points in the direction where the panel will pop up.  The
 specifies the maximum width and height of the indicator.  Without
 this size FvwmButtons will make the indicator fit the button. You
 will probably want to use the \fIPadding\fP option to leave a few
-pixels between the indicator and the frame of the button.
+pixels between the indicator and the frame of the button. Second
+option to indicator may be given which enters the look of the
+triangle. If this keyword is \fIin\fP, triangle will appear pressed
+in, while \fIout\fP will make triangle to appear depressed (3D raised).
+If this keyword is omitted, default will be \fIout\fP or depressed.
 
 The \fIposition\fP option allows one to place the panel. The syntax
 is:

--- a/modules/FvwmButtons/FvwmButtons.h
+++ b/modules/FvwmButtons/FvwmButtons.h
@@ -226,6 +226,9 @@ struct button_info_struct
 	int slide_delay_ms;          /* b_Panel */
 	int indicator_size;          /* b_Panel */
 	panel_flags_type panel_flags;
+	int indicator_sunkraise;     /* b_Panel */
+	char indicator_in_out;       /* b_Panel */
+
 };
 
 #include "button.h"

--- a/modules/FvwmButtons/draw.c
+++ b/modules/FvwmButtons/draw.c
@@ -663,9 +663,20 @@ void RedrawButton(button_info *b, int draw, XEvent *pev)
 					break;
 				}
 			}
-			DrawTrianglePattern(
-				Dpy, MyWindow, NormalGC, ShadowGC, None,
-				ix, iy, iw, ih, 0, dir, 1, 0, 0);
+
+			if (b->indicator_sunkraise == 2)
+			{
+				DrawTrianglePattern(
+					Dpy, MyWindow, ShadowGC, NormalGC, None,
+					ix, iy, iw, ih, 0, dir, 1, 0, 0);
+			}
+			else
+			{
+				DrawTrianglePattern(
+					Dpy, MyWindow, NormalGC, ShadowGC, None,
+					ix, iy, iw, ih, 0, dir, 1, 0, 0);
+			}
+
 		}
 	} /* panel indicator */
 

--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -396,7 +396,8 @@ static void ParsePanel(
 	char **ss, unsigned int *flags, unsigned int *mask, char *direction,
 	int *steps, int *delay, panel_flags_type *panel_flags,
 	int *indicator_size, int *rela_x, int *rela_y, char *position,
-	char *context)
+	char *context, int *indicator_sunkraise, char *indicator_in_out)
+
 {
 	char *swallowopts[] =
 	{
@@ -424,6 +425,9 @@ static void ParsePanel(
 
 	char *t, *s = *ss;
 	int n;
+	char *instr = "in";
+	char *outstr = "out";
+	char *clear_comma;
 
 	while (*s && *s != ')')
 	{
@@ -515,7 +519,38 @@ static void ParsePanel(
 			n = 0;
 			(*panel_flags).panel_indicator = 1;
 			*indicator_size = 0;
-			sscanf(s, "%d%n", indicator_size, &n);
+			sscanf(s, "%d %s%n", indicator_size, indicator_in_out, &n);
+
+			/* Remove comma from %s of sscanf */
+			clear_comma = strchr(indicator_in_out, ',');
+			if (clear_comma != NULL)
+			{
+				*clear_comma = '\0';
+			}
+
+			if (*indicator_in_out == *instr)
+			{
+			        *indicator_sunkraise = 2;
+			}
+			if (*indicator_in_out == *outstr)
+			{
+			        *indicator_sunkraise = 1;
+			}
+
+			/* Not defined - parse indicator size without in/out after it */
+			if (*indicator_sunkraise < 1 || *indicator_sunkraise > 2)
+			{
+			        *indicator_sunkraise = 1;
+			        s = trimleft(s);
+			        n = n - 1;
+			        sscanf(s, "%d%n", indicator_size, &n);
+			        if (*indicator_size < 0 || *indicator_size > 100)
+			        {
+			                *indicator_size = 0;
+			        }
+			}
+
+
 			if (*indicator_size < 0 || *indicator_size > 100)
 			{
 				*indicator_size = 0;
@@ -1151,7 +1186,9 @@ static void ParseButton(button_info **uberb, char *s)
 							&b->relative_x,
 							&b->relative_y,
 							&b->slide_position,
-							&b->slide_context);
+							&b->slide_context,
+							&b->indicator_sunkraise,
+							&b->indicator_in_out);
 					}
 				}
 				t = seekright(&s);

--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -427,7 +427,6 @@ static void ParsePanel(
 	int n;
 	char *instr = "in";
 	char *outstr = "out";
-	char *clear_comma;
 
 	while (*s && *s != ')')
 	{
@@ -522,11 +521,7 @@ static void ParsePanel(
 			sscanf(s, "%d %s%n", indicator_size, indicator_in_out, &n);
 
 			/* Remove comma from %s of sscanf */
-			clear_comma = strchr(indicator_in_out, ',');
-			if (clear_comma != NULL)
-			{
-				*clear_comma = '\0';
-			}
+			indicator_in_out[strcspn(indicator_in_out, ",")] = '\0';
 
 			if (*indicator_in_out == *instr)
 			{


### PR DESCRIPTION
Hi Thomas. This is my long existing patch 2/3 it messes with the same files as window name patch, so I have split it and sent as separate patch.

What does it do: it adds ability for subpanel launcher triangle indicator to be drawn in 3D sunken in, not just raised out. This means that indicator has new argument - after positive integer, there can be keyword "in" or "out". Absence of this argument means "out" which is visual and configuration parsing backward compatible behaviour.

A small illustration attached: right is default raised triangle, left is sunken in new option.
![FvwmButtons-Patch-in-out-detail](https://user-images.githubusercontent.com/48650374/92719852-11416900-f364-11ea-91ab-375098ff528b.png)
