### PR TITLE
Support for setting default mouse cursor on all FvwmScript widgets

### DIFF
--- a/modules/FvwmScript/FvwmScript.1.in
+++ b/modules/FvwmScript/FvwmScript.1.in
@@ -85,6 +85,11 @@ command or in the script with the ShadowColor command, grey55 is used.
 .IP "*FvwmScript: DefaultColorset \fIcolorset\fP"
 Tells the module to use colorset \fIcolorset\fP as the default colorset.
 
+.IP "*FvwmScript: DefaultCursor \fIcursor\fP"
+Tells the module to use X11 cursor \fIcursor\fP as the default for all
+widgets. Cursor names are those defined in the include file X11/cursorfont.h
+but without XC_ prefix.
+
 .SH ANATOMY OF A SCRIPT
 FvwmScript uses a particular programming language. A script is composed of
 five parts. Heading contains general characteristics of the window and

--- a/modules/FvwmScript/Widgets/CheckBox.c
+++ b/modules/FvwmScript/Widgets/CheckBox.c
@@ -44,8 +44,10 @@ void InitCheckBox(struct XObj *xobj)
   mask = 0;
   Attr.background_pixel = xobj->TabColor[back];
   mask |= CWBackPixel;
-  Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
-  mask |= CWCursor;  /* Cursor for the window */
+  if (!x11base->cursor) {
+    Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+    mask |= CWCursor;  /* Window cursor */
+  }
 
   xobj->win = XCreateWindow(dpy, *xobj->ParentWin,
 		xobj->x, xobj->y, xobj->width, xobj->height,0,

--- a/modules/FvwmScript/Widgets/HScrollBar.c
+++ b/modules/FvwmScript/Widgets/HScrollBar.c
@@ -93,8 +93,10 @@ void InitHScrollBar(struct XObj *xobj)
   mask = 0;
   Attr.background_pixel = xobj->TabColor[back];
   mask |= CWBackPixel;
-  Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
-  mask |= CWCursor;             /* cursor for window */
+  if (!x11base->cursor) {
+    Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+    mask |= CWCursor;  /* Window cursor */
+  }
 
   xobj->win = XCreateWindow(dpy, *xobj->ParentWin,
 			    xobj->x, xobj->y, xobj->width, xobj->height, 0,

--- a/modules/FvwmScript/Widgets/List.c
+++ b/modules/FvwmScript/Widgets/List.c
@@ -49,8 +49,10 @@ void InitList(struct XObj *xobj)
   mask = 0;
   Attr.background_pixel = xobj->TabColor[back];
   mask |= CWBackPixel;
-  Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
-  mask |= CWCursor;  /* Window cursor */
+  if (!x11base->cursor) {
+	Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+	mask |= CWCursor;  /* Window cursor */
+  }
   xobj->win = XCreateWindow(dpy, *xobj->ParentWin,
 			  xobj->x, xobj->y, xobj->width, xobj->height, 0,
 			  CopyFromParent, InputOutput, CopyFromParent,

--- a/modules/FvwmScript/Widgets/Menu.c
+++ b/modules/FvwmScript/Widgets/Menu.c
@@ -49,8 +49,10 @@ void InitMenu(struct XObj *xobj)
   mask = 0;
   Attr.background_pixel = xobj->TabColor[back];
   mask |= CWBackPixel;
-  Attr.cursor = XCreateFontCursor(dpy, XC_hand2);
-  mask |= CWCursor;
+  if (!x11base->cursor) {
+    Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+    mask |= CWCursor;
+  }
   xobj->win = XCreateWindow(dpy, *xobj->ParentWin,
 			    xobj->x, xobj->y, xobj->width, xobj->height, 0,
 			    CopyFromParent, InputOutput, CopyFromParent,
@@ -194,9 +196,10 @@ void EvtMouseMenu(struct XObj *xobj, XButtonEvent *EvtButton)
   mask |=  CWBorderPixel;
   Attr.colormap = Pcmap;
   mask |= CWColormap;
-  Attr.cursor = XCreateFontCursor(dpy, XC_hand2);
-  /* cursor for the window */
-  mask |= CWCursor;
+  if (!x11base->cursor) {
+    Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+    mask |= CWCursor; /* cursor for the window */
+  }
   Attr.override_redirect = True;
   mask |= CWOverrideRedirect;
   WinPop = XCreateWindow(dpy, Root, x, y, wMenu-5, hMenu, 0, Pdepth,

--- a/modules/FvwmScript/Widgets/PopupMenu.c
+++ b/modules/FvwmScript/Widgets/PopupMenu.c
@@ -49,9 +49,11 @@ void InitPopupMenu(struct XObj *xobj)
   mask = 0;
   Attr.background_pixel = xobj->TabColor[back];
   mask |= CWBackPixel;
-  Attr.cursor = XCreateFontCursor(dpy, XC_hand2);
-  mask |= CWCursor;             /* window cursor */
 
+  if (!x11base->cursor) {
+    Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+    mask |= CWCursor;  /* Window cursor */
+  }
   xobj->win = XCreateWindow(dpy, *xobj->ParentWin,
 		xobj->x, xobj->y, xobj->width, xobj->height, 0,
 		CopyFromParent, InputOutput, CopyFromParent,
@@ -189,8 +191,10 @@ void EvtMousePopupMenu(struct XObj *xobj, XButtonEvent *EvtButton)
   mask |= CWBorderPixel;
   Attr.colormap = Pcmap;
   mask |= CWColormap;
-  Attr.cursor = XCreateFontCursor(dpy, XC_hand2);
-  mask |= CWCursor;             /* Window cursor */
+  if (!x11base->cursor) {
+    Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+    mask |= CWCursor;  /* Window cursor */
+  }
   Attr.override_redirect = True;
   mask |= CWOverrideRedirect;
   WinPop = XCreateWindow(dpy, Root, x, y, xobj->width, hMenu, 0,

--- a/modules/FvwmScript/Widgets/PushButton.c
+++ b/modules/FvwmScript/Widgets/PushButton.c
@@ -47,8 +47,10 @@ void InitPushButton(struct XObj *xobj)
 	}
 
 	mask = 0;
-	Attr.cursor = XCreateFontCursor(dpy, XC_hand2);
-	mask |= CWCursor;
+	if (!x11base->cursor) {
+		Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+		mask |= CWCursor;  /* Window cursor */
+	}
 	Attr.background_pixel = xobj->TabColor[back];
 	mask |= CWBackPixel;
 
@@ -293,8 +295,10 @@ void EvtMousePushButton(struct XObj *xobj, XButtonEvent *EvtButton)
 			mask |= CWBorderPixel;
 			Attr.colormap = Pcmap;
 			mask |= CWColormap;
-			Attr.cursor = XCreateFontCursor(dpy, XC_hand2);
-			mask |= CWCursor;         /* Window cursor */
+			if (!x11base->cursor) {
+				Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+				mask |= CWCursor;  /* Window cursor */
+			}
 			Attr.override_redirect = True;
 			mask |= CWOverrideRedirect;
 			WinPop = XCreateWindow(

--- a/modules/FvwmScript/Widgets/RadioButton.c
+++ b/modules/FvwmScript/Widgets/RadioButton.c
@@ -42,8 +42,10 @@ void InitRadioButton(struct XObj *xobj)
 	}
 
 	mask=0;
-	Attr.cursor=XCreateFontCursor(dpy,XC_hand2);
-	mask|=CWCursor;                /* Cursor for window */
+	if (!x11base->cursor) {
+		Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+		mask |= CWCursor;  /* Window cursor */
+	}
 	Attr.background_pixel=xobj->TabColor[back];
 	mask|=CWBackPixel;
 

--- a/modules/FvwmScript/Widgets/VScrollBar.c
+++ b/modules/FvwmScript/Widgets/VScrollBar.c
@@ -95,8 +95,10 @@ void InitVScrollBar(struct XObj *xobj)
 	mask = 0;
 	Attr.background_pixel = xobj->TabColor[back];
 	mask |= CWBackPixel;
-	Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
-	mask |= CWCursor;             /* Cursor for window */
+	if (!x11base->cursor) {
+		Attr.cursor = XCreateFontCursor(dpy,XC_hand2);
+		mask |= CWCursor;  /* Window cursor */
+	}
 
 	xobj->win = XCreateWindow(
 		dpy, *xobj->ParentWin, xobj->x, xobj->y, xobj->width,

--- a/modules/FvwmScript/types.h
+++ b/modules/FvwmScript/types.h
@@ -156,6 +156,7 @@ typedef struct
   char *hilicolor;
   int colorset;
   char *font;
+  char *cursor;
   char *icon;
   char *title;
   Bloc *periodictasks;


### PR DESCRIPTION
Hi Thomas.

This is patch 3/3. I had to rework it as configurable option, and not just to re-hardcode - to be acceptable for wider public.

Why:
Most of the FvwmScript widgets (push buttons, menus, checkboxes ...) are changing default cursor into XC_hand2. This is interesting but weird choice because no any other widget in my knowledge is using cursor symbol for hyperlinks, URLs, or pulling something (hand2) on objects/widgets of such nature. It looks weird.

However:
This default lasts long years, and there may be users who likes XC_hand2 on widgets or got used to this. Because of that, this patch is non-intrusive.

How:
It adds new FvwmScript configuration option "*FvwmScript DefaultCursor" which argument is cursor name from X11/cursorfont.h without "XC_" prefix - just like in CursorStyle FVWM option (it uses the same API from libs/Cursor.c).

Behaviour:
* if DefaultCursor option is present and valid, it changes cursor on widgets (for example to left_ptr)
* if DefaultCursor option is present and invalid, it is discarded and old behaviour takes a place
* if DefaultCursor option is not present, old behaviour takes a place

P. S.
I hope I was careful not to leave leaks and corpses behind it! :-)
