### PR TITLE
sticky windows: explicitly move to desk

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1554,8 +1554,6 @@ void do_move_window_to_desk(FvwmWindow *fw, int desk)
 	/*
 	 * Set the window's desktop, and map or unmap it as needed.
 	 */
-	/* Only change mapping for non-sticky windows */
-	if (!is_window_sticky_across_desks(fw) /*&& !IS_ICON_UNMAPPED(fw)*/)
 	{
 		if (fw->Desk == m->virtual_scr.CurrentDesk)
 		{


### PR DESCRIPTION
In the case of Fvwmbuttons subpanels, the windows are mapped in the void
and never moved, if the parent FvwmButtons changes desk.  When RandR
support was added, the separation caused this check to become important.
Therefore, remove it and allow sticky windows to be mapped correctly.

Fixes #224
