### PR TITLE
Fix window locations in Global mode

### DIFF
--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -918,7 +918,7 @@ void CMD_Send_WindowList(F_CMD_ARGS)
 
 		for (t = Scr.FvwmRoot.next; t != NULL; t = t->next)
 		{
-			if ((!(monitor_mode == MONITOR_TRACKING_G)) && t->m != m)
+			if ((monitor_mode == MONITOR_TRACKING_M) && t->m != m)
 				continue;
 
 			SendConfig(mod,M_CONFIGURE_WINDOW,t);

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -238,6 +238,23 @@ monitor_get_all_heights(void)
 }
 
 void
+monitor_assign_virtual(struct monitor *ref)
+{
+	struct monitor	*m;
+
+	if (monitor_mode == MONITOR_TRACKING_M)
+		return;
+
+	TAILQ_FOREACH(m, &monitor_q, entry) {
+		if (m == ref)
+			continue;
+
+		memcpy(&m->virtual_scr, &ref->virtual_scr, sizeof(m->virtual_scr));
+	}
+}
+
+
+void
 FScreenSelect(Display *dpy)
 {
 	XRRSelectInput(disp, DefaultRootWindow(disp),

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -163,6 +163,7 @@ void		 monitor_output_change(Display *, XRRScreenChangeNotifyEvent *);
 int		 monitor_get_all_widths(void);
 int		 monitor_get_all_heights(void);
 void		 monitor_add_new(void);
+void		 monitor_assign_virtual(struct monitor *);
 
 #define FSCREEN_MANGLE_USPOS_HINTS_MAGIC ((short)-32109)
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -972,10 +972,9 @@ void list_new_desk(unsigned long *body)
   int change_cs = -1;
   int change_ballooncs = -1;
   int change_highcs = -1;
-  int mon_num = body[1];
   struct fpmonitor *m;
 
-  m = fpmonitor_by_output(mon_num);
+  m = fpmonitor_this();
 
   if (monitor_to_track != NULL && strcmp(m->name, monitor_to_track) != 0)
 	  return;

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1903,7 +1903,9 @@ void SwitchToDesk(int Desk)
 	char command[256];
 	struct fpmonitor *m = fpmonitor_this();
 
-	sprintf(command, "GotoDesk %s 0 %d", m->name, Desk + desk1);
+	sprintf(command, "GotoDesk %s 0 %d", monitor_to_track ? m->name : "",
+			Desk + desk1);
+	fprintf(stderr, "%s: cmd: %s\n", __func__, command);
 	SendText(fd,command,0);
 }
 
@@ -1921,7 +1923,9 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
     vy = Event->xbutton.y * mon->virtual_scr.VHeight / (desk_h * mon->virtual_scr.MyDisplayHeight);
     mon->virtual_scr.Vx = vx * mon->virtual_scr.MyDisplayWidth;
     mon->virtual_scr.Vy = vy * mon->virtual_scr.MyDisplayHeight;
-    sprintf(command, "GotoDeskAndPage %s %d %d %d", mon->name, Desk + desk1, vx, vy);
+    sprintf(command, "GotoDeskAndPage %s %d %d %d",
+		monitor_to_track ? mon->name : "", Desk + desk1, vx, vy);
+    fprintf(stderr, "%s: cmd: %s\n", __func__, command);
     SendText(fd, command, 0);
 
   }
@@ -1941,8 +1945,8 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
       x = mon->virtual_scr.VxMax / mon->virtual_scr.MyDisplayWidth;
     if (y * mon->virtual_scr.MyDisplayHeight > mon->virtual_scr.VyMax)
       y = mon->virtual_scr.VyMax / mon->virtual_scr.MyDisplayHeight;
-    sprintf(command, "GotoPage %s %d %d", mon->name, x, y);
-    fprintf(stderr, "%s: going to page: %s %d, %d\n", __func__, mon->name, x, y);
+    sprintf(command, "GotoPage %s %d %d", monitor_to_track ? mon->name : "", x, y);
+    fprintf(stderr, "%s: cmd: %s\n", __func__, command);
     SendText(fd, command, 0);
   }
   Wait = 1;
@@ -1954,9 +1958,10 @@ void IconSwitchPage(XEvent *Event)
   struct fpmonitor *mon = fpmonitor_this();
 
   sprintf(command,"GotoPage %s %d %d",
-	  mon->name,
+	  monitor_to_track ? mon->name : "",
 	  Event->xbutton.x * mon->virtual_scr.VWidth / (icon_w * mon->virtual_scr.MyDisplayWidth),
 	  Event->xbutton.y * mon->virtual_scr.VHeight / (icon_h * mon->virtual_scr.MyDisplayHeight));
+  fprintf(stderr, "%s: cmd: %s\n", __func__, command);
   SendText(fd, command, 0);
   Wait = 1;
 }


### PR DESCRIPTION
Fix the locations of windows when in global mode.

Previous to this change, only windows on the active monitor were being
updated, leading to inconsistencies in where the windows were being placed.

- FvwmPager: respect DesktopConfiguration setting
- FvwmPager: list_new_desk: use this monitor
- global mode: track virtual_scr across all monitors
