### PR TITLE
Add support for infostore in EnvIsSet Test case

### DIFF
--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -2092,7 +2092,7 @@ void CMD_Test(F_CMD_ARGS)
 			{
 				const char *value;
 
-				if ( (strlen(var_name) > 10) && (memcmp(var_name,"infostore.",10) == 0)  )
+				if (memcmp(var_name,"infostore.",10) == 0)
 				{
 					value = get_metainfo_value(var_name+10);
 					match = (value != NULL) ? 1 : 0;

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -2090,9 +2090,18 @@ void CMD_Test(F_CMD_ARGS)
 			flags_ptr = GetNextSimpleOption(flags_ptr, &var_name);
 			if (var_name)
 			{
-				const char *value = getenv(var_name);
+				const char *value;
 
-				match = (value != NULL) ? 1 : 0;
+				if ( (strlen(var_name) > 10) && (memcmp(var_name,"infostore.",10) == 0)  )
+				{
+					value = get_metainfo_value(var_name+10);
+					match = (value != NULL) ? 1 : 0;
+				}
+				else
+				{
+					value = getenv(var_name);
+					match = (value != NULL) ? 1 : 0;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Hi @ThomasAdam 

EnvIsSet for infostore variables is something I missed a lot on 2.6.X FVWM, and I see it is still missing in FVWM3, so if there is no some good reason for not having it which is unknown to me, here is my humble proposal for enriching EnvIsSet Test case.
