### PR TITLE
Add variable/parameter which indicates the state of the FVWM3 logging

### DIFF
--- a/doc/fvwm/expansion.xml
+++ b/doc/fvwm/expansion.xml
@@ -518,6 +518,15 @@ command can be used:</para>
     </listitem>
   </varlistentry>
   <varlistentry>
+    <term>$[debuglog.state]</term>
+    <listitem>
+      <para>
+	Either <replaceable>0</replaceable> (debug log closed) or <replaceable>1</replaceable>.
+	Indicates the current state of debuging and logging facility.
+      </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
     <term>$[gt.<replaceable>str</replaceable>]</term>
     <listitem>
       <para>

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -41,6 +41,7 @@
 #include "libs/charmap.h"
 #include "libs/wcontext.h"
 #include "libs/Fsvg.h"
+#include "libs/log.h"
 
 /* ---------------------------- local definitions -------------------------- */
 
@@ -79,6 +80,7 @@ static char *function_vars[] =
 	"cw.width",
 	"cw.x",
 	"cw.y",
+	"debuglog.state",
 	"desk.height",
 	"desk.n",
 	"desk.pagesx",
@@ -167,6 +169,7 @@ enum
 	VAR_CW_WIDTH,
 	VAR_CW_X,
 	VAR_CW_Y,
+	VAR_DEBUG_LOG_STATE,
 	VAR_DESK_HEIGHT,
 	VAR_DESK_N,
 	VAR_DESK_PAGESX,
@@ -1055,6 +1058,10 @@ static signed int expand_vars_extended(
 		is_target = True;
 		target[0] = wcontext_wcontext_to_char(exc->w.wcontext);
 		target[1] = '\0';
+		break;
+	case VAR_DEBUG_LOG_STATE:
+		is_numeric = True;
+		val = log_get_level();
 		break;
 	default:
 		/* unknown variable - try to find it in the environment */

--- a/libs/log.c
+++ b/libs/log.c
@@ -43,6 +43,12 @@ log_set_level(int ll)
 	log_level = ll;
 }
 
+/* Get log level. */
+int log_get_level(void)
+{
+	return log_level;
+}
+
 /* Open logging to file. */
 void
 log_open(const char *fvwm_userdir)


### PR DESCRIPTION
Hi @ThomasAdam 

I realized that there is no way to check if logging and debugging with SIGUSR2 is currently enabled or disabled. This may lead to the situation that something opens the log, crash and not closes it, then "opens" it again, but actually closes it.
This is my proposal for new internal varible/parameter `$[debuglog.state]` with value 0 or 1 for checking this state.

P. S.
In libs/log.h I already found `log_get_level()` declared but unused in log.c when I wanted to declare it. So I'm probably on the trace of some forgotten idea. :-)
