### PR TITLE
EWMH area: don't crop the boundary

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -979,8 +979,8 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 		bottom = max(bottom, fw->strut.bottom);
 	}
 
-	w = m->si->x + m->si->w;
-	h = m->si->y + m->si->h;
+	w = m->si->x > 0 ? m->si->x : 0 + m->si->w;
+	h = m->si->y > 0 ? m->si->y : 0 + m->si->y + m->si->h;
 
 	x = left;
 	y = top;
@@ -1038,8 +1038,8 @@ void ewmh_HandleDynamicWorkArea(struct monitor *m)
 		dyn_bottom = max(dyn_bottom, fw->dyn_strut.bottom);
 	}
 
-	w = m->si->x + m->si->w;
-	h = m->si->y + m->si->h;
+	w = m->si->x > 0 ? m->si->x : 0 + m->si->w;
+	h = m->si->y > 0 ? m->si->y : 0 + m->si->y + m->si->h;
 	x = dyn_left;
 	y = dyn_top;
 	width  = w - (dyn_left + dyn_right);
@@ -1109,8 +1109,8 @@ void EWMH_GetWorkAreaIntersection(
 	}
 	nx = max(*x, area_x);
 	ny = max(*y, area_y);
-	nw = min(*x + *w, area_x + area_w) - nx;
-	nh = min(*y + *h, area_y + area_h) - ny;
+	nw = min(*x + *w, area_x + area_w);
+	nh = min(*y + *h, area_y + area_h);
 
 	*x = nx;
 	*y = ny;


### PR DESCRIPTION
When getting the working EWMH area, don't crop the boundary to the
screen edge.
