### PR TITLE
Fix Maximize on monitor 2

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1109,8 +1109,8 @@ void EWMH_GetWorkAreaIntersection(
 	}
 	nx = max(*x, area_x);
 	ny = max(*y, area_y);
-	nw = min(*x + *w, area_x + area_w);
-	nh = min(*y + *h, area_y + area_h);
+	nw = min(*w, area_w);
+	nh = min(*h, area_h);
 
 	*x = nx;
 	*y = ny;


### PR DESCRIPTION
Issue #250 
I have 2 monitors:
monitor 1: HDMI-2 connected primary 1920x1080+0+0
monitor 2: DVI-I-1 connected 1280x1024+1920+0

If I maximize a window on monitor 2, I get an oversized window: 1920x1080, instead of 1280x1024.

