### PR TITLE
desk_add: remove debug

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2668,8 +2668,6 @@ desk_add_fw(FvwmWindow *fw)
 			dfws = fxcalloc(1, sizeof *dfws);
 			dfws->fw = fw;
 			TAILQ_INSERT_TAIL(&df_loop->desk_fvwmwin_q, dfws, entry);
-			fvwm_debug(__func__, "1: added fw (%s) to mon %s, desk: %d",
-				fw->visible_name, fw->m->si->name, desk);
 			return;
 		}
 	}
@@ -2682,8 +2680,6 @@ desk_add_fw(FvwmWindow *fw)
 
 	TAILQ_INSERT_TAIL(&df->desk_fvwmwin_q, dfws, entry);
 	TAILQ_INSERT_TAIL(&desktop_fvwm_q, df, entry);
-	fvwm_debug(__func__, "2: added fw (%s) to mon %s, desk: %d",
-			fw->visible_name, fw->m->si->name, desk);
 }
 
 void


### PR DESCRIPTION
Although debugging lines were masked via fvwm_debug() when counting the
number of windows on a desk, this can get very chatty with large numbers
of windows open, and isn't all that useful.
