### PR TITLE
FvwmForm: use posix timer

### DIFF
--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -100,7 +100,7 @@ int colorset = -1;
 int itemcolorset = 0;
 
 /* global not exported */
-const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} };
+const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} }; /* interval = 100ms, value = 100ms */
 
 /* prototypes */
 static void RedrawSeparator(Item *item);
@@ -2607,9 +2607,9 @@ static void MainLoop(void)
     /*XFlush(dpy);*/
     if (fvwmSelect(fd_width, &fds, NULL, NULL, NULL) > 0) {
       if (FD_ISSET(Channel[1], &fds))
-	ReadFvwm();
+        ReadFvwm();
       if (FD_ISSET(fd_x, &fds))
-	ReadXServer();
+        ReadXServer();
     }
   }
 }
@@ -2677,7 +2677,6 @@ TimerHandler(int sig)
   }
   else {
     RedrawTimeout(timer);
-    setitimer(ITIMER_REAL, &itv_100ms, NULL);
   }
 
   SIGNAL_RETURN;

--- a/modules/FvwmForm/Makefile.am
+++ b/modules/FvwmForm/Makefile.am
@@ -51,7 +51,7 @@ config_DATA =             \
 ## so we might as well link against libXpm, if present.
 LDADD = -L$(top_builddir)/libs -lfvwm3 $(Xft_LIBS) $(X_LIBS)  \
 	$(X_PRE_LIBS) $(XRandR_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) \
-	-lm $(Xrender_LIBS) $(rsvg_LIBS) $(iconv_LIBS) $(Bidi_LIBS)
+	-lm -lrt $(Xrender_LIBS) $(rsvg_LIBS) $(iconv_LIBS) $(Bidi_LIBS)
 
 AM_CPPFLAGS = -I$(top_srcdir) $(Xft_CFLAGS) $(X_CFLAGS) $(iconv_CFLAGS) \
 	$(Bidi_CFLAGS) $(Xrender_CFLAGS)


### PR DESCRIPTION
The actual FvwmForm timer code is based on setitimer and signal management.
The setitimer man page lists the following bug:
"The generation and delivery of a signal are distinct, and only one instance of each of the signals listed above may be pending for a process. Under very heavy loading, an ITIMER_REAL timer may expire before the signal from a previous expiration has been delivered. The second signal in such an event will be lost."

I use FvwmForm to display the desktop name, for 400ms, each time desktop changes.
By changing desktop very often I - very rarely - manage to have a FvwmForm hang, lost in an infinite loop, with a 99% cpu usage. I then have to kill it with -KILL.
I debugged to find there was a missing TimerHandler call
So, I thought this was due to a signal loss as mentioned above. 

I tried to modify the code to solve that, and also because setitimer is considered deprecated.

Unfortunately, I still have the FvwmForm hang, with the same rare occurrence.

I let @ThomasAdam decide whether this PR is of interest.