### PR TITLE
FvwmForm: remove useless setitimer call

### DIFF
--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -100,7 +100,7 @@ int colorset = -1;
 int itemcolorset = 0;
 
 /* global not exported */
-const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} }; /* interval = 100ms, value = 100ms */
+const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} };
 
 /* prototypes */
 static void RedrawSeparator(Item *item);
@@ -2607,9 +2607,9 @@ static void MainLoop(void)
     /*XFlush(dpy);*/
     if (fvwmSelect(fd_width, &fds, NULL, NULL, NULL) > 0) {
       if (FD_ISSET(Channel[1], &fds))
-        ReadFvwm();
+	ReadFvwm();
       if (FD_ISSET(fd_x, &fds))
-        ReadXServer();
+	ReadXServer();
     }
   }
 }

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -100,7 +100,7 @@ int colorset = -1;
 int itemcolorset = 0;
 
 /* global not exported */
-const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} };
+const struct itimerval itv_100ms = { {0L, 100000L}, {0L, 100000L} }; /* interval = 100ms, value = 100ms */
 
 /* prototypes */
 static void RedrawSeparator(Item *item);
@@ -2607,9 +2607,9 @@ static void MainLoop(void)
     /*XFlush(dpy);*/
     if (fvwmSelect(fd_width, &fds, NULL, NULL, NULL) > 0) {
       if (FD_ISSET(Channel[1], &fds))
-	ReadFvwm();
+        ReadFvwm();
       if (FD_ISSET(fd_x, &fds))
-	ReadXServer();
+        ReadXServer();
     }
   }
 }
@@ -2677,7 +2677,6 @@ TimerHandler(int sig)
   }
   else {
     RedrawTimeout(timer);
-    setitimer(ITIMER_REAL, &itv_100ms, NULL);
   }
 
   SIGNAL_RETURN;


### PR DESCRIPTION
As the initial setitimer is configured with a periodic restart, the call in TimerHandler is useless.