### PR TITLE
FvwmForm: remove useless setitimer call

### DIFF
--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -2677,7 +2677,6 @@ TimerHandler(int sig)
   }
   else {
     RedrawTimeout(timer);
-    setitimer(ITIMER_REAL, &itv_100ms, NULL);
   }
 
   SIGNAL_RETURN;


### PR DESCRIPTION
As the initial setitimer is configured with a periodic restart, the call in TimerHandler is useless.