### PR TITLE
FvwmForm: use libevent for timer instead of signal

### DIFF
--- a/modules/FvwmForm/Makefile.am
+++ b/modules/FvwmForm/Makefile.am
@@ -51,9 +51,10 @@ config_DATA =             \
 ## so we might as well link against libXpm, if present.
 LDADD = -L$(top_builddir)/libs -lfvwm3 $(Xft_LIBS) $(X_LIBS)  \
 	$(X_PRE_LIBS) $(XRandR_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) \
-	-lm $(Xrender_LIBS) $(rsvg_LIBS) $(iconv_LIBS) $(Bidi_LIBS)
+	-lm $(Xrender_LIBS) $(rsvg_LIBS) $(iconv_LIBS) $(Bidi_LIBS) \
+	$(libevent_LIBS)
 
 AM_CPPFLAGS = -I$(top_srcdir) $(Xft_CFLAGS) $(X_CFLAGS) $(iconv_CFLAGS) \
-	$(Bidi_CFLAGS) $(Xrender_CFLAGS)
+	$(Bidi_CFLAGS) $(Xrender_CFLAGS) $(libevent_CFLAGS)
 
 CLEANFILES = $(module_SCRIPTS)


### PR DESCRIPTION
With the current signal based timer, FvwmForm sometimes falls into an infinite loop.
Using libevent is a tentative to avoid this hang.