### PR TITLE
PanFrames: per-monitor support

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2231,12 +2231,9 @@ ENTER_DBG((stderr, "en: exit: found LeaveNotify\n"));
 			int delta_x = 0;
 			int delta_y = 0;
 			XEvent e;
-			struct monitor	*m;
 
 			if (fw != NULL)
 				m = fw->m;
-			else
-				m = monitor_get_current();
 
 			/* this was in the HandleMotionNotify before, HEDU */
 			Scr.flags.is_pointer_on_this_screen = 1;

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -736,7 +736,6 @@ void list_add(unsigned long *body)
 	while(t != NULL)
 	{
 		//t->m = newm;
-		fprintf(stderr, "WINDOW %s: mon: %s\n", t->window_name, t->m->name);
 		if (t->w == cfgpacket->w)
 		{
 			/* it's already there, do nothing */


### PR DESCRIPTION
When `DesktopConfiguration per-monitor` is used, panframes need to be
enabled at monitor boundaries as well as outer edges.

Currently a WIP.

Helps with #285