### PR TITLE
FvwmPager: fix geometry string values when using @MONITORNAME

### DIFF
--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -631,11 +631,11 @@ void initialize_pager(void)
   if (xneg)
   {
     sizehints.win_gravity = NorthEastGravity;
-    window_x = mon->w - window_w + window_x;
+    window_x = monitor_get_all_widths() - window_w + window_x;
   }
   if (yneg)
   {
-    window_y = mon->h - window_h + window_y;
+    window_y = monitor_get_all_heights() - window_h + window_y;
     if(sizehints.win_gravity == NorthEastGravity)
       sizehints.win_gravity = SouthEastGravity;
     else


### PR DESCRIPTION
    When FvwmPager parses a geometry string with a monitor name embedded in
    it, such as:
    
        *FvwmPager: Geometry 100x90-0+0@MONITORNAME
    
    FvwmPager would not take into account MONITORNAME's dimensions, instead
    defaulting to the current monitor.
    
    This results from an incorrect use of global screen, vs specific screen.
    Geometry strings are treated as the global screen, so FvwmPager needs to
    use those values when calculating where to place its window.