### PR TITLE
FvwmButtons: Allow Title to contain just "-"

### DIFF
--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -1025,7 +1025,7 @@ static void ParseButton(button_info **uberb, char *s)
 					}
 				}
 				t = seekright(&s);
-				if (t && *t && (t[0] != '-' || t[1] != 0))
+				if (t && *t)
 				{
 					if (b->title)
 					{


### PR DESCRIPTION
FvwmButtons produces a blank title when using the following:

    *FvwmButtons: (1x1, Title "-")

The reason for this is the parsing code assumes anything with a leading
hyphen is a geometry string -- however, although this is true, the code
is too permissive in the check and should be relaxed.

Fixes #313
