### PR TITLE
CI: reduce IRC notification noise

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -47,20 +47,13 @@ jobs:
     runs-on: ubuntu-20.04
     name: notifications
     steps:
-      - name: irc push
-        uses: rectalogic/notify-irc@v1
-        if: github.event_name == 'push'
-        with:
-          channel: "#fvwm"
-          nickname: fvwm3-gh
-          message: ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
       - name: irc pull request
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'pull_request'
         with:
           channel: "#fvwm"
           nickname: fvwm3-gh
-          message: ${{ github.actor }} opened PR ${{ github.event.html_url }}
+          message: "PR: [${{ github.event.pull_request.number }}]: ${{ github.event.pull_request.title }} -- [${{ github.event.pull_request.user.login }}]"
       - name: irc tag created
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'create' && github.event.ref_type == 'tag'


### PR DESCRIPTION
Only notify for events which happen via pull-requests, rather than
pushes.