### PR TITLE
ewmh: compute workarea against all monitors

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -978,8 +978,8 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 		bottom = max(bottom, fw->strut.bottom);
 	}
 
-	w = m->si->x > 0 ? m->si->x : 0 + m->si->w;
-	h = m->si->y > 0 ? m->si->y : 0 + m->si->y + m->si->h;
+	w = monitor_get_all_widths();
+	h = monitor_get_all_heights();
 
 	x = left;
 	y = top;
@@ -1037,8 +1037,8 @@ void ewmh_HandleDynamicWorkArea(struct monitor *m)
 		dyn_bottom = max(dyn_bottom, fw->dyn_strut.bottom);
 	}
 
-	w = m->si->x > 0 ? m->si->x : 0 + m->si->w;
-	h = m->si->y > 0 ? m->si->y : 0 + m->si->y + m->si->h;
+	w = monitor_get_all_widths();
+	h = monitor_get_all_heights();
 	x = dyn_left;
 	y = dyn_top;
 	width  = w - (dyn_left + dyn_right);
@@ -1071,7 +1071,7 @@ void EWMH_GetWorkAreaIntersection(
 {
 	struct monitor	*m = (fw && fw->m) ? fw->m : monitor_get_current();
 
-	EWMH_UpdateWorkArea(m);
+	//EWMH_UpdateWorkArea(m);
 
 	int nx,ny,nw,nh;
 	int area_x = m->Desktops->ewmh_working_area.x;
@@ -1108,8 +1108,8 @@ void EWMH_GetWorkAreaIntersection(
 	}
 	nx = max(*x, area_x);
 	ny = max(*y, area_y);
-	nw = min(*w, area_w);
-	nh = min(*h, area_h);
+	nw = min(*x + *w, area_x + area_w) - nx;
+	nh = min(*y + *h, area_y + area_h) - ny;
 
 	*x = nx;
 	*y = ny;

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -1401,6 +1401,9 @@ void get_page_offset_check_visible(
 		get_page_offset(ret_page_x, ret_page_y, fw);
 	}
 
+	fprintf(stderr, "%s: MON: %s {page_x: %d, page_y: %d}\n",
+		__func__, fw->m->si->name, *ret_page_x, *ret_page_y);
+
 	return;
 }
 

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -4890,12 +4890,10 @@ void CMD_Maximize(F_CMD_ARGS)
 	/* Check if we should constrain rectangle to some Xinerama screen */
 	if (!is_screen_given)
 	{
-		fscreen_scr_arg fscr;
-
-		fscr.xypos.x = fw->g.frame.x + fw->g.frame.width  / 2 - page_x;
-		fscr.xypos.y = fw->g.frame.y + fw->g.frame.height / 2 - page_y;
-		FScreenGetScrRect(&fscr, FSCREEN_XYPOS,
-				  &scr_x, &scr_y, &scr_w, &scr_h);
+		scr_x = fw->m->si->x;
+		scr_y = fw->m->si->y;
+		scr_w = fw->m->si->w;
+		scr_h = fw->m->si->h;
 	}
 
 	if (!ignore_working_area)

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -582,6 +582,8 @@ FindScreen(fscreen_scr_arg *arg, fscreen_scr_t screen)
 		m = monitor_by_name(GLOBAL_SCREEN_NAME);
 		break;
 	case FSCREEN_PRIMARY:
+		m = monitor_by_primary();
+		break;
 	case FSCREEN_CURRENT:
 		/* translate to xypos format */
 		if (!arg)


### PR DESCRIPTION
When computing and setting the EWMH work area (which also implies
EwmhBaseStrut settings), calculate the struts relative to the overall
screen widths and heights.

Certain monitors with certain resolutions combined will often have "dead
space" which calculating per-monitor is a distorted value.  The window's
offset against the work area is calculated when placing/maimizing a
window, so doesn't incur per-monitor offsets.

Fixes #271, fixes #265, fixes #264, fixes #250
