### PR TITLE
FvwmEvent: comply better with the GPL

### DIFF
--- a/doc/modules/FvwmEvent.adoc
+++ b/doc/modules/FvwmEvent.adoc
@@ -203,7 +203,7 @@ can trigger the associated action.
   during the delay period are ignored. This option is useful when _fvwm_
   starts and restarts using an audio player. The default delay is 0.
 
-== COPYRIGHTS
+== HISTORY
 
 This module has evolved of _FvwmAudio_, which in term is heavily based
 on a similar Fvwm module called _FvwmSound_ by Mark Boyns. _FvwmAudio_
@@ -213,15 +213,6 @@ specific things on specific events, _FvwmEvent_ took this one step
 further and now calls any _fvwm_ function, or builtin-rplay. If _fvwm_'s
 Exec function is used, any external program can be called with any
 parameter.
-
-The concept for interfacing this module to the Window Manager, is
-original work by Robert Nation.
-
-Copyright 1998 Albrecht Kadlec. Copyright 1994, Mark Boyns and Mark
-Scott. No guarantees or warranties or anything are provided or implied
-in any way whatsoever. Use this program at your own risk. Permission to
-use and modify this program for any purpose is given, as long as the
-copyright is kept intact.
 
 == AUTHORS
 

--- a/modules/FvwmEvent/FvwmEvent.c
+++ b/modules/FvwmEvent/FvwmEvent.c
@@ -20,14 +20,7 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>
  */
 
-/*
- * This module is based on FvwmModuleDebugger which has the following
- * copyright:
- *
- * This module, and the entire ModuleDebugger program, and the concept for
- * interfacing this module to the Window Manager, are all original work
- * by Robert Nation
- */
+/* This module is based on FvwmModuleDebugger */
 
 /* ---------------------------- included header files ----------------------- */
 


### PR DESCRIPTION
Although fvwm has been under the GPL for some time, certain part of fvwm
(especially around modules) which have had different contriutions from
different authors over the years, have meant that certain copyright
messages have remained.

These copyright messages which are subject to modification as long as
said message remains intact, goes against the spirit of the GPL.
Indeed, in speaking with the authors in question, such practises were
common before the GPL was established as a means of licensing/modifiying
software.

The following authors were contacted and their responses indicate
they're happy for FvwmEvent's copyright notices to change:

* Mark Scott (2020-11-23):

	Thomas,

	Wow, it’s great to hear from someone keeping that old code alive!  I
	honestly had forgotten about ever even writing that code. 😊  You are
	sure welcome to do whatever you like with that code base.

	I hereby release all copyright claims to any FvwmSound or FvwmAudio
	related code. Feel free to re-license it under GPL or any other license
	you feel appropriate.

* Mark Boyns (2020-11-23):

	Hi Thomas, you found the correct Mark. You have my permission to update
	the license as needed. Good luck with fvwm and your open source
	projects.

This change therefore removes the explicit copyright notices regarding
the behaviour of the copyright notices, but still firmly records their
contributions to FvwmSound/FvwmEvent.

The man page has been updated to reflect this as well.
