### PR TITLE
FvwmButtons: comply better with the GPL

### DIFF
--- a/doc/modules/FvwmButtons.adoc
+++ b/doc/modules/FvwmButtons.adoc
@@ -1123,20 +1123,14 @@ DestroyModuleConfig FvwmButtons: *
 The action part of the Swallow option must be quoted if it contains any
 whitespace character.
 
-== COPYRIGHTS
+== HISTORY
 
 The FvwmButtons program, and the concept for interfacing this module to
 the Window Manager, are all original work by Robert Nation.
 
-Copyright 1993, Robert Nation. No guarantees or warranties or anything
-are provided or implied in any way whatsoever. Use this program at your
-own risk. Permission to use this program for any purpose is given, as
-long as the copyright is kept intact.
-
-Further modifications and patching by Jarl Totland, copyright 1996. The
-statement above still applies.
+Originally, FvwmGoodStuff preceeded FvwmButtons.
 
 == AUTHOR
 
-Robert Nation. Somewhat enhanced by Jarl Totland, Jui-Hsuan Joshua Feng,
-Scott Smedley.
+Robert Nation (1993). Somewhat enhanced by Jarl Totland (1996),
+Jui-Hsuan Joshua Feng, Scott Smedley.


### PR DESCRIPTION
Although fvwm has been under the GPL for some time, certain part of fvwm
(especially around modules) which have had different contriutions from
different authors over the years, have meant that certain copyright
messages have remained.

These copyright messages which are subject to modification as long as
said message remains intact, goes against the spirit of the GPL.
Indeed, in speaking with the authors in question, such practises were
common before the GPL was established as a means of licensing/modifiying
software.

The following authors were contacted and their responses indicate
they're happy for FvwmButtons's copyright notices to change:

* Jarl Totland (2020-11-23):

	Hi Thomas!

	Wow, that was a long time ago :) I see from github you have been hard at
	work on fvwm3 for some years, happy to hear my humble contribution is
	still useful today!  I trust you to make the right license decisions
	going forward and give you my full permission to change licensing as you
	see fit. Appreciate if my name stays in there somewhere as long as the
	code stays alive.

	Sincerely,
	-Jarl

The man page has been updated to reflect this change.
