### PR TITLE
freetype: don't clober CFLAGS/LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -582,6 +582,8 @@ AC_ARG_ENABLE(xft,
   ]
 )
 
+freetype_CFLAGS=""
+freetype_LIBS=""
 AH_TEMPLATE([HAVE_XFT],[Define if Xft library is used.])
 AH_TEMPLATE([HAVE_XFT2],[Define if Xft 2 library is used.])
 AH_TEMPLATE([HAVE_XFT_UTF8],[Define if Xft library can handle utf8 encoding])
@@ -591,14 +593,17 @@ if test ! x"$with_xft" = xno; then
     AC_MSG_RESULT([yes])
     CFLAGS_FREETYPE=`"${PKG_CONFIG}" --cflags freetype2`
     FREETYPE_LIBS=`"${PKG_CONFIG}" --libs freetype2`
-    CFLAGS="$CFLAGS $CFLAGS_FREETYPE"
-    LIBS="$LIBS $FREETYPE_LIBS"
+    freetype_CFLAGS="$CFLAGS_FREETYPE"
+    freetype_LIBS="$FREETYPE_LIBS"
 
     have_freetype=yes
   else
   AC_MSG_RESULT([no])
   have_freetype=no
   fi
+
+  AC_SUBST(freetype_CFLAGS)
+  AC_SUBST(freetype_LIBS)
 
   # check for fontconfig for Xft 2
   have_fontconfig=no

--- a/modules/FvwmAnimate/Makefile.am
+++ b/modules/FvwmAnimate/Makefile.am
@@ -13,7 +13,7 @@ FvwmAnimate_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 ## so we might as well link against libXpm, if present.
 LDADD = -L$(top_builddir)/libs $(X_LIBS) -lfvwm3 $(xpm_LIBS) \
 	$(X_PRE_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) -lm $(png_LIBS) \
-	$(rsvg_LIBS) $(Xrender_LIBS) $(Xcursor_LIBS)
+	$(rsvg_LIBS) $(Xrender_LIBS) $(Xcursor_LIBS) $(freetype_LIBS)
 
 AM_CPPFLAGS = -I$(top_srcdir) $(xpm_CFLAGS) $(X_CFLAGS) \
-	$(png_CFLAGS) $(Xrender_CFLAGS)
+	$(png_CFLAGS) $(Xrender_CFLAGS) $(freetype_CFLAGS)

--- a/modules/FvwmAuto/Makefile.am
+++ b/modules/FvwmAuto/Makefile.am
@@ -9,7 +9,8 @@ FvwmAuto_SOURCES = FvwmAuto.c
 FvwmAuto_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 
 LDADD = -L$(top_builddir)/libs $(X_LIBS) -lfvwm3  \
-	$(X_PRE_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) $(XRandR_LIBS)
+	$(X_PRE_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) $(XRandR_LIBS) \
+	$(freetype_LIBS)
 
-AM_CPPFLAGS = -I$(top_srcdir) $(X_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) $(X_CFLAGS) $(freetype_CFLAGS)
 

--- a/modules/FvwmBacker/Makefile.am
+++ b/modules/FvwmBacker/Makefile.am
@@ -15,7 +15,7 @@ FvwmBacker_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 
 LDADD = -L$(top_builddir)/libs $(X_LIBS) -lfvwm3 \
 	$(X_PRE_LIBS) $(XRandR_LIBS) -lXext -lX11 -lm $(X_EXTRA_LIBS) \
-	$(Xrender_LIBS) $(rsvg_LIBS)
+	$(Xrender_LIBS) $(rsvg_LIBS) $(freetype_LIBS)
 
-AM_CPPFLAGS = -I$(top_srcdir) $(X_CFLAGS) $(Xrender_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) $(X_CFLAGS) $(Xrender_CFLAGS) $(freetype_CFLAGS)
 

--- a/modules/FvwmEvent/Makefile.am
+++ b/modules/FvwmEvent/Makefile.am
@@ -9,6 +9,6 @@ FvwmEvent_SOURCES = FvwmEvent.c
 FvwmEvent_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 
 LDADD = -L$(top_builddir)/libs $(X_LIBS) -lfvwm3 \
-	$(X_PRE_LIBS) -lXext -lX11 $(X_EXTRA_LIBS)
+	$(X_PRE_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) $(freetype_LIBS)
 
-AM_CPPFLAGS = -I$(top_srcdir) $(X_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) $(X_CFLAGS) $(freetype_CFLAGS)


### PR DESCRIPTION
When detecting Freetype, don't include its own compilation information
directly in CFLAGS/LDFLAGS.  Instead, separate this out.

This fixes the case where a user could override CFLAGS as in:

    make CFLAGS="-O0 -ggdb" -j $(nproc)

yet freetype clobbers this, resulting in freetype not being detected.
