### PR TITLE
status: track sticky windows to current desk

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -5198,6 +5198,8 @@ static void __handle_stick_exit(
 		BroadcastConfig(M_CONFIGURE_WINDOW,fw);
 		EWMH_SetWMState(fw, False);
 		EWMH_SetWMDesktop(fw);
+
+		desk_add_fw(fw);
 	}
 
 	return;


### PR DESCRIPTION
When a window transitions out of being sticky (and has therefore changed
desks), the Status command tracking wasn't updating the desk the window
was on.

This change fixes that by updating the desk information.

Fixes #331