### PR TITLE
libs: remove CatString2/CatString3

### DIFF
--- a/fvwm/functions.c
+++ b/fvwm/functions.c
@@ -553,10 +553,6 @@ static void __execute_function(
 			must_free_string = set_repeat_data(
 				expaction, REPEAT_COMMAND, bif);
 		}
-		else
-		{
-			must_free_string = True;
-		}
 	}
 	else
 	{
@@ -674,10 +670,6 @@ static void __execute_function(
 	if (cond_rc != NULL)
 	{
 		cond_rc->break_levels = func_rc->break_levels;
-	}
-	if (must_free_string)
-	{
-		free(expaction);
 	}
 	if (must_free_function)
 	{

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -107,8 +107,12 @@ void ModuleConfig(char *action)
 			{
 				name = MOD_ALIAS(module);
 			}
+			char *modstring;
+
+			xasprintf(&modstring, "%s%s", "*", name);
 			SendConfigToModule(
-				module, new_entry, CatString2("*", name), 0);
+				module, new_entry, modstring, 0);
+			free(modstring);
 		}
 	}
 
@@ -141,7 +145,7 @@ static struct moduleInfoList *AddToModList(char *tline)
 		char *conf_start = alias_end + 1;
 		while (isspace(*conf_start)) conf_start++;
 		*alias_end = '\0';
-		rline = CatString2(tline, conf_start);
+		xasprintf(&rline, "%s%s", tline, conf_start);
 		*alias_end = MODULE_CONFIG_DELIM;
 		this->alias_len = alias_end - tline;
 	}
@@ -150,6 +154,7 @@ static struct moduleInfoList *AddToModList(char *tline)
 	this->data = expand_vars(rline, NULL, False, True, NULL, exc);
 	strcpy(this->data, rline);
 	exc_destroy_context(exc);
+	free(rline);
 
 	this->next = NULL;
 	if(prev == NULL)
@@ -192,11 +197,15 @@ void CMD_DestroyModuleConfig(F_CMD_ARGS)
 		{
 			return;
 		}
-		info = stripcpy(CatString2(action, conf_start));
+		char *aconf;
+
+		xasprintf(&aconf, "%s%s", action, conf_start);
+		info = stripcpy(aconf);
 		*alias_end = MODULE_CONFIG_DELIM;
 		/* +1 for a leading '*' */
 		alias_len = alias_end - action + 1;
 		free(conf_start);
+		free(aconf);
 	}
 	else
 	{

--- a/fvwm/module_list.c
+++ b/fvwm/module_list.c
@@ -832,23 +832,23 @@ static void KillModuleByName(char *name, char *alias)
 
 static char *get_pipe_name(fmodule *module)
 {
-	char *name="";
+	char *name;
 
 	if (MOD_NAME(module) != NULL)
 	{
 		if (MOD_ALIAS(module) != NULL)
 		{
-			name = CatString3(
-				MOD_NAME(module), " ", MOD_ALIAS(module));
+			xasprintf(&name, "%s %s", MOD_NAME(module),
+			    MOD_ALIAS(module));
 		}
 		else
 		{
-			name = MOD_NAME(module);
+			xasprintf(&name, "%s", MOD_NAME(module));
 		}
 	}
 	else
 	{
-		name = CatString3("(null)", "", "");
+		name = fxstrdup("(null)");
 	}
 
 	return name;
@@ -1005,6 +1005,7 @@ void FlushMessageQueue(fmodule *module)
 						   name, rc, isTerminated ?
 						   'Y' : 'N');
 					module_kill(module);
+					free(name);
 
 					return;
 				}

--- a/fvwm/read.c
+++ b/fvwm/read.c
@@ -195,7 +195,7 @@ int run_command_file(
 	char *filename, const exec_context_t *exc)
 {
 	char *full_filename;
-	FILE* f = NULL;
+	FILE *f = NULL;
 
 	/* We attempt to open the filename by doing the following:
 	 *
@@ -216,7 +216,7 @@ int run_command_file(
 	 *
 	 *    ./.foo
 	 */
-	full_filename = filename;
+	full_filename = fxstrdup(filename);
 
 	if (full_filename[0] == '/')
 	{
@@ -226,29 +226,35 @@ int run_command_file(
 		/* It's a relative path.  Check in either FVWM_USERDIR or
 		 * FVWM_DATADIR.
 		 * */
-		full_filename = CatString3(fvwm_userdir, "/", filename);
+		free(full_filename);
+		xasprintf(&full_filename, "%s/%s", fvwm_userdir, filename);
 
 		if((f = fopen(full_filename, "r")) == NULL)
 		{
-			full_filename = CatString3(
-					FVWM_DATADIR, "/", filename);
+			free(full_filename);
+			xasprintf(&full_filename, "%s/%s", FVWM_DATADIR, filename);
 			f = fopen(full_filename, "r");
 		}
 	}
 
 	if ((f == NULL) &&
 		(f = fopen(filename, "r")) == NULL) {
+
 		/* We really couldn't open the file. */
+		free(full_filename);
 		return 0;
 	}
 
 	if (push_read_file(full_filename) == 0)
 	{
+		free(full_filename);
 		return 0;
 	}
 	run_command_stream(NULL, f, exc);
 	fclose(f);
 	pop_read_file();
+
+	free(full_filename);
 
 	return 1;
 }

--- a/libs/Fft.c
+++ b/libs/Fft.c
@@ -309,22 +309,24 @@ FftFontType *FftGetFont(Display *dpy, char *fontname, char *module)
 		if ((fc = FlocaleCharsetGetFLCXOMCharset()) != NULL &&
 		    StrEquals(fc->x,FLC_FFT_ENCODING_ISO8859_1))
 		{
-			fn = CatString2(fontname,":encoding=ISO8859-1");
+			xasprintf(&fn, "%s%s", fontname, ":encoding=ISO8859-1");
 		}
 		else
 		{
-			fn = CatString2(fontname,":encoding=ISO10646-1");
+			xasprintf(&fn, fontname, ":encoding=ISO10646-1");
 		}
 	}
 	else
 	{
-		fn = fontname;
+		fn = fxstrdup(fontname);
 	}
 	SUPPRESS_UNUSED_VAR_WARNING(fn);
 	if ((src_pat = FftNameParse(fn)) == NULL)
 	{
+		free(fn);
 		goto bail;
 	}
+	free(fn);
 	SUPPRESS_UNUSED_VAR_WARNING(result);
 	if ((load_pat = FftFontMatch(dpy, fftscreen, src_pat, &result)) == NULL)
 	{

--- a/libs/Ficonv.c
+++ b/libs/Ficonv.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #include <stdio.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include <X11/Xlib.h>
 
@@ -87,29 +88,40 @@ Bool is_iconv_supported(char *c1, char *c2)
 static
 char *translit_csname(char *cs)
 {
-	return CatString2(cs, TRANSLIT_SUFFIX);
+	char	*cpy;
+
+	xasprintf(&cpy, "%s%s", cs, TRANSLIT_SUFFIX);
+	return (cpy);
 }
 
 static
 int is_translit_supported(char *c1, char *c2)
 {
 	Ficonv_t cd;
+	char	*fname;
 
 	if (!FiconvSupport || !c1 || !c2)
 		return 0;
 
-	cd = Ficonv_open(translit_csname(c1),c2);
+	fname = translit_csname(c1);
+	cd = Ficonv_open(fname,c2);
 	if (cd == (Ficonv_t) -1)
 	{
+		free(fname);
 		return 0;
 	}
 	(void)Ficonv_close(cd);
-	cd = Ficonv_open(translit_csname(c2),c1);
+	free(fname);
+
+	fname = translit_csname(c2);
+	cd = Ficonv_open(fname,c1);
 	if (cd == (Ficonv_t) -1)
 	{
+		free(fname);
 		return 0;
 	}
 	(void)Ficonv_close(cd);
+	free(fname);
 
 	return 1;
 }

--- a/libs/PictureBase.c
+++ b/libs/PictureBase.c
@@ -261,9 +261,10 @@ char* PictureFindImageFile(const char* icon, const char* pathlist, int type)
 			   who want to access the file on disk will have
 			   to remove these prepended options themselves.
 			   The format is ":svg_opts:/path/to/file.svg". */
-			tmpbuf = CatString3(render_opts, ":", full_filename);
+			xasprintf(&tmpbuf, "%s:%s", render_opts, full_filename);
 			free(full_filename);
 			full_filename = fxstrdup(tmpbuf);
+			free(tmpbuf);
 		}
 	}
 

--- a/libs/Strings.c
+++ b/libs/Strings.c
@@ -23,52 +23,6 @@
 #include "safemalloc.h"
 #include "Strings.h"
 
-
-#define CHUNK_SIZE 256
-char *CatString3(const char *a, const char *b, const char *c)
-{
-	static char* buffer = NULL;
-	static int buffer_len = 0;
-	int len = 1;
-
-	if (a != NULL)
-	{
-		len += strlen(a);
-	}
-	if (b != NULL)
-	{
-		len += strlen(b);
-	}
-	if (c != NULL)
-	{
-		len += strlen(c);
-	}
-
-	/* Expand buffer to fit string, to a multiple of CHUNK_SIZE */
-	if (len > buffer_len)
-	{
-		buffer_len = CHUNK_SIZE * (1 + ((len - 1) / CHUNK_SIZE));
-		buffer = fxrealloc(buffer, buffer_len, buffer_len);
-	}
-	buffer[0] = 0;
-	if (a != NULL)
-	{
-		strcat(buffer, a);
-	}
-	if (b != NULL)
-	{
-		strcat(buffer, b);
-	}
-	if (c != NULL)
-	{
-		strcat(buffer, c);
-	}
-
-	return buffer;
-}
-#undef CHUNK_SIZE
-
-
 void CopyString(char **dest, const char *source)
 {
 	int len;

--- a/libs/Strings.h
+++ b/libs/Strings.h
@@ -2,18 +2,6 @@
 #ifndef FVWMLIB_STRINGS_H
 #define FVWMLIB_STRINGS_H
 
-
-/**
- * Concatenate three strings.
- *
- * Parameters may be NULL to signify the empty string.
- *
- * Returns pointer to static storage, overwritten on the next call.
- **/
-char *CatString3(const char *a, const char *b, const char *c);
-#define CatString2(a,b) CatString3(a,b,NULL)
-
-
 /**
  * Copy string into newly-malloced memory, stripping leading and
  * trailing spaces.  The string is terminated by either a NUL or

--- a/modules/FvwmAuto/FvwmAuto.c
+++ b/modules/FvwmAuto/FvwmAuto.c
@@ -260,8 +260,10 @@ main(int argc, char **argv)
 			token = PeekToken(enter_fn, NULL);
 			if (!StrEquals(token, "Silent"))
 			{
-				enter_fn = fxstrdup(
-					CatString2("Silent ", enter_fn));
+				char *t;
+				xasprintf(&t, "Silent %s", enter_fn);
+				enter_fn = fxstrdup(t);
+				free(t);
 			}
 		}
 		/*** leave command ***/
@@ -283,8 +285,10 @@ main(int argc, char **argv)
 			token = PeekToken(leave_fn, NULL);
 			if (!StrEquals(token, "Silent"))
 			{
-				leave_fn = fxstrdup(
-					CatString2("Silent ", leave_fn));
+				char *t;
+				xasprintf(&t, "Silent %s", leave_fn);
+				leave_fn = fxstrdup(t);
+				free(t);
 			}
 		}
 	}
@@ -307,11 +311,14 @@ main(int argc, char **argv)
 	}
 	/* Disable special raise/lower support on general actions. *
 	 * This works as expected in most of cases. */
-	if (matchWildcards("*Raise*", CatString2(enter_fn, leave_fn)) ||
-	    matchWildcards("*Lower*", CatString2(enter_fn, leave_fn)))
+	char *rl;
+	xasprintf(&rl, "%s%s", enter_fn, leave_fn);
+	if (matchWildcards("*Raise*", rl) ||
+	    matchWildcards("*Lower*", rl))
 	{
 		m_mask |= M_RAISE_WINDOW | M_LOWER_WINDOW;
 	}
+	free(rl);
 
 	/* migo (04/May/2000): It is simply incorrect to listen to raise/lower
 	 * packets and change the state if the action itself has no raise/lower.

--- a/modules/FvwmBacker/FvwmBacker.c
+++ b/modules/FvwmBacker/FvwmBacker.c
@@ -140,7 +140,8 @@ int main(int argc, char **argv)
 	}
 
 	Module = temp;
-	configPrefix = CatString2("*", Module);
+
+	xasprintf(&configPrefix, "*%s", Module);
 
 	if ((argc != 6) && (argc != 7))
 	{
@@ -695,8 +696,7 @@ void AddCommand(char *line)
 	}
 	else
 	{
-		fvwm_debug(__func__,
-			   CatString2("Unknown directive: ", line));
+		fvwm_debug(__func__, "Unknown directive: %s", line);
 		return;
 	}
 	this->flags.do_ignore_desk = do_ignore_desk;

--- a/modules/FvwmButtons/dynamic.c
+++ b/modules/FvwmButtons/dynamic.c
@@ -60,7 +60,10 @@ static void show_error(const char *msg, ...)
 		return;
 	}
 	va_start(args, msg);
-	vfprintf(stderr, CatString3(MyName, ": ", msg), args);
+	if (msg != NULL) {
+		vfprintf(stderr, msg, args);
+		fprintf(stderr, ": ");
+	}
 	va_end(args);
 }
 

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -81,6 +81,7 @@ char bg_state = 'd';			/* in default state */
 char endDefaultsRead = 'n';
 char *font_names[4];
 char *screen_background_color;
+char *mname;
 static ModuleArgs *module;
 int Channel[2];
 Bool Swallowed = False;
@@ -337,7 +338,7 @@ static void ParseConfigLine(char *buf)
     LoadColorset(&buf[8]);
     return;
   }
-  if (strncasecmp(buf, CatString3("*",module->name,0), module->namelen+1) != 0) {/* If its not for me */
+  if (strncasecmp(buf, mname, module->namelen+1) != 0) {/* If its not for me */
     return;
   } /* Now I know its for me. */
   p = buf+module->namelen+1;		      /* jump to end of my name */
@@ -1305,7 +1306,7 @@ static void ReadConfig(void)
 {
   char *line_buf;			/* ptr to curr config line */
 
-  InitGetConfigLine(Channel,CatString3("*",module->name,0));
+  InitGetConfigLine(Channel, mname);
   while (GetConfigLine(Channel,&line_buf),line_buf) { /* get config from fvwm */
     ParseConfigLine(line_buf);		/* process config lines */
   }
@@ -2508,10 +2509,7 @@ static void ParseActiveMessage(char *buf)
 		return;
 	}
 #endif
-	if (
-		strncasecmp(
-			buf, CatString3("*",module->name,0),
-			module->namelen+1) != 0)
+	if (strncasecmp(buf, mname, module->namelen+1) != 0)
 	{
 		/* If its not for me */
 		return;
@@ -2681,6 +2679,8 @@ int main (int argc, char **argv)
 	    "FvwmForm Version "VERSION" should only be executed by fvwm!\n");
     exit(1);
   }
+
+  xasprintf(&mname, "*%s", module->name);
 
 #ifdef HAVE_SIGACTION
   {

--- a/modules/FvwmIdent/FvwmIdent.c
+++ b/modules/FvwmIdent/FvwmIdent.c
@@ -74,6 +74,7 @@ static int x_fd;
 
 static char *yes = "Yes";
 static char *no = "No";
+static char *mname;
 
 /* default colorset to use, set to -1 when explicitly setting colors */
 static int colorset = 0;
@@ -134,6 +135,8 @@ int main(int argc, char **argv)
 			   " by fvwm!\n", VERSION);
 		exit(1);
 	}
+
+	xasprintf(&mname, "*%s", module->name);
 
 #ifdef HAVE_SIGACTION
 	{
@@ -207,7 +210,7 @@ int main(int argc, char **argv)
 	/* scan config file for set-up parameters */
 	/* Colors and fonts */
 
-	InitGetConfigLine(fd,CatString3("*",module->name,0));
+	InitGetConfigLine(fd, mname);
 	GetConfigLine(fd,&tline);
 
 	while (tline != (char *)0)
@@ -216,9 +219,7 @@ int main(int argc, char **argv)
 		{
 			continue;
 		}
-		if (strncasecmp(tline,
-				CatString3("*",module->name,0),
-				module->namelen+1) == 0)
+		if (strncasecmp(tline, mname, module->namelen+1) == 0)
 		{
 			tline += (module->namelen +1);
 			if (strncasecmp(tline, "Font", 4) == 0)

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -1784,6 +1784,7 @@ static void SetDeskLabel(struct fpmonitor *m, int desk, const char *label)
 void ParseOptions(void)
 {
   char *tline= NULL;
+  char *mname;
   int desk;
   int dx = 3;
   int dy = 3;
@@ -1797,7 +1798,11 @@ void ParseOptions(void)
   {
 	  fpa.mask |= FPAM_DITHER;
   }
-  InitGetConfigLine(fd,CatString3("*",MyName,0));
+
+  xasprintf(&mname, "*%s", MyName);
+  InitGetConfigLine(fd, mname);
+  free(mname);
+
   for (GetConfigLine(fd,&tline); tline != NULL; GetConfigLine(fd,&tline))
   {
     int g_x, g_y, flags;

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -85,7 +85,7 @@ void setFvwmUserDir(void)
   FvwmUserDir = getenv("FVWM_USERDIR");
   if (FvwmUserDir == NULL)
   {
-    FvwmUserDir = fxstrdup(CatString2(home_dir, "/.fvwm"));
+    xasprintf(&FvwmUserDir, "%s/.fvwm", home_dir);
   }
 }
 
@@ -1871,8 +1871,9 @@ static void Key (int NbArg,long *TabArg)
     free(tmp);
   }
 
-  tmp = fxstrdup(CatString3(widget, " ", sig));
-  action = fxstrdup(CatString3(tmp, " ", str));
+  xasprintf(&tmp, "%s %s", widget, sig);
+  xasprintf(&action, "%s %s", tmp, str);
+
   free(sig);
   free(widget);
   free(str);


### PR DESCRIPTION
CatString2 and CatString3 provided a means of concatenating either two
or three variables together.  However, the callers of these don't get to
specify a format string, as in:

    "%s %s"

which breaks compiling fvwm3 with:

    CFLAGS="-Wformat -Werror=format-security"

Given these wrappers are inflexible, and that xasprintf() already exists
in the codebase, switch to using that.

Fixes #334
