### PR TITLE
Make bin/FvwmCommand.in use @PYTHON@

### DIFF
--- a/bin/FvwmCommand.in
+++ b/bin/FvwmCommand.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!@PYTHON@
 
 import socket
 import getopt


### PR DESCRIPTION
We both missed the fact that python path can be placed by automake. I have replaced `#!/usr/bin/env python3` with `#!@PYTHON@` in bin/FvwmCommand.in
