### PR TITLE
FvwmConsole: add missing freetype libs/cflags

### DIFF
--- a/modules/FvwmConsole/Makefile.am
+++ b/modules/FvwmConsole/Makefile.am
@@ -22,10 +22,12 @@ FvwmConsoleC_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 EXTRA_DIST = FvwmConsoleC.pl.in Changes .fvwm2rc.sample
 
 # Use X_EXTRA_LIBS to get socket(), etc.
-LDADD = -L$(top_builddir)/libs -lfvwm3 $(readline_LIBS) $(X_EXTRA_LIBS)
+LDADD = -L$(top_builddir)/libs -lfvwm3 $(readline_LIBS) $(freetype_LIBS) \
+	$(X_EXTRA_LIBS)
 
 # FIXME:
 # Despite not using X functions explicitly, the code includes
 # fvwmlib.h, which *does* include X headers and xpm.h!
-AM_CPPFLAGS = -I$(top_srcdir) $(readline_CFLAGS) $(xpm_CFLAGS) $(X_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir) $(readline_CFLAGS) $(xpm_CFLAGS) \
+	      $(freetype_CFLAGS) $(X_CFLAGS)
 endif !FVWM_BUILD_GOLANG


### PR DESCRIPTION
If fvwm3 is compiled without --enable-golang, then FvwmConsole defaults
to being built.  In ccfad7759 (freetype: don't clober CFLAGS/LDFLAGS,
2020-12-06), this was changed to split out freetype's compile-time
LIBS/CFLAGS, but was missed from FvwmConsole as this is not built
routinely.
