### PR TITLE
ewmhbasestruts: handle `0 0 0 0` when maximizing

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -978,11 +978,11 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 		bottom = max(bottom, fw->strut.bottom);
 	}
 
+	x = left;
+	y = top;
 	w = monitor_get_all_widths();
 	h = monitor_get_all_heights();
 
-	x = left;
-	y = top;
 	width =  w - (left + right);
 	height = h - (top + bottom);
 
@@ -1037,10 +1037,11 @@ void ewmh_HandleDynamicWorkArea(struct monitor *m)
 		dyn_bottom = max(dyn_bottom, fw->dyn_strut.bottom);
 	}
 
-	w = monitor_get_all_widths();
-	h = monitor_get_all_heights();
 	x = dyn_left;
 	y = dyn_top;
+	w = monitor_get_all_widths();
+	h = monitor_get_all_heights();
+
 	width  = w - (dyn_left + dyn_right);
 	height = h - (dyn_top + dyn_bottom);
 
@@ -1071,7 +1072,7 @@ void EWMH_GetWorkAreaIntersection(
 {
 	struct monitor	*m = (fw && fw->m) ? fw->m : monitor_get_current();
 
-	//EWMH_UpdateWorkArea(m);
+	EWMH_UpdateWorkArea(m);
 
 	int nx,ny,nw,nh;
 	int area_x = m->Desktops->ewmh_working_area.x;

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2458,12 +2458,12 @@ int main(int argc, char **argv)
 	Scr.gray_bitmap =
 		XCreateBitmapFromData(dpy,Scr.Root,g_bits, g_width,g_height);
 
-	TAILQ_FOREACH(m, &monitor_q, entry)
-		EWMH_Init(m);
-
 	/* This should be done early enough to have the window states loaded
 	 * before the first call to AddWindow. */
 	LoadWindowStates(state_filename);
+
+	TAILQ_FOREACH(m, &monitor_q, entry)
+		EWMH_Init(m);
 
 	SetRCDefaults();
 	flush_window_updates();


### PR DESCRIPTION
When EwmhBaseStruts was set to '0 0 0 0', the strut values were computed
to 0, since the width of the overall monitor was calculated incorrectly.

Fixes #143