### PR TITLE
config parsing: be more tolerant when finding configs

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2492,7 +2492,7 @@ int main(int argc, char **argv)
 		 *   /usr/local/etc/system.fvwm2rc
 		 */
 		int upper = 8;
-		int nl = 0, tries = 0;
+		int nl = -1, tries = 0;
 		char *cfg_loc[upper];
 
 		xasprintf(&cfg_loc[++nl], "%s/%s", fvwm_userdir, FVWM_CONFIG);
@@ -2505,8 +2505,14 @@ int main(int argc, char **argv)
 		xasprintf(&cfg_loc[++nl], "%s/default-config/config", FVWM_DATADIR);
 
 		for (nl = 0; nl < upper; nl++) {
-			if (!run_command_file(cfg_loc[nl], exc))
+			if (!run_command_file(cfg_loc[nl], exc)) {
+				fvwm_debug(__func__,
+				    "couldn't find/load [%d]: %s\n", nl, cfg_loc[nl]);
 				tries++;
+			} else {
+				fprintf(stderr, "loaded [%d]: %s\n", nl, cfg_loc[nl]);
+				break;
+			}
 		}
 
 		if (tries == upper) {


### PR DESCRIPTION
When looking for which config file to load by default (that is, without
invoking fvwm with '-f'), there is a long compatibility list of file
locations to look through.

Fix an off-by-one error in array assignment, and also break out of the
compatibility loop once we have found a config file to load -- we don't
want to clobber that file by continuing down the list; the first match
always wins, which for most people will be ~/.fvwm/config

Noticed by Brandon Martin (codedmart) on #fvwm IRC.
