### PR TITLE
Startup: reinstate session functions

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1546,7 +1546,7 @@ void StartupStuff(void)
 	{
 		char *action;
 
-		xasprintf(&action, "Function ", init_func_name);
+		xasprintf(&action, "Function %s", init_func_name);
 		execute_function(NULL, exc, action, 0);
 		free(action);
 	}


### PR DESCRIPTION
When fvwm starts up, it looks for functions such as InitFunction, etc.
This was inadvertently lost during
841524a34 (libs: remove CatString2/CatString3, 2020-12-08)
