### PR TITLE
panframes: recheck for all monitors

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2555,10 +2555,6 @@ int main(int argc, char **argv)
 		dpy, Scr.Root, 0, 0, 1, 1, 0, Pdepth,
 		InputOutput, Pvisual, valuemask, &attributes);
 	resize_geometry_window();
-	initPanFrames();
-	MyXGrabServer(dpy);
-	checkPanFrames();
-	MyXUngrabServer(dpy);
 	CoerceEnterNotifyOnCurrentWindow();
 	SessionInit();
 


### PR DESCRIPTION
When PanFrames need to be checked, do so for all monitors, and not just the current monitor.  Without this, EdgeCommand won't be applied to all monitors.
