### PR TITLE
PaneFrames: disallow Edge/Leave without direction

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2223,6 +2223,7 @@ ENTER_DBG((stderr, "en: exit: found LeaveNotify\n"));
 		}
 		else if (edge_command)
 		{
+			fvwm_debug(__func__, "EC is: %s", edge_command);
 			execute_function(NULL, ea->exc, edge_command, 0);
 		}
 		else


### PR DESCRIPTION
Using EdgeCommand without a direction is now invalid - and hence to
clear a Edge/Leave command, the following has to be used:

    EdgeCommand Right
