### PR TITLE
Edgecommands: silence warnings

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1850,7 +1850,7 @@ char *GetDesktopName(struct monitor *m, int desk)
 void CMD_EdgeCommand(F_CMD_ARGS)
 {
 	direction_t direction;
-	char *command = NULL, *actdup, *rest;
+	char *command = NULL, *actdup = NULL, *rest;
 	struct monitor	*m;
 
 	if (action != NULL)
@@ -1927,7 +1927,7 @@ void CMD_EdgeCommand(F_CMD_ARGS)
 void CMD_EdgeLeaveCommand(F_CMD_ARGS)
 {
 	direction_t direction;
-	char *command = NULL, *actdup, *rest;
+	char *command = NULL, *actdup = NULL, *rest;
 	struct monitor *m;
 
 	if (action != NULL)


### PR DESCRIPTION
GCC is becoming increasingly pickier about pre-assignment of variables
leading to false-positives but unsightly warnings during compilation.
Fix them for now.
