### PR TITLE
FvwmMFL: make pid file slight more unique

### DIFF
--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -142,14 +142,16 @@ static void
 set_pid_file(void)
 {
 	char	*fud = getenv("FVWM_USERDIR");
+	char	*dsp = getenv("DISPLAY");
 
-	if (fud == NULL) {
-		fprintf(stderr, "FVWM_USERDIR is not set in the environment\n");
+	if (fud == NULL || dsp == NULL) {
+		fprintf(stderr,
+		    "FVWM_USERDIR or DISPLAY is not set in the environment\n");
 		exit(1);
 	}
 
 	free(pid_file);
-	xasprintf(&pid_file, "%s/fvwm_mfl.pid", fud);
+	xasprintf(&pid_file, "%s/fvwm_mfl_%s.pid", fud, dsp);
 }
 
 static void


### PR DESCRIPTION
When FvwmMFL learned to only start one instance of itself, the pid file
used didn't contain any unique attribute.  As such, trying to run fvwm3
with FvwmMFL under Xephyr meant that separate instance of FvwmMFL was
never started.

To fix this, embed the DISPLAY value to the pid filename to allow it to
run more than once, albeit unique to each display.
