### PR TITLE
update_fvwm_screen: don't lose desk from StartsOnScreen

### DIFF
--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -485,8 +485,7 @@ typedef struct ScreenInfo
 		get_unshaded_geometry((fw), &g);			   \
 		mnew = FindScreenOfXY((fw)->g.frame.x, (fw)->g.frame.y);   \
 		/* Avoid unnecessary updates. */			   \
-		if (mnew == (fw)->m &&					   \
-		    (fw)->Desk == mnew->virtual_scr.CurrentDesk)	   \
+		if (mnew == (fw)->m)					   \
 			break;						   \
 		(fw)->m_prev = (fw)->m;					   \
 		(fw)->m = mnew;						   \


### PR DESCRIPTION
When updating the desk which a window is on, don't be so clever about
updating the currentdesk if it's the same as the screen.  Other parts of
fvwm3 will be setting this conditionally for their own reasons, and this
check was clobbering that (such as in placement.c for StartsOnDesk
style).

Fixes #373
