### PR TITLE
fvwm3: fix segfault caused by incorrect screen number in -s option

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2131,6 +2131,8 @@ int main(int argc, char **argv)
 					   "can't open display %s, single screen "
 					   "number %d maybe not correct",
 					   new_dn, single_screen_num);
+				free(new_dn);
+				exit (1);
 			}
 			Scr.screen = single_screen_num;
 			Scr.NumberOfScreens = ScreenCount(dpy);


### PR DESCRIPTION
Way to reproduce the error: call "fvwm3 -s <N>" with some non-existing screen number N. In this case XOpenDisplay() returns dpi==0, program should exit before using it in ScreenCount(dpi)