### PR TITLE
Remove explicit path to bson.h (closes #375)

### DIFF
--- a/fvwm/builtins.h
+++ b/fvwm/builtins.h
@@ -3,12 +3,7 @@
 #ifndef FVWM_BUILTINS_H
 #define FVWM_BUILTINS_H
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__sun__)
-#include <libbson-1.0/bson.h>
-#else
-#include <bson/bson.h>
-#endif
-
+#include <bson.h>
 #include "fvwm.h"
 #include "screen.h"
 


### PR DESCRIPTION
pkg-config is used in configure script to detect libbson library and to set correct compiler flags (-I...). No need to write system-dependent paths explicitly.
