### PR TITLE
fvwm-root: fix Makefile

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -16,9 +16,10 @@ man_MANS = fvwm-menu-xlock.1 fvwm-menu-directory.1 fvwm-perllib.1
 
 LDADD = -L$(top_builddir)/libs $(X_LIBS) -lfvwm3 $(xpm_LIBS) $(Xcursor_LIBS) \
 	$(X_PRE_LIBS) -lXext -lX11 -lm $(X_EXTRA_LIBS) $(Xrender_LIBS) \
-	$(Xcursor_LIBS) $(png_LIBS) $(rsvg_LIBS) $(XRandR_LIBS)
+	$(Xcursor_LIBS) $(png_LIBS) $(rsvg_LIBS) $(XRandR_LIBS) \
+	$(XFT_LIBS)
 AM_CPPFLAGS = -I$(top_srcdir) $(xpm_CFLAGS) $(X_CFLAGS) $(png_CFLAGS) \
-	$(rsvg_CFLAGS) $(Xinerama_CFLAGS)
+	$(rsvg_CFLAGS) $(XRandR_CFLAGS) $(XFT_CFLAGS)
 
 configdir = @FVWM_DATADIR@
 config_DATA = fvwm-menu-desktop-config.fpl

--- a/modules/FvwmConsole/Makefile.am
+++ b/modules/FvwmConsole/Makefile.am
@@ -20,11 +20,11 @@ FvwmConsoleC_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 
 # Use X_EXTRA_LIBS to get socket(), etc.
 LDADD = -L$(top_builddir)/libs -lfvwm3 $(readline_LIBS) $(freetype_LIBS) \
-	$(X_EXTRA_LIBS)
+	$(X_EXTRA_LIBS) $(XFT_LIBS)
 
 # FIXME:
 # Despite not using X functions explicitly, the code includes
 # fvwmlib.h, which *does* include X headers and xpm.h!
 AM_CPPFLAGS = -I$(top_srcdir) $(readline_CFLAGS) $(xpm_CFLAGS) \
-	      $(freetype_CFLAGS) $(X_CFLAGS)
+	      $(freetype_CFLAGS) $(X_CFLAGS) $(XFT_CFLAGS)
 endif !FVWM_BUILD_GOLANG


### PR DESCRIPTION
Remove references to Xinerama, and add missing XFT cflags/ldflags
