### PR TITLE
Revert "Remove SAFEFREE macro"

### DIFF
--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -38,6 +38,8 @@
 
 /* ---------------------------- local definitions -------------------------- */
 
+#define SAFEFREE( p )  {if (p) {free(p);(p)=NULL;}}
+
 /* ---------------------------- local macros ------------------------------- */
 
 /* ---------------------------- imports ------------------------------------ */
@@ -361,7 +363,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_ICON_NAME(*merged_style));
+			SAFEFREE(SGET_ICON_NAME(*merged_style));
 			SSET_ICON_NAME(
 				*merged_style, (SGET_ICON_NAME(*add_style)) ?
 				fxstrdup(SGET_ICON_NAME(*add_style)) : NULL);
@@ -376,7 +378,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_MINI_ICON_NAME(*merged_style));
+			SAFEFREE(SGET_MINI_ICON_NAME(*merged_style));
 			SSET_MINI_ICON_NAME(
 				*merged_style,
 				(SGET_MINI_ICON_NAME(*add_style)) ?
@@ -394,7 +396,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_DECOR_NAME(*merged_style));
+			SAFEFREE(SGET_DECOR_NAME(*merged_style));
 			SSET_DECOR_NAME(
 				*merged_style, (SGET_DECOR_NAME(*add_style)) ?
 				fxstrdup(SGET_DECOR_NAME(*add_style)) :
@@ -410,7 +412,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_ICON_FONT(*merged_style));
+			SAFEFREE(SGET_ICON_FONT(*merged_style));
 			SSET_ICON_FONT(
 				*merged_style, (SGET_ICON_FONT(*add_style)) ?
 				fxstrdup(SGET_ICON_FONT(*add_style)) : NULL);
@@ -425,7 +427,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_WINDOW_FONT(*merged_style));
+			SAFEFREE(SGET_WINDOW_FONT(*merged_style));
 			SSET_WINDOW_FONT(
 				*merged_style, (SGET_WINDOW_FONT(*add_style)) ?
 				fxstrdup(SGET_WINDOW_FONT(*add_style)) :
@@ -454,7 +456,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_FORE_COLOR_NAME(*merged_style));
+			SAFEFREE(SGET_FORE_COLOR_NAME(*merged_style));
 			SSET_FORE_COLOR_NAME(
 				*merged_style,
 				(SGET_FORE_COLOR_NAME(*add_style)) ?
@@ -472,7 +474,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_BACK_COLOR_NAME(*merged_style));
+			SAFEFREE(SGET_BACK_COLOR_NAME(*merged_style));
 			SSET_BACK_COLOR_NAME(
 				*merged_style,
 				(SGET_BACK_COLOR_NAME(*add_style)) ?
@@ -490,7 +492,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_FORE_COLOR_NAME_HI(*merged_style));
+			SAFEFREE(SGET_FORE_COLOR_NAME_HI(*merged_style));
 			SSET_FORE_COLOR_NAME_HI(
 				*merged_style,
 				(SGET_FORE_COLOR_NAME_HI(*add_style)) ?
@@ -508,7 +510,7 @@ static void merge_styles(
 	{
 		if (do_free_src_and_alloc_copy)
 		{
-			free(SGET_BACK_COLOR_NAME_HI(*merged_style));
+			SAFEFREE(SGET_BACK_COLOR_NAME_HI(*merged_style));
 			SSET_BACK_COLOR_NAME_HI(
 				*merged_style,
 				(SGET_BACK_COLOR_NAME_HI(*add_style)) ?
@@ -717,14 +719,14 @@ static void merge_styles(
 	}
 	if (add_style->flags.has_placement_position_string)
 	{
-		free(SGET_PLACEMENT_POSITION_STRING(*merged_style));
+		SAFEFREE(SGET_PLACEMENT_POSITION_STRING(*merged_style));
 		SSET_PLACEMENT_POSITION_STRING(
 			*merged_style,
 			strdup(SGET_PLACEMENT_POSITION_STRING(*add_style)));
 	}
 	if (add_style->flags.has_initial_map_command_string)
 	{
-		free(SGET_INITIAL_MAP_COMMAND_STRING(*merged_style));
+		SAFEFREE(SGET_INITIAL_MAP_COMMAND_STRING(*merged_style));
 		SSET_INITIAL_MAP_COMMAND_STRING(
 			*merged_style,
 			strdup(SGET_INITIAL_MAP_COMMAND_STRING(*add_style)));
@@ -732,14 +734,14 @@ static void merge_styles(
 
 	if (add_style->flags.has_title_format_string)
 	{
-		free(SGET_TITLE_FORMAT_STRING(*merged_style));
+		SAFEFREE(SGET_TITLE_FORMAT_STRING(*merged_style));
 		SSET_TITLE_FORMAT_STRING(*merged_style,
 				strdup(SGET_TITLE_FORMAT_STRING(*add_style)));
 	}
 
 	if (add_style->flags.has_icon_title_format_string)
 	{
-		free(SGET_ICON_TITLE_FORMAT_STRING(*merged_style));
+		SAFEFREE(SGET_ICON_TITLE_FORMAT_STRING(*merged_style));
 		SSET_ICON_TITLE_FORMAT_STRING(*merged_style,
 				strdup(SGET_ICON_TITLE_FORMAT_STRING(*add_style)));
 	}
@@ -786,21 +788,21 @@ static void merge_styles(
 static void free_style(window_style *style)
 {
 	/* Free contents of style */
-	free(SGET_NAME(*style));
-	free(SGET_BACK_COLOR_NAME(*style));
-	free(SGET_FORE_COLOR_NAME(*style));
-	free(SGET_BACK_COLOR_NAME_HI(*style));
-	free(SGET_FORE_COLOR_NAME_HI(*style));
-	free(SGET_DECOR_NAME(*style));
-	free(SGET_ICON_FONT(*style));
-	free(SGET_WINDOW_FONT(*style));
-	free(SGET_ICON_NAME(*style));
-	free(SGET_MINI_ICON_NAME(*style));
+	SAFEFREE(SGET_NAME(*style));
+	SAFEFREE(SGET_BACK_COLOR_NAME(*style));
+	SAFEFREE(SGET_FORE_COLOR_NAME(*style));
+	SAFEFREE(SGET_BACK_COLOR_NAME_HI(*style));
+	SAFEFREE(SGET_FORE_COLOR_NAME_HI(*style));
+	SAFEFREE(SGET_DECOR_NAME(*style));
+	SAFEFREE(SGET_ICON_FONT(*style));
+	SAFEFREE(SGET_WINDOW_FONT(*style));
+	SAFEFREE(SGET_ICON_NAME(*style));
+	SAFEFREE(SGET_MINI_ICON_NAME(*style));
 	remove_icon_boxes_from_style(style);
-	free(SGET_PLACEMENT_POSITION_STRING(*style));
-	free(SGET_INITIAL_MAP_COMMAND_STRING(*style));
-	free(SGET_TITLE_FORMAT_STRING(*style));
-	free(SGET_ICON_TITLE_FORMAT_STRING(*style));
+	SAFEFREE(SGET_PLACEMENT_POSITION_STRING(*style));
+	SAFEFREE(SGET_INITIAL_MAP_COMMAND_STRING(*style));
+	SAFEFREE(SGET_TITLE_FORMAT_STRING(*style));
+	SAFEFREE(SGET_ICON_TITLE_FORMAT_STRING(*style));
 
 	return;
 }
@@ -820,39 +822,39 @@ static void free_style_mask(window_style *style, style_flags *mask)
 	/* Free contents of style */
 	if (pmask->has_color_back)
 	{
-		free(SGET_BACK_COLOR_NAME(*style));
+		SAFEFREE(SGET_BACK_COLOR_NAME(*style));
 	}
 	if (pmask->has_color_fore)
 	{
-		free(SGET_FORE_COLOR_NAME(*style));
+		SAFEFREE(SGET_FORE_COLOR_NAME(*style));
 	}
 	if (pmask->has_color_back_hi)
 	{
-		free(SGET_BACK_COLOR_NAME_HI(*style));
+		SAFEFREE(SGET_BACK_COLOR_NAME_HI(*style));
 	}
 	if (pmask->has_color_fore_hi)
 	{
-		free(SGET_FORE_COLOR_NAME_HI(*style));
+		SAFEFREE(SGET_FORE_COLOR_NAME_HI(*style));
 	}
 	if (pmask->has_decor)
 	{
-		free(SGET_DECOR_NAME(*style));
+		SAFEFREE(SGET_DECOR_NAME(*style));
 	}
 	if (pmask->common.has_icon_font)
 	{
-		free(SGET_ICON_FONT(*style));
+		SAFEFREE(SGET_ICON_FONT(*style));
 	}
 	if (pmask->common.has_window_font)
 	{
-		free(SGET_WINDOW_FONT(*style));
+		SAFEFREE(SGET_WINDOW_FONT(*style));
 	}
 	if (pmask->has_icon)
 	{
-		free(SGET_ICON_NAME(*style));
+		SAFEFREE(SGET_ICON_NAME(*style));
 	}
 	if (pmask->has_mini_icon)
 	{
-		free(SGET_MINI_ICON_NAME(*style));
+		SAFEFREE(SGET_MINI_ICON_NAME(*style));
 	}
 	if (pmask->has_icon_boxes)
 	{
@@ -2128,7 +2130,7 @@ static Bool style_parse_one_style_option(
 			rest = GetNextToken(rest, &token);
 			if (token)
 			{
-				free(SGET_BACK_COLOR_NAME(*ps));
+				SAFEFREE(SGET_BACK_COLOR_NAME(*ps));
 				SSET_BACK_COLOR_NAME(*ps, token);
 				ps->flags.has_color_back = 1;
 				ps->flag_mask.has_color_back = 1;
@@ -2310,7 +2312,7 @@ static Bool style_parse_one_style_option(
 					rest, &token, NULL, ",/", &c);
 			}
 			rest = next;
-			free(SGET_FORE_COLOR_NAME(*ps));
+			SAFEFREE(SGET_FORE_COLOR_NAME(*ps));
 			SSET_FORE_COLOR_NAME(*ps, token);
 			ps->flags.has_color_fore = 1;
 			ps->flag_mask.has_color_fore = 1;
@@ -2342,7 +2344,7 @@ static Bool style_parse_one_style_option(
 					   " color argument.");
 				break;
 			}
-			free(SGET_BACK_COLOR_NAME(*ps));
+			SAFEFREE(SGET_BACK_COLOR_NAME(*ps));
 			SSET_BACK_COLOR_NAME(*ps, token);
 			ps->flags.has_color_back = 1;
 			ps->flag_mask.has_color_back = 1;
@@ -2619,7 +2621,7 @@ static Bool style_parse_one_style_option(
 		}
 		else if (StrEquals(token, "Font"))
 		{
-			free(SGET_WINDOW_FONT(*ps));
+			SAFEFREE(SGET_WINDOW_FONT(*ps));
 			rest = GetNextToken(rest, &token);
 			SSET_WINDOW_FONT(*ps, token);
 			S_SET_HAS_WINDOW_FONT(SCF(*ps), (token != NULL));
@@ -2632,7 +2634,7 @@ static Bool style_parse_one_style_option(
 			rest = GetNextToken(rest, &token);
 			if (token)
 			{
-				free(SGET_FORE_COLOR_NAME(*ps));
+				SAFEFREE(SGET_FORE_COLOR_NAME(*ps));
 				SSET_FORE_COLOR_NAME(*ps, token);
 				ps->flags.has_color_fore = 1;
 				ps->flag_mask.has_color_fore = 1;
@@ -2768,7 +2770,7 @@ static Bool style_parse_one_style_option(
 			rest = GetNextToken(rest, &token);
 			if (token)
 			{
-				free(SGET_FORE_COLOR_NAME_HI(*ps));
+				SAFEFREE(SGET_FORE_COLOR_NAME_HI(*ps));
 				SSET_FORE_COLOR_NAME_HI(*ps, token);
 				ps->flags.has_color_fore_hi = 1;
 				ps->flag_mask.has_color_fore_hi = 1;
@@ -2789,7 +2791,7 @@ static Bool style_parse_one_style_option(
 			rest = GetNextToken(rest, &token);
 			if (token)
 			{
-				free(SGET_BACK_COLOR_NAME_HI(*ps));
+				SAFEFREE(SGET_BACK_COLOR_NAME_HI(*ps));
 				SSET_BACK_COLOR_NAME_HI(*ps, token);
 				ps->flags.has_color_back_hi = 1;
 				ps->flag_mask.has_color_back_hi = 1;
@@ -2848,7 +2850,7 @@ static Bool style_parse_one_style_option(
 			{
 				rest = GetNextToken(rest, &token);
 
-				free(SGET_ICON_NAME(*ps));
+				SAFEFREE(SGET_ICON_NAME(*ps));
 				SSET_ICON_NAME(*ps,token);
 				ps->flags.has_icon = (token != NULL);
 				ps->flag_mask.has_icon = 1;
@@ -2911,7 +2913,7 @@ static Bool style_parse_one_style_option(
 		}
 		else if (StrEquals(token, "IconFont"))
 		{
-			free(SGET_ICON_FONT(*ps));
+			SAFEFREE(SGET_ICON_FONT(*ps));
 			rest = GetNextToken(rest, &token);
 			SSET_ICON_FONT(*ps, token);
 			S_SET_HAS_ICON_FONT(SCF(*ps), (token != NULL));
@@ -3323,7 +3325,7 @@ static Bool style_parse_one_style_option(
 			rest = GetNextToken(rest, &token);
 			if (token)
 			{
-				free(SGET_MINI_ICON_NAME(*ps));
+				SAFEFREE(SGET_MINI_ICON_NAME(*ps));
 				SSET_MINI_ICON_NAME(*ps, token);
 				ps->flags.has_mini_icon = 1;
 				ps->flag_mask.has_mini_icon = 1;
@@ -4337,7 +4339,7 @@ static Bool style_parse_one_style_option(
 		}
 		else if (StrEquals(token, "UseDecor"))
 		{
-			free(SGET_DECOR_NAME(*ps));
+			SAFEFREE(SGET_DECOR_NAME(*ps));
 			rest = GetNextToken(rest, &token);
 			SSET_DECOR_NAME(*ps, token);
 			ps->flags.has_decor = (token != NULL);


### PR DESCRIPTION
The SAFEFREE() macro sets the free()d variable to NULL -- when this
macro was removed, the side-effect of losing that assignment changed the
style code's behaviour.

Revert this for now.

This reverts commit 54f2f13781e633ffe9002aae542fec44e8aefe74.
