### PR TITLE
fvwm2: provide compat wrapper FvwmCommandS

### DIFF
--- a/modules/FvwmMFL/Makefile.am
+++ b/modules/FvwmMFL/Makefile.am
@@ -4,9 +4,24 @@ program_transform_name =
 
 moduledir = @FVWM_MODULEDIR@
 module_PROGRAMS = FvwmMFL
+module_SCRIPTS = FvwmCommandS
 
 FvwmMFL_SOURCES = FvwmMFL.c
 FvwmMFL_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
+
+## FvwmCommand/FvwmCommandS was made obsolete via
+##
+## 7b8684385 (Deprecation of modules, 2019-04-14)
+##
+## However, to maintain backwards compatibility with fvwm2, provide a wrapper
+## for FvwmCommandS to point to FvwmMFL so that there's better parity.
+FvwmCommandS: Makefile
+	echo "#!/bin/sh" > $@
+	echo 'modargs="$$1 $$2 $$3 $$4 $$5"' >> $@
+	echo 'shift; shift; shift; shift; shift' >> $@
+	echo exec $(moduledir)'/FvwmMFL $$modargs $$@' >> $@
+
+CLEANFILES = $(module_SCRIPTS)
 
 LDADD = -L$(top_builddir)/libs $(X_LIBS) -lfvwm3  \
 	$(X_PRE_LIBS) -lXext -lX11 $(X_EXTRA_LIBS) $(XRandR_LIBS) \


### PR DESCRIPTION
When fvwm3 deprecated FvwmCommand and replaced it with a wrapper round
FvwmMFL, it no longer required the use of FvwmCommandS.

However, because fvwm3 is currently backwards compatible with fvwm2, the
config files are mostly the same.  To help with reducing the need for
changes, provide the wrapper FvwmCommandS for starting FvwmMFL instead.
Under fvwm2, this will use the older FvwmCommandS code.

Fixes #391
