### PR TITLE
Maximizing: handle RandR screen selection better

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -4887,13 +4887,14 @@ void CMD_Maximize(F_CMD_ARGS)
 	new_g.height = fw->g.frame.height;
 	get_page_offset_check_visible(&page_x, &page_y, fw);
 
-	/* Check if we should constrain rectangle to some Xinerama screen */
 	if (!is_screen_given)
 	{
-		scr_x = fw->m->si->x;
-		scr_y = fw->m->si->y;
-		scr_w = fw->m->si->w;
-		scr_h = fw->m->si->h;
+		fscreen_scr_arg fscr;
+
+		fscr.xypos.x = fw->g.frame.x + fw->g.frame.width  / 2 - page_x;
+		fscr.xypos.y = fw->g.frame.y + fw->g.frame.height / 2 - page_y;
+		FScreenGetScrRect(&fscr, FSCREEN_XYPOS, &scr_x, &scr_y, &scr_w,
+		    &scr_h);
 	}
 
 	if (!ignore_working_area)


### PR DESCRIPTION
When maximizing a window which sits between two monitor boundaries --
even a tiny fraction -- maximizing said window would chose the window
the monitor was technically on, not which monitor the majority of the
window is on.

Fixes #394
