### PR TITLE
Revert "PanFrames: always keep mapped"

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2460,7 +2460,6 @@ int main(int argc, char **argv)
 	TAILQ_FOREACH(m, &monitor_q, entry)
 		EWMH_Init(m);
 
-	initPanFrames();
 	SetRCDefaults();
 	flush_window_updates();
 	simplify_style_list();

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -960,7 +960,7 @@ should_free_panframe(PanFrame *pf)
 	if (pf->command != NULL || pf->command_leave != NULL)
 		return (false);
 
-	return (false);
+	return (true);
 }
 
 /*
@@ -1021,16 +1021,14 @@ void checkPanFrames(void)
 		}
 
 		/* correct the unmap variables if pan frame commands are set */
-		if (edge_thickness != 0) {
-			if (!should_free_panframe(&m->PanFrameLeft))
-				do_unmap_l = False;
-			if (!should_free_panframe(&m->PanFrameRight))
-				do_unmap_r = False;
-			if (!should_free_panframe(&m->PanFrameBottom))
-				do_unmap_b = False;
-			if (!should_free_panframe(&m->PanFrameTop))
-				do_unmap_t = False;
-		}
+		if (!should_free_panframe(&m->PanFrameLeft))
+			do_unmap_l = False;
+		if (!should_free_panframe(&m->PanFrameRight))
+			do_unmap_r = False;
+		if (!should_free_panframe(&m->PanFrameBottom))
+			do_unmap_b = False;
+		if (!should_free_panframe(&m->PanFrameTop))
+			do_unmap_t = False;
 		/*
 		 * hide or show the windows
 		 */
@@ -1140,13 +1138,13 @@ void checkPanFrames(void)
 				m->PanFrameBottom.isMapped = True;
 			}
 		}
+		last_edge_thickness = edge_thickness;
 		fvwm_debug(__func__,
 			"2 %s: {left: %d, right; %d, top: %d, bottom: %d}\n",
 			m->si->name,
 			m->PanFrameLeft.isMapped, m->PanFrameRight.isMapped,
 			m->PanFrameTop.isMapped,  m->PanFrameBottom.isMapped);
 	}
-	last_edge_thickness = edge_thickness;
 }
 
 /*
@@ -1298,16 +1296,12 @@ void initPanFrames(void)
 			m->si->w, edge_thickness,
 			0, CopyFromParent, InputOnly, CopyFromParent, valuemask,
 			&attributes);
-		m->PanFrameTop.command = NULL;
-		m->PanFrameTop.command_leave = NULL;
 		attributes.cursor = Scr.FvwmCursors[CRS_LEFT_EDGE];
 		m->PanFrameLeft.win = XCreateWindow(
 			dpy, Scr.Root, m->si->x, m->si->y,
 			edge_thickness, m->si->h,
 			0, CopyFromParent, InputOnly, CopyFromParent, valuemask,
 			&attributes);
-		m->PanFrameLeft.command = NULL;
-		m->PanFrameLeft.command_leave = NULL;
 		attributes.cursor = Scr.FvwmCursors[CRS_RIGHT_EDGE];
 		m->PanFrameRight.win = XCreateWindow(
 			dpy, Scr.Root,
@@ -1315,8 +1309,6 @@ void initPanFrames(void)
 			edge_thickness, m->si->h, 0,
 			CopyFromParent, InputOnly, CopyFromParent, valuemask,
 			&attributes);
-		m->PanFrameRight.command = NULL;
-		m->PanFrameRight.command_leave = NULL;
 		attributes.cursor = Scr.FvwmCursors[CRS_BOTTOM_EDGE];
 		m->PanFrameBottom.win = XCreateWindow(
 			dpy, Scr.Root, m->si->x,
@@ -1324,8 +1316,6 @@ void initPanFrames(void)
 			m->si->w, edge_thickness, 0,
 			CopyFromParent, InputOnly, CopyFromParent, valuemask,
 			&attributes);
-		m->PanFrameBottom.command = NULL;
-		m->PanFrameBottom.command_leave = NULL;
 		m->PanFrameTop.isMapped=m->PanFrameLeft.isMapped=
 			m->PanFrameRight.isMapped= m->PanFrameBottom.isMapped=False;
 	}


### PR DESCRIPTION
PR reverting per conversation with @ThomasAdam on irc. This broke the auto_hide function I use for my top bar in my config.

This reverts commit 29f00243542bd23aa28c6f51d83db4483e05a6b0.

* **What does this PR do?**

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
