### PR TITLE
Deprecate HAVE_XRandR/FScreenIsEnabled()

### DIFF
--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -901,7 +901,7 @@ Bool MatchesConditionMask(FvwmWindow *fw, WindowConditionMask *mask)
 	if (mask->my_flags.do_check_page ||
 	    mask->my_flags.do_check_desk_and_page)
 	{
-		if (FScreenIsEnabled() && !mask->my_flags.do_not_check_screen)
+		if (!mask->my_flags.do_not_check_screen)
 		{
 			is_on_page = !!FScreenIsRectangleOnScreen(
 				NULL, FSCREEN_CURRENT, &(fw->g.frame));

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1765,7 +1765,6 @@ static void __refocus_stolen_focus_win(const evh_args_t *ea)
 
 /* ---------------------------- event handlers ----------------------------- */
 
-#ifdef HAVE_XRANDR
 void monitor_update_ewmh(void)
 {
 	FvwmWindow	*t;
@@ -1831,7 +1830,6 @@ monitor_emit_broadcast(void)
 		}
 	}
 }
-#endif
 
 void HandleButtonPress(const evh_args_t *ea)
 {
@@ -4078,7 +4076,6 @@ void dispatch_event(XEvent *e)
 
 	XFlush(dpy);
 
-#if HAVE_XRANDR
 	XRRScreenChangeNotifyEvent *sce;
 
 	switch (e->type - randr_event) {
@@ -4091,7 +4088,6 @@ void dispatch_event(XEvent *e)
 			break;
 		}
 	}
-#endif
 
 	if (w == Scr.Root)
 	{

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1305,9 +1305,7 @@ static void setVersionInfo(void)
 #ifdef HAVE_BIDI
 	strcat(support_str, " Bidi text,");
 #endif
-#ifdef HAVE_XRANDR
 	strcat(support_str, " XRandR,");
-#endif
 #ifdef HAVE_XRENDER
 	strcat(support_str, " XRender,");
 #endif

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2260,7 +2260,7 @@ static void DoSnapAttract(
 		}
 	}
 	/* Resist moving windows between xineramascreens */
-	if (fw->edge_resistance_xinerama_move > 0 && FScreenIsEnabled())
+	if (fw->edge_resistance_xinerama_move)
 	{
 		int scr_x0, scr_y0;
 		int scr_x1, scr_y1;

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -2131,39 +2131,36 @@ static void __explain_placement(FvwmWindow *fw, pl_reason_t *reason)
 		s += strlen(s);
 	}
 	/* screen */
-	if (FScreenIsEnabled() == True)
+	switch (reason->screen.reason)
 	{
-		switch (reason->screen.reason)
-		{
-		case PR_SCREEN_CURRENT:
-			r = "current screen";
-			break;
-		case PR_SCREEN_STYLE:
-			r = "specified by style";
-			break;
-		case PR_SCREEN_X_RESOURCE_FVWMSCREEN:
-			r = "specified by 'fvwmscreen' X resource";
-			break;
-		case PR_SCREEN_IGNORE_CAPTURE:
-			r = "window was (re)captured";
-			break;
-		default:
-			r = "bug";
-			break;
-		}
+	case PR_SCREEN_CURRENT:
+		r = "current screen";
+		break;
+	case PR_SCREEN_STYLE:
+		r = "specified by style";
+		break;
+	case PR_SCREEN_X_RESOURCE_FVWMSCREEN:
+		r = "specified by 'fvwmscreen' X resource";
+		break;
+	case PR_SCREEN_IGNORE_CAPTURE:
+		r = "window was (re)captured";
+		break;
+	default:
+		r = "bug";
+		break;
+	}
+	sprintf(
+		s, "  screen: %s: %d %d %dx%d (%s)\n",
+		reason->screen.screen, reason->screen.g.x,
+		reason->screen.g.y, reason->screen.g.width,
+		reason->screen.g.height, r);
+	s += strlen(s);
+	if (reason->screen.was_modified_by_ewmh_workingarea == 1)
+	{
 		sprintf(
-			s, "  screen: %s: %d %d %dx%d (%s)\n",
-			reason->screen.screen, reason->screen.g.x,
-			reason->screen.g.y, reason->screen.g.width,
-			reason->screen.g.height, r);
+			s, "    (screen area modified by EWMH working"
+			" area)\n");
 		s += strlen(s);
-		if (reason->screen.was_modified_by_ewmh_workingarea == 1)
-		{
-			sprintf(
-				s, "    (screen area modified by EWMH working"
-				" area)\n");
-			s += strlen(s);
-		}
 	}
 	/* position */
 	is_placed_by_algo = 0;

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -70,11 +70,6 @@ static void GetMouseXY(XEvent *eventp, int *x, int *y)
 		disp, DefaultRootWindow(disp), eventp, x, y);
 }
 
-Bool FScreenIsEnabled(void)
-{
-	return (IS_RANDR_ENABLED);
-}
-
 struct monitor *
 monitor_new(void)
 {
@@ -483,7 +478,7 @@ void FScreenInit(Display *dpy)
 		is_randr_present = true;
 
 
-	if (FScreenIsEnabled() && !is_randr_present) {
+	if (!is_randr_present) {
 		/* Something went wrong. */
 		fvwm_debug(__func__, "Couldn't initialise XRandR: %s\n",
 			   strerror(errno));

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -29,12 +29,6 @@
 #include "FScreen.h"
 #include "FEvent.h"
 
-#ifdef HAVE_XRANDR
-#	define IS_RANDR_ENABLED 1
-#else
-#	define IS_RANDR_ENABLED 0
-#endif
-
 #define GLOBAL_SCREEN_NAME "_global"
 
 /* In fact, only corners matter -- there will never be GRAV_NONE */

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -165,7 +165,6 @@ extern int randr_event;
 extern const char *prev_focused_monitor;
 
 /* Control */
-Bool FScreenIsEnabled(void);
 void FScreenInit(Display *dpy);
 void FScreenSelect(Display *dpy);
 void FScreenSetPrimaryScreen(int scr);

--- a/libs/fvwm_x11.h
+++ b/libs/fvwm_x11.h
@@ -11,6 +11,7 @@
 #include <X11/cursorfont.h>
 #include <X11/Xproto.h>
 #include <X11/Intrinsic.h>
+#include <X11/extensions/Xrandr.h>
 
 #ifdef XPM
 #define XpmSupport 1
@@ -44,10 +45,6 @@ typedef Picture XRenderPicture;
 #define _XFT_NO_COMPAT_ 1
 #include <X11/Xft/Xft.h>
 #include <fontconfig/fontconfig.h>
-#endif
-
-#ifdef HAVE_XRANDR
-#include <X11/extensions/Xrandr.h>
 #endif
 
 #ifdef SHAPE

--- a/modules/FvwmIdent/FvwmIdent.c
+++ b/modules/FvwmIdent/FvwmIdent.c
@@ -385,7 +385,7 @@ void list_configure(unsigned long *body)
 
 		target.monitor_id = cfgpacket->monitor_id;
 		target.monitor = fxstrdup("unknown");
-		if (FScreenIsEnabled()) {
+		{
 			free(target.monitor);
 			target.monitor = fxstrdup(
 				monitor_by_output((int)target.monitor_id)->si->name);


### PR DESCRIPTION
Now that RandR is mandatory in `Fvwm3`, remove the HAVE_XRANDR guards, as well
as FScreenIsEnabled() function from libfvwm3, as they're no longer required.
