### PR TITLE
FvwmPager: Fix division by zero

### DIFF
--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -549,7 +549,7 @@ void initialize_pager(void)
   /* Size the window */
   if(Rows < 0)
   {
-    if(Columns < 0)
+    if(Columns <= 0)
     {
       Columns = ndesks;
       Rows = 1;


### PR DESCRIPTION
Fixes #413

* **What does this PR do?**
Fixes a division by zero when `Rows` < 0 (e.g. -1) and `Columns` is 0.  In `initialize_pager()`, FvwmPager divides `ndesks` by `Columns`, which results in a division by zero.

* **Screenshots (if applicable)**
* See screenshot in issue #413

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
