### PR TITLE
Codecov: add support for code coverage

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,6 +17,10 @@ jobs:
       run: docker pull fvwmorg/fvwm3-build:latest
     - name: Build Package
       run: 'docker build -t fvwm3 .'
+    - name: Code Coverage (via Codecov)
+      uses: codecov/codecov-action@v1
+      with:
+        verbose: true
 
   changelog:
       name: Update Changelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM fvwmorg/fvwm3-build:latest
 ENV GOROOT="/usr/lib/go-1.14/"
 ENV PATH="$GOROOT/bin:$PATH"
 ENV GO111MODULE="on"
+ENV CFLAGS="$CFLAGS -coverage"
 
 COPY . /build
 WORKDIR /build


### PR DESCRIPTION
This adds codecov support to Github Actions, eventually deprecating
Codacy.
