### PR TITLE
Fix invalid read of size 1 error from Valgrind.

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1724,7 +1724,7 @@ static void __handle_bpress_on_managed(const exec_context_t *exc)
 		}
 	}
 	/* raise the window */
-	if (IS_SCHEDULED_FOR_RAISE(fw))
+	if (check_if_fvwm_window_exists(fw) && IS_SCHEDULED_FOR_RAISE(fw))
 	{
 		/* Now that we know the action did not restack the window we
 		 * can raise it.


### PR DESCRIPTION
After __handle_bpress_action is called, the window fw might have been
freed by CMD_close. Check that the window still exists before checking
if it is scheduled to be raised, so that we don't attempt to read freed memory.

* **What does this PR do?**
Fixes an attempt to read freed memory. (#418)

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
