### PR TITLE
Fix file handle leak.

### DIFF
--- a/fvwm/read.c
+++ b/fvwm/read.c
@@ -248,6 +248,7 @@ int run_command_file(
 	if (push_read_file(full_filename) == 0)
 	{
 		free(full_filename);
+		fclose(f);
 		return 0;
 	}
 	run_command_stream(NULL, f, exc);


### PR DESCRIPTION
When the maximum read depth is reached, push_read_file() fails and
run_command_file() returns without closing the file.

* **What does this PR do?**
Fixes a "resource leak: f" detected by Codacy and Cppcheck.
* **Screenshots (if applicable)**

* **Issue number(s)**
#107
If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
