### PR TITLE
Remove package (libx11-dev) already present in core dependencies

### DIFF
--- a/dev-docs/INSTALL.md
+++ b/dev-docs/INSTALL.md
@@ -37,7 +37,6 @@ FVWM3 has the following dependencies.
 * libreadline-dev
 * librsvg-dev
 * libsm-dev
-* libx11-dev
 * libxcursor-dev
 * libxext-dev
 * libxft-dev


### PR DESCRIPTION
I figured this did not need an issue of its own, but let me know if you would like me to file one.