### PR TITLE
Correct menu error short option from `-t` to `-e`

### DIFF
--- a/doc/bin/fvwm-menu-desktop.adoc
+++ b/doc/bin/fvwm-menu-desktop.adoc
@@ -109,7 +109,7 @@ below for some solutions.
   Generates all menus listed in a space separated list of full menu
   paths. This option overrides any defaults and
   **--desktop**|*--menu-type* settings.
---menu-error |-t::
+--menu-error |-e::
   If this option is present and python-xdg is not found, the script will
   print the error in the generated menu. Used in the default-config.
 --verbose::


### PR DESCRIPTION
The short option shown in `man fvwm-menu-desktop` for `--menu-error` is `-t`. In the help for the command shown on the command-line (via `fvwm-menu-desktop --help`) the short option is `-e`.

This trivial patch changes the `-t` in the `--menu-error` section to `-e` in the man page.

Again, I figured this wasn't worth an issue, but let me know if I should add one.