### PR TITLE
Fix 22kb memory leak.

### DIFF
--- a/fvwm/functions.c
+++ b/fvwm/functions.c
@@ -673,6 +673,11 @@ static void __execute_function(
 	{
 		free(function);
 	}
+	/* Free the string allocated by expand_vars earlier in this function. */
+	if (!(exec_flags & FUNC_DONT_EXPAND_COMMAND))
+	{
+		free(expaction);
+	}
 	func_depth--;
 
 	return;


### PR DESCRIPTION
When FUNC_DONT_EXPAND_COMMAND isn't set, expand_vars allocates a string
and returns it. This string wasn't being freed by the calling function.

Fixes #425.

* **What does this PR do?**
Fixes a leak detected by Valgrind.
* **Screenshots (if applicable)**

* **Issue number(s)**
#425.
If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
