### PR TITLE
Fix returning pointer to freed memory in FCreateFImage.

### DIFF
--- a/libs/FImage.c
+++ b/libs/FImage.c
@@ -186,6 +186,7 @@ FImage *FCreateFImage (
 		else
 		{
 			free(fim);
+			return NULL;
 		}
 	}
 


### PR DESCRIPTION
When XCreateImage fails, fim is freed and then returned. The returned
pointer value is invalid.

* **What does this PR do?**
Fixes returning an invalid memory address in `FCreateFImage` by returning NULL.
* **Screenshots (if applicable)**

* **Issue number(s)**
#107
If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
