### PR TITLE
Fix double free.

### DIFF
--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -154,7 +154,10 @@ static struct moduleInfoList *AddToModList(char *tline)
 	this->data = expand_vars(rline, NULL, False, True, NULL, exc);
 	strcpy(this->data, rline);
 	exc_destroy_context(exc);
-	free(rline);
+	/* Free rline only if it is xasprintf'd memory (not pointing at tline
+	 * anymore). If we free our tline argument it causes a crash in __execute_function. */
+	if (rline != tline)
+		free(rline);
 
 	this->next = NULL;
 	if(prev == NULL)


### PR DESCRIPTION
 When a command starting with an asterisk was encountered, ModuleConfig
was called, which calls AddToModList which frees its argument
sometimes. Then __execute_function tries to free the same pointer
again. This commit fixes this by only freeing rline in AddToModList if
it points at xasprintf'd memory, as freeing the memory from xasprintf
won't invalidate expaction.  

Fixes #425.

* **What does this PR do?**
Fixes a double free by conditionally freeing `rline` in AddToModList only if it doesn't point at `tline` anymore (by calling xasprintf).

The command causing the segfault was:
`*FvwmIconMan*action      Mouse   1 N sendcommand "Iconify off", sendcommand "FlipFocus", sendcommand "Raise"`

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
