### PR TITLE
Fix a 21 byte memory leak.

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -1828,6 +1828,7 @@ int setup_visible_names(FvwmWindow *fw, int what_changed)
 			free(ext_name);
 		}
 	}
+	free_style(&style);
 
 	return (changed_styles) ? changed_styles : affected_titles;
 }
@@ -2358,6 +2359,7 @@ FvwmWindow *AddWindow(
 		}
 		free(fw);
 		MyXUngrabServer(dpy);
+		free_style(&style);
 		return NULL;
 	}
 
@@ -2389,6 +2391,7 @@ FvwmWindow *AddWindow(
 		}
 		free(fw);
 		MyXUngrabServer(dpy);
+		free_style(&style);
 		return AW_UNMANAGED;
 	}
 
@@ -2807,6 +2810,7 @@ FvwmWindow *AddWindow(
 		destroy_window(fw);
 		fw = NULL;
 	}
+	free_style(&style);
 
 	return fw;
 }

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -2426,6 +2426,7 @@ void CMD_PlaceAgain(F_CMD_ARGS)
 		AnimatedMoveFvwmWindow(
 			fw, FW_W_FRAME(fw), -1, -1, attr_g.x, attr_g.y, False,
 			-1, ppctMovement);
+		free_style(&style);
 	}
 	if (fw->Desk != old_desk)
 	{

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -785,7 +785,7 @@ static void merge_styles(
 	return;
 }
 
-static void free_style(window_style *style)
+void free_style(window_style *style)
 {
 	/* Free contents of style */
 	SAFEFREE(SGET_NAME(*style));
@@ -4764,7 +4764,7 @@ void lookup_style(FvwmWindow *fw, window_style *styles)
 	{
 		if (fw_match_style_id(fw, SGET_ID(*nptr)))
 		{
-			merge_styles(styles, nptr, False);
+			merge_styles(styles, nptr, True);
 		}
 	}
 	EWMH_GetStyle(fw, styles);

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -676,5 +676,6 @@ void update_icon_background_cs_style(FvwmWindow *fw, window_style *pstyle);
 void free_icon_boxes(icon_boxes *ib);
 void style_destroy_style(style_id_t s_id);
 void print_styles(int verbose);
+void free_style(window_style *style);
 
 #endif /* FVWM_STYLE_H */

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -655,6 +655,7 @@ void apply_decor_change(FvwmWindow *fw)
 	flags.do_redecorate = True;
 	flags.do_update_window_font_height = True;
 	apply_window_updates(fw, &flags, &style, get_focus_window());
+	free_style(&style);
 
 	return;
 }
@@ -725,6 +726,7 @@ void flush_window_updates(void)
 		}
 		/* now apply the changes */
 		apply_window_updates(t, &flags, &style, focus_fw);
+		free_style(&style);
 	}
 
 	/* restore the focus; also handles the case that the previously focused

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2699,6 +2699,7 @@ desk_get_fw_count(struct monitor *m, int desk)
 				if (SIS_UNMANAGED(sflags))
 					continue;
 				count++;
+				free_style(&style);
 			}
 		}
 	}


### PR DESCRIPTION
merge_styles allocated a small amount of memory using strdup(). This
memory wasn't being freed by the callers. I had to change
do_free_src_and_alloc_copy argument of merge_styles to True in
lookup_style() to get free_style() to stop crashing.

Fixes #430.

* **What does this PR do?**
Fixes a memory leak by always calling merge_styles with do_free_src_and_alloc_copy set to True and then calling free_style on the style later.

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
