### PR TITLE
Pager: don't restrict new_desk to monitor boundaries

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -787,7 +787,7 @@ void list_configure(unsigned long *body)
   }
 
   is_new_monitor = ((monitor_to_track != NULL) && (t->m != newm));
-  is_new_desk = (t->desk != cfgpacket->desk && is_new_monitor);
+  is_new_desk = (t->desk != cfgpacket->desk);
 
   /* If the monitor is different to the one the window was previously on,
    * remove the window in the pager as it's no longer on that screen.


### PR DESCRIPTION
When FvwmPager is asked to place a window in its view via a
{new,configurenotify}event, FvwmPager was previously ignoring the
new_desk event if the window's monitor didn't match.

This isn't correct, and the monitor shouldn't be required for tracking a
new desk.

Fixes #433
