### PR TITLE
PanFrames: correct right panframe location

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1083,7 +1083,7 @@ void checkPanFrames(void)
 				XMoveResizeWindow(
 					dpy, m->PanFrameRight.win,
 					(m->si->x + m->si->w) - edge_thickness,
-					m->si->y + m->si->h,
+					m->si->y,
 					edge_thickness, (m->si->y + m->si->h));
 			}
 			if (!m->PanFrameRight.isMapped)


### PR DESCRIPTION
When changing EdgeThickness, e.g. from default (2) to 1, PanFrameRight.win is
reconfigured with the wrong position (lower right corner instead of upper
right corner). Moving to a page at the right of the current page with the
mouse does not work as expected after that.

From Göran Bengtson on fvwm-workers@

Fixes #436
