### PR TITLE
PanFrames: handle DesktopConfiguration changes

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1505,8 +1505,7 @@ void StartupStuff(void)
 	}
 	/* Have to do this here too because preprocessor modules have not run
 	 * to the end when HandleEvents is entered from the main loop. */
-	checkPanFrames();
-
+	initPanFrames();
 	fFvwmInStartup = False;
 
 	/* Make sure the geometry window uses the current font */
@@ -2458,7 +2457,6 @@ int main(int argc, char **argv)
 	TAILQ_FOREACH(m, &monitor_q, entry)
 		EWMH_Init(m);
 
-	initPanFrames();
 	SetRCDefaults();
 	flush_window_updates();
 	simplify_style_list();

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1261,19 +1261,23 @@ void initPanFrames(void)
 
 		m = TAILQ_FIRST(&monitor_q);
 
+		attributes.cursor = Scr.FvwmCursors[CRS_TOP_EDGE];
 		m->PanFrameTop.win = XCreateWindow(dpy, Scr.Root, 0, 0, gw,
 		    edge_thickness, 0, CopyFromParent, InputOnly,
 		    CopyFromParent, valuemask, &attributes);
 
+		attributes.cursor = Scr.FvwmCursors[CRS_LEFT_EDGE];
 		m->PanFrameLeft.win = XCreateWindow(dpy, Scr.Root, 0, 0,
 		    edge_thickness, gh, 0, CopyFromParent, InputOnly,
 		    CopyFromParent, valuemask, &attributes);
 
+		attributes.cursor = Scr.FvwmCursors[CRS_RIGHT_EDGE];
 		m->PanFrameRight.win = XCreateWindow(dpy, Scr.Root,
 		    gw - edge_thickness, 0, edge_thickness, gh, 0,
 		    CopyFromParent, InputOnly, CopyFromParent, valuemask,
 		    &attributes);
 
+		attributes.cursor = Scr.FvwmCursors[CRS_BOTTOM_EDGE];
 		m->PanFrameBottom.win = XCreateWindow(dpy, Scr.Root, 0,
 		    gh - edge_thickness, gw, edge_thickness, 0,
 		    CopyFromParent, InputOnly, CopyFromParent, valuemask,

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -11,7 +11,6 @@ int HandlePaging(
 	XEvent *pev, int HorWarpSize, int VertWarpSize, int *xl, int *yt,
 	int *delta_x, int *delta_y, Bool Grab, Bool fLoop,
 	Bool do_continue_previous, int delay);
-void checkPanFrames(void);
 void raisePanFrames(void);
 void initPanFrames(void);
 Bool is_pan_frame(Window w);


### PR DESCRIPTION
When panframes are created, the DesktopConfiguration is taken in to
account.  This means that during startup, the panframes will be
initialised in the global state, but could change to being per-monitor
shortly afterward.
    
The implementation assumed that all monitors would needed to have been
checked, however this isn't true in the case of per-monitor mode; as a
result, panframes around other monitors were being unmapped.
    
Instead, callers of checkPanFrames() already know which monitor needs to
be involved and can pass that through.  This change removes the previous
should_free_panframe() call as it's never used from more than one place,
so can be inlined once more.  In doing so, s/Bool/bool/ since Bool is
reserved for X11 purposes.
    
Fixes #381, fixes #401