### PR TITLE
Only allocate a copy of style strings if requested.

### DIFF
--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -719,31 +719,65 @@ static void merge_styles(
 	}
 	if (add_style->flags.has_placement_position_string)
 	{
-		SAFEFREE(SGET_PLACEMENT_POSITION_STRING(*merged_style));
-		SSET_PLACEMENT_POSITION_STRING(
-			*merged_style,
-			strdup(SGET_PLACEMENT_POSITION_STRING(*add_style)));
+		if (do_free_src_and_alloc_copy)
+		{
+			SAFEFREE(SGET_PLACEMENT_POSITION_STRING(*merged_style));
+			SSET_PLACEMENT_POSITION_STRING(
+				*merged_style,
+				strdup(SGET_PLACEMENT_POSITION_STRING(*add_style)));
+		}
+		else
+		{
+			SSET_PLACEMENT_POSITION_STRING(
+				*merged_style,
+				SGET_PLACEMENT_POSITION_STRING(*add_style));
+		}
 	}
 	if (add_style->flags.has_initial_map_command_string)
 	{
-		SAFEFREE(SGET_INITIAL_MAP_COMMAND_STRING(*merged_style));
-		SSET_INITIAL_MAP_COMMAND_STRING(
-			*merged_style,
-			strdup(SGET_INITIAL_MAP_COMMAND_STRING(*add_style)));
+		if (do_free_src_and_alloc_copy)
+		{
+			SAFEFREE(SGET_INITIAL_MAP_COMMAND_STRING(*merged_style));
+			SSET_INITIAL_MAP_COMMAND_STRING(
+				*merged_style,
+				strdup(SGET_INITIAL_MAP_COMMAND_STRING(*add_style)));
+		}
+		else
+		{
+			SSET_INITIAL_MAP_COMMAND_STRING(
+				*merged_style,
+				SGET_INITIAL_MAP_COMMAND_STRING(*add_style));
+		}
 	}
 
 	if (add_style->flags.has_title_format_string)
 	{
-		SAFEFREE(SGET_TITLE_FORMAT_STRING(*merged_style));
-		SSET_TITLE_FORMAT_STRING(*merged_style,
+		if (do_free_src_and_alloc_copy)
+		{
+			SAFEFREE(SGET_TITLE_FORMAT_STRING(*merged_style));
+			SSET_TITLE_FORMAT_STRING(*merged_style,
 				strdup(SGET_TITLE_FORMAT_STRING(*add_style)));
+		}
+		else
+		{
+			SSET_TITLE_FORMAT_STRING(*merged_style,
+				SGET_TITLE_FORMAT_STRING(*add_style));
+		}
 	}
 
 	if (add_style->flags.has_icon_title_format_string)
 	{
-		SAFEFREE(SGET_ICON_TITLE_FORMAT_STRING(*merged_style));
-		SSET_ICON_TITLE_FORMAT_STRING(*merged_style,
+		if (do_free_src_and_alloc_copy)
+		{
+			SAFEFREE(SGET_ICON_TITLE_FORMAT_STRING(*merged_style));
+			SSET_ICON_TITLE_FORMAT_STRING(*merged_style,
 				strdup(SGET_ICON_TITLE_FORMAT_STRING(*add_style)));
+		}
+		else
+		{
+			SSET_ICON_TITLE_FORMAT_STRING(*merged_style,
+				SGET_ICON_TITLE_FORMAT_STRING(*add_style));
+		}
 	}
 	/* merge the style flags */
 


### PR DESCRIPTION
do_free_src_and_alloc_copy wasn't being checked for the placement
position, the initial map command, the title format, and the icon title
format.

Fixes #430.

* **What does this PR do?**
I took a different approach to fixing #430. This pull request fixes #430 by only allocating a copy of the style strings if copying was requested (i.e. `do_free_src_and_alloc_copy` is True), instead of the #431 approach that involved trying to free the style, which broke setting icon images.

I hope this PR doesn't break anything like my previous one did.

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
