### PR TITLE
Fix over-eager window positioning

### DIFF
--- a/fvwm/misc.c
+++ b/fvwm/misc.c
@@ -434,9 +434,9 @@ Bool IsRectangleOnThisPage(struct monitor *m, const rectangle *rec, int desk)
 
 	//if (m->virtual_scr.CurrentDesk == desk &&
 	if (rec->x + (signed int)rec->width > 0 &&
-		(rec->x < 0 || rec->x <= m->virtual_scr.MyDisplayWidth) &&
+		(rec->x < 0 || rec->x < m->virtual_scr.MyDisplayWidth) &&
 		rec->y + (signed int)rec->height > 0 &&
-		(rec->y < 0 || rec->y <= m->virtual_scr.MyDisplayHeight)) {
+		(rec->y < 0 || rec->y < m->virtual_scr.MyDisplayHeight)) {
 			return (True);
 	}
 	return (False);


### PR DESCRIPTION
When calculating if a window is on a page, ensure its position is less
than the overall height/width of the screen, and not equal to it.  This
would otherwise mean that maximized windows would be taken into account
when in fact they're on a separate page entirely.

Fixes #443
