### PR TITLE
add a CursorSet command

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4461,11 +4461,13 @@ MoveToDesk 0 n
 
 === Focus & Mouse Movement
 
-*CursorMove* _horizontal_[p] _vertical_[p]::
-	Moves the mouse pointer by _horizontal_ pages in the X direction and
-	_vertical_ pages in the Y direction. Either or both entries may be
-	negative. Both horizontal and vertical values are expressed in percent
-	of pages, so
+*CursorMove* _horizontal_[p] _vertical_[p] [_absolute horizontal_[p]] [_absolute vertical_[p]]::
+	Moves the mouse pointer by _horizontal_ pages in the X
+	direction and _vertical_ pages in the Y direction. Either or both
+	entries may be negative. Both horizontal and vertical values are
+	expressed in percent of pages. If both horizontal and vertical are zero,
+	then mouse pointer moves _to_ the position specified by _absolute
+	horizontal_ and _absolute vertical_.
 +
 
 ....
@@ -4493,6 +4495,18 @@ CursorMove -10p -10p
 +
 means move ten pixels up and ten pixels left. The CursorMove function
 should not be called from pop-up menus.
++
+....
+CursorMove 0 0 50 50
+....
++
+means move the mouse at the center of the screen.
++
+....
+CursorMove 0 0 100p 100p
+....
++
+means move the mouse to pixel 100,100 on the screen.
 
 *FlipFocus* [NoWarp]::
 	Executes a *Focus* command as if the user had used the pointer to

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2286,14 +2286,21 @@ void CMD_CursorMove(F_CMD_ARGS)
 	int x_pages, y_pages;
 	struct monitor	*m = NULL;
 
-	if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2)
-	{
+	if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2) {
 		fvwm_debug(__func__, "CursorMove needs 2 arguments");
 		return;
 	}
-	if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
-			  &x, &y, &JunkX, &JunkY, &JunkMask) == False)
-	{
+	if (val1 == 0 && val2 == 0) {
+		/* Move to absolute point */
+		action = SkipNTokens(action, 2);
+		if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2) {
+			return;
+		}
+		/* x and y are 0 and we skip the QueryPointer so that we can
+		 * move to the absolute point. */
+	} else if (FQueryPointer(
+			dpy, Scr.Root, &JunkRoot, &JunkChild,
+			&x, &y, &JunkX, &JunkY, &JunkMask) == False) {
 		/* pointer is on a different screen */
 		return;
 	}
@@ -2369,12 +2376,10 @@ void CMD_CursorMove(F_CMD_ARGS)
 	 * Whilst this stops the cursor short of the edge of the screen in a
 	 * given direction, this is the desired behaviour.
 	 */
-	if (m->virtual_scr.EdgeScrollX == 0 && (x >= m->virtual_scr.MyDisplayWidth ||
-	    x + x_unit >= m->virtual_scr.MyDisplayWidth))
+	if (m->virtual_scr.EdgeScrollX == 0 && x >= m->virtual_scr.MyDisplayWidth)
 		return;
 
-	if (m->virtual_scr.EdgeScrollY == 0 && (y >= m->virtual_scr.MyDisplayHeight ||
-	    y + y_unit >= m->virtual_scr.MyDisplayHeight))
+	if (m->virtual_scr.EdgeScrollY == 0 && y >= m->virtual_scr.MyDisplayHeight)
 		return;
 
 	FWarpPointerUpdateEvpos(

--- a/libs/Parse.c
+++ b/libs/Parse.c
@@ -840,13 +840,11 @@ int GetTwoPercentArguments(
 {
 	char *tok1;
 	char *tok2;
-	char *next;
 	int n = 0;
 
 	*val1 = 0;
 	*val2 = 0;
 
-	tok1 = PeekToken(action, &next);
 	action = GetNextToken(action, &tok1);
 	if (!tok1)
 	{


### PR DESCRIPTION
`CursorSet` can set an absolute mouse cursor position. This is helpful for save and restoring mouse cursor positions.

On IRC, we talked about support some auto mouse move features from CWM. With `CursorSet`, you no longer need an external script/process and `CursorMove` to save and restore the cursor.