### PR TITLE
_NET_CURRENT_DESKTOP: update across monitor boundaries

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2540,6 +2540,7 @@ void HandleFocusIn(const evh_args_t *ea)
 				BroadcastName(MX_MONITOR_FOCUS, -1, -1, -1,
 				    fw->m->si->name /* Name of the monitor. */
 			        );
+				EWMH_SetCurrentDesktop(fw->m);
 			}
 			status_send();
 		}


### PR DESCRIPTION
When dealing with a configuration of per-monitor, make sure that the
current desktop is updated to reflect any differences in desktops when
moving/draging windows between monitors.

Chrome uses the _NET_CURRENT_DESKTOP to track where windows are when it
comes to dragging and dropping tabs.

Fixes #442
