### PR TITLE
change the default of warp to window to 50%,50%

### DIFF
--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -1252,30 +1252,35 @@ void CMD_WarpToWindow(F_CMD_ARGS)
 		}
 		else
 		{
-			warp_to_fvwm_window(exc, 0, 0, 0, 0, do_raise);
+			warp_to_fvwm_window(
+				exc,
+				50, m->virtual_scr.MyDisplayWidth,
+				50, m->virtual_scr.MyDisplayHeight,
+				do_raise);
 		}
 	}
 	else
 	{
-		int x = 0;
-		int y = 0;
+		int wx;
+		int wy;
+		int ww;
+		int wh;
+
+		if (!XGetGeometry(
+				dpy, exc->w.w, &JunkRoot, &wx, &wy,
+				(unsigned int*)&ww, (unsigned int*)&wh,
+				(unsigned int*)&JunkBW,
+				(unsigned int*)&JunkDepth))
+		{
+			free(token);
+			return;
+		}
+
+		int x = (ww - 1) / 2;
+		int y = (wh - 1) / 2;
 
 		if (n == 2)
 		{
-			int wx;
-			int wy;
-			int ww;
-			int wh;
-
-			if (!XGetGeometry(
-				    dpy, exc->w.w, &JunkRoot, &wx, &wy,
-				    (unsigned int*)&ww, (unsigned int*)&wh,
-				    (unsigned int*)&JunkBW,
-				    (unsigned int*)&JunkDepth))
-			{
-				free(token);
-				return;
-			}
 			if (val1_unit != m->virtual_scr.MyDisplayWidth)
 			{
 				x = val1;


### PR DESCRIPTION
If no parameter is given to `WarpToWindow`, then it defaults to `WarpToWindow 0 0` without reporting an error.

I believe this is intentional, because `WarpToWindow` with two variables that fail to expand can cause this undocumented behaviour. However, 0, 0 means at the top-left of the window, which is extremely awkward. This patch changes this (undocumented) default to 50%, 50%, which is the centre of the window.