### PR TITLE
Revert the commit that supports CursorMove to an absolute position

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4464,8 +4464,10 @@ MoveToDesk 0 n
 *CursorMove* _horizontal_[p] _vertical_[p]::
 	Moves the mouse pointer by _horizontal_ pages in the X direction and
 	_vertical_ pages in the Y direction. Either or both entries may be
-	negative. Both horizontal and vertical values are expressed in percent
-	of pages, so
+	negative. CursorMove can only move the mouse cursor to a relative
+	position. To move the mouse cursor to an absolute position, see
+	*WarpToWindow*. Both horizontal and vertical values are expressed in
+	percent of pages, so
 +
 
 ....

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4461,13 +4461,11 @@ MoveToDesk 0 n
 
 === Focus & Mouse Movement
 
-*CursorMove* _horizontal_[p] _vertical_[p] [_absolute horizontal_[p]] [_absolute vertical_[p]]::
-	Moves the mouse pointer by _horizontal_ pages in the X
-	direction and _vertical_ pages in the Y direction. Either or both
-	entries may be negative. Both horizontal and vertical values are
-	expressed in percent of pages. If both horizontal and vertical are zero,
-	then mouse pointer moves _to_ the position specified by _absolute
-	horizontal_ and _absolute vertical_.
+*CursorMove* _horizontal_[p] _vertical_[p]::
+	Moves the mouse pointer by _horizontal_ pages in the X direction and
+	_vertical_ pages in the Y direction. Either or both entries may be
+	negative. Both horizontal and vertical values are expressed in percent
+	of pages, so
 +
 
 ....
@@ -4495,18 +4493,6 @@ CursorMove -10p -10p
 +
 means move ten pixels up and ten pixels left. The CursorMove function
 should not be called from pop-up menus.
-+
-....
-CursorMove 0 0 50 50
-....
-+
-means move the mouse at the center of the screen.
-+
-....
-CursorMove 0 0 100p 100p
-....
-+
-means move the mouse to pixel 100,100 on the screen.
 
 *FlipFocus* [NoWarp]::
 	Executes a *Focus* command as if the user had used the pointer to

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2286,21 +2286,14 @@ void CMD_CursorMove(F_CMD_ARGS)
 	int x_pages, y_pages;
 	struct monitor	*m = NULL;
 
-	if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2) {
+	if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2)
+	{
 		fvwm_debug(__func__, "CursorMove needs 2 arguments");
 		return;
 	}
-	if (val1 == 0 && val2 == 0) {
-		/* Move to absolute point */
-		action = SkipNTokens(action, 2);
-		if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2) {
-			return;
-		}
-		/* x and y are 0 and we skip the QueryPointer so that we can
-		 * move to the absolute point. */
-	} else if (FQueryPointer(
-			dpy, Scr.Root, &JunkRoot, &JunkChild,
-			&x, &y, &JunkX, &JunkY, &JunkMask) == False) {
+	if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
+			  &x, &y, &JunkX, &JunkY, &JunkMask) == False)
+	{
 		/* pointer is on a different screen */
 		return;
 	}
@@ -2376,10 +2369,12 @@ void CMD_CursorMove(F_CMD_ARGS)
 	 * Whilst this stops the cursor short of the edge of the screen in a
 	 * given direction, this is the desired behaviour.
 	 */
-	if (m->virtual_scr.EdgeScrollX == 0 && x >= m->virtual_scr.MyDisplayWidth)
+	if (m->virtual_scr.EdgeScrollX == 0 && (x >= m->virtual_scr.MyDisplayWidth ||
+	    x + x_unit >= m->virtual_scr.MyDisplayWidth))
 		return;
 
-	if (m->virtual_scr.EdgeScrollY == 0 && y >= m->virtual_scr.MyDisplayHeight)
+	if (m->virtual_scr.EdgeScrollY == 0 && (y >= m->virtual_scr.MyDisplayHeight ||
+	    y + y_unit >= m->virtual_scr.MyDisplayHeight))
 		return;
 
 	FWarpPointerUpdateEvpos(


### PR DESCRIPTION
This PR reverts the `CursorMove 0,0,x,y` usage because `WarpToWindow` provides exactly the same thing.

Also update the document in case another user is looking for the same functionality.