### PR TITLE
Tear-off menu: don't mask pos_hints

### DIFF
--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -6207,6 +6207,9 @@ void do_menu(MenuParameters *pmp, MenuReturn *pmret)
 					indirect_depth--;
 					free(*pmp->ret_paction);
 					*pmp->ret_paction = NULL;
+
+					MyXUngrabKeyboard(dpy);
+					return;
 				}
 				last_saved_pos_hints.flags.
 					do_ignore_pos_hints = False;


### PR DESCRIPTION
When a submenu of a tearoff submenu (that's going to be tricky to read
in ~6 months time) has an action associated with it, the action would
only run when the pointer moved outside of the menu.

Don't store the position hints for such menus when executing an action.

Fixes #456
