### PR TITLE
EWMH: CurrentDesktop improvements

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2543,7 +2543,9 @@ void HandleFocusIn(const evh_args_t *ea)
 				BroadcastName(MX_MONITOR_FOCUS, -1, -1, -1,
 				    fw->m->si->name /* Name of the monitor. */
 			        );
-				EWMH_SetCurrentDesktop(fw->m);
+				if (pfm->virtual_scr.CurrentDesk !=
+				    fw->m->virtual_scr.CurrentDesk)
+					EWMH_SetCurrentDesktop(fw->m);
 			}
 			status_send();
 		}

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2536,7 +2536,10 @@ void HandleFocusIn(const evh_args_t *ea)
 				(long)fc, (long)bc);
 			EWMH_SetActiveWindow(focus_w);
 
-			if (fw != NULL && strcmp(fw->m->si->name, prev_focused_monitor) != 0) {
+			struct monitor *pfm;
+			pfm = monitor_resolve_name( prev_focused_monitor);
+
+			if (fw != NULL && fw->m != pfm) {
 				BroadcastName(MX_MONITOR_FOCUS, -1, -1, -1,
 				    fw->m->si->name /* Name of the monitor. */
 			        );


### PR DESCRIPTION
This PR does the following:

* Reduces overhead on `monitor_focus` events, by comparing `struct monitor *` pointers, and not strings;
* Only updates the `_NET_CURRENT_DESKTOP` value when focusing monitors, if the desktop number itself is different between the two.