### PR TITLE
API: remove MyDisplay{Width,Height}

### DIFF
--- a/contrib/coccinelle/remove_mw_mh.cocci
+++ b/contrib/coccinelle/remove_mw_mh.cocci
@@ -1,0 +1,13 @@
+@@
+expression *m;
+@@
+
+- m->virtual_scr.MyDisplayWidth
++ monitor_get_all_widths()
+
+@@
+expression *m;
+@@
+
+- m->virtual_scr.MyDisplayHeight
++ monitor_get_all_heights()

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -278,8 +278,8 @@ static void hide_screen(
 		valuemask = CWOverrideRedirect | CWCursor | CWSaveUnder |
 			CWBackingStore | CWBackPixmap;
 		hide_win = XCreateWindow(
-			dpy, Scr.Root, 0, 0, m->virtual_scr.MyDisplayWidth,
-			m->virtual_scr.MyDisplayHeight, 0, Pdepth, InputOutput,
+			dpy, Scr.Root, 0, 0, monitor_get_all_widths(),
+			monitor_get_all_heights(), 0, Pdepth, InputOutput,
 			Pvisual, valuemask, &xswa);
 		if (hide_win)
 		{
@@ -289,8 +289,8 @@ static void hide_screen(
 			 * reparent them to an unmapped window that looks like
 			 * the root window. */
 			parent_win = XCreateWindow(
-				dpy, Scr.Root, 0, 0, m->virtual_scr.MyDisplayWidth,
-				m->virtual_scr.MyDisplayHeight, 0, CopyFromParent,
+				dpy, Scr.Root, 0, 0, monitor_get_all_widths(),
+				monitor_get_all_heights(), 0, CopyFromParent,
 				InputOutput, CopyFromParent, valuemask, &xswa);
 			if (!parent_win)
 			{
@@ -2702,8 +2702,8 @@ FvwmWindow *AddWindow(
 		memset(&e, 0, sizeof(e));
 		FWarpPointer(
 			dpy, Scr.Root, Scr.Root, 0, 0,
-			mon->virtual_scr.MyDisplayWidth,
-			mon->virtual_scr.MyDisplayHeight,
+			monitor_get_all_widths(),
+			monitor_get_all_heights(),
 			fw->g.frame.x + (fw->g.frame.width>>1),
 			fw->g.frame.y + (fw->g.frame.height>>1));
 		e.xany.type = ButtonPress;
@@ -3596,25 +3596,25 @@ void RestoreWithdrawnLocation(
 	{
 		/* Don't mess with it if its partially on the screen now */
 		if (unshaded_g.x < 0 || unshaded_g.y < 0 ||
-		    unshaded_g.x >= m->virtual_scr.MyDisplayWidth ||
-		    unshaded_g.y >= m->virtual_scr.MyDisplayHeight)
+		    unshaded_g.x >= monitor_get_all_widths() ||
+		    unshaded_g.y >= monitor_get_all_heights())
 		{
 			w2 = (unshaded_g.width >> 1);
 			h2 = (unshaded_g.height >> 1);
-			if ( xwc.x < -w2 || xwc.x > m->virtual_scr.MyDisplayWidth - w2)
+			if ( xwc.x < -w2 || xwc.x > monitor_get_all_widths() - w2)
 			{
-				xwc.x = xwc.x % m->virtual_scr.MyDisplayWidth;
+				xwc.x = xwc.x % monitor_get_all_widths();
 				if (xwc.x < -w2)
 				{
-					xwc.x += m->virtual_scr.MyDisplayWidth;
+					xwc.x += monitor_get_all_widths();
 				}
 			}
-			if (xwc.y < -h2 || xwc.y > m->virtual_scr.MyDisplayHeight - h2)
+			if (xwc.y < -h2 || xwc.y > monitor_get_all_heights() - h2)
 			{
-				xwc.y = xwc.y % m->virtual_scr.MyDisplayHeight;
+				xwc.y = xwc.y % monitor_get_all_heights();
 				if (xwc.y < -h2)
 				{
-					xwc.y += m->virtual_scr.MyDisplayHeight;
+					xwc.y += monitor_get_all_heights();
 				}
 			}
 		}

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -1398,8 +1398,8 @@ void refresh_window(Window w, Bool window_update)
 	attributes.background_pixmap = None;
 	attributes.backing_store = NotUseful;
 	w = XCreateWindow(
-		dpy, w, 0, 0, m->virtual_scr.MyDisplayWidth,
-		m->virtual_scr.MyDisplayHeight, 0,
+		dpy, w, 0, 0, monitor_get_all_widths(),
+		monitor_get_all_heights(), 0,
 		CopyFromParent, CopyFromParent, CopyFromParent, valuemask,
 		&attributes);
 	XMapWindow(dpy, w);
@@ -2310,14 +2310,14 @@ void CMD_CursorMove(F_CMD_ARGS)
 	virtual_y = m->virtual_scr.Vy;
 	if (x >= 0)
 	{
-		x_pages = x / m->virtual_scr.MyDisplayWidth;
+		x_pages = x / monitor_get_all_widths();
 	}
 	else
 	{
-		x_pages = ((x + 1) / m->virtual_scr.MyDisplayWidth) - 1;
+		x_pages = ((x + 1) / monitor_get_all_widths()) - 1;
 	}
-	virtual_x += x_pages * m->virtual_scr.MyDisplayWidth;
-	x -= x_pages * m->virtual_scr.MyDisplayWidth;
+	virtual_x += x_pages * monitor_get_all_widths();
+	x -= x_pages * monitor_get_all_widths();
 	if (virtual_x < 0)
 	{
 		x += virtual_x;
@@ -2331,14 +2331,14 @@ void CMD_CursorMove(F_CMD_ARGS)
 
 	if (y >= 0)
 	{
-		y_pages = y / m->virtual_scr.MyDisplayHeight;
+		y_pages = y / monitor_get_all_heights();
 	}
 	else
 	{
-		y_pages = ((y + 1) / m->virtual_scr.MyDisplayHeight) - 1;
+		y_pages = ((y + 1) / monitor_get_all_heights()) - 1;
 	}
-	virtual_y += y_pages > m->virtual_scr.MyDisplayHeight;
-	y -= y_pages * m->virtual_scr.MyDisplayHeight;
+	virtual_y += y_pages > monitor_get_all_heights();
+	y -= y_pages * monitor_get_all_heights();
 
 	if (virtual_y < 0)
 	{
@@ -2369,18 +2369,18 @@ void CMD_CursorMove(F_CMD_ARGS)
 	 * Whilst this stops the cursor short of the edge of the screen in a
 	 * given direction, this is the desired behaviour.
 	 */
-	if (m->virtual_scr.EdgeScrollX == 0 && (x >= m->virtual_scr.MyDisplayWidth ||
-	    x + x_unit >= m->virtual_scr.MyDisplayWidth))
+	if (m->virtual_scr.EdgeScrollX == 0 && (x >= monitor_get_all_widths() ||
+						x + x_unit >= monitor_get_all_widths()))
 		return;
 
-	if (m->virtual_scr.EdgeScrollY == 0 && (y >= m->virtual_scr.MyDisplayHeight ||
-	    y + y_unit >= m->virtual_scr.MyDisplayHeight))
+	if (m->virtual_scr.EdgeScrollY == 0 && (y >= monitor_get_all_heights() ||
+						y + y_unit >= monitor_get_all_heights()))
 		return;
 
 	FWarpPointerUpdateEvpos(
 		exc->x.elast, dpy, None, Scr.Root, 0, 0,
-		m->virtual_scr.MyDisplayWidth,
-		m->virtual_scr.MyDisplayHeight, x, y);
+		monitor_get_all_widths(),
+		monitor_get_all_heights(), x, y);
 
 	return;
 }

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -734,8 +734,8 @@ static inline void _cr_detect_icccm_move(
 	/* check full screen */
 	if ((cre->value_mask & (CWX | CWY)) == (CWX | CWY) &&
 	    (has_x || has_y) &&
-	    cre->width == mon->virtual_scr.MyDisplayWidth &&
-	    cre->height == mon->virtual_scr.MyDisplayHeight)
+	    cre->width == monitor_get_all_widths() &&
+	    cre->height == monitor_get_all_heights())
 	{
 		if (grav_g.x == -b->top_left.width &&
 		    grav_g.y == -b->top_left.height)
@@ -804,11 +804,11 @@ static inline void _cr_detect_icccm_move(
 	{
 		mx = CR_MOTION_METHOD_AUTO;
 	}
-	else if (static_g.x == 0 || static_g.x + w == mon->virtual_scr.MyDisplayWidth)
+	else if (static_g.x == 0 || static_g.x + w == monitor_get_all_widths())
 	{
 		mx = CR_MOTION_METHOD_STATIC_GRAV;
 	}
-	else if (grav_g.x == 0 || grav_g.x + w == mon->virtual_scr.MyDisplayWidth)
+	else if (grav_g.x == 0 || grav_g.x + w == monitor_get_all_widths())
 	{
 		mx = CR_MOTION_METHOD_USE_GRAV;
 	}
@@ -820,11 +820,11 @@ static inline void _cr_detect_icccm_move(
 	{
 		my = CR_MOTION_METHOD_AUTO;
 	}
-	else if (static_g.y == 0 || static_g.y + h == mon->virtual_scr.MyDisplayHeight)
+	else if (static_g.y == 0 || static_g.y + h == monitor_get_all_heights())
 	{
 		my = CR_MOTION_METHOD_STATIC_GRAV;
 	}
-	else if (grav_g.y == 0 || grav_g.y + h == mon->virtual_scr.MyDisplayHeight)
+	else if (grav_g.y == 0 || grav_g.y + h == monitor_get_all_heights())
 	{
 		my = CR_MOTION_METHOD_USE_GRAV;
 	}

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1164,28 +1164,28 @@ float ewmh_GetStrutIntersection(struct monitor *m,
 	x21 = 0;
 	y21 = 0;
 	x22 = left;
-	y22 = m->virtual_scr.MyDisplayHeight;
+	y22 = monitor_get_all_heights();
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 	/* right */
-	x21 = m->virtual_scr.MyDisplayWidth - right;
+	x21 = monitor_get_all_widths() - right;
 	y21 = 0;
-	x22 = m->virtual_scr.MyDisplayWidth;
-	y22 = m->virtual_scr.MyDisplayHeight;
+	x22 = monitor_get_all_widths();
+	y22 = monitor_get_all_heights();
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 	/* top */
 	x21 = 0;
 	y21 = 0;
-	x22 = m->virtual_scr.MyDisplayWidth;
+	x22 = monitor_get_all_widths();
 	y22 = top;
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 	/* bottom */
 	x21 = 0;
-	y21 = m->virtual_scr.MyDisplayHeight - bottom;
-	x22 = m->virtual_scr.MyDisplayWidth;
-	y22 = m->virtual_scr.MyDisplayHeight;
+	y21 = monitor_get_all_heights() - bottom;
+	x22 = monitor_get_all_widths();
+	y22 = monitor_get_all_heights();
 	ret += get_intersection(
 		x11, y11, x12, y12, x21, y21, x22, y22, use_percent);
 
@@ -1209,11 +1209,11 @@ float EWMH_GetStrutIntersection(struct monitor *m,
 	/* FIXME: needs broadcast if global monitor in use. */
 
 	left = m->Desktops->ewmh_working_area.x;
-	right = m->virtual_scr.MyDisplayWidth -
+	right = monitor_get_all_widths() -
 		(m->Desktops->ewmh_working_area.x
 		 + m->Desktops->ewmh_working_area.width);
 	top = m->Desktops->ewmh_working_area.y;
-	bottom = m->virtual_scr.MyDisplayHeight -
+	bottom = monitor_get_all_heights() -
 		(m->Desktops->ewmh_working_area.y
 		 + m->Desktops->ewmh_working_area.height);
 

--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -75,8 +75,8 @@ int ewmh_DesktopGeometry(
 	long height = ev->xclient.data.l[1];
 	struct monitor	*m = monitor_get_current();
 
-	width = width / m->virtual_scr.MyDisplayWidth;
-	height = height / m->virtual_scr.MyDisplayHeight;
+	width = width / monitor_get_all_widths();
+	height = height / monitor_get_all_heights();
 
 	if (width <= 0 || height <= 0)
 	{

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -590,19 +590,19 @@ static signed int expand_vars_extended(
 		break;
 	case VAR_DESK_WIDTH:
 		is_numeric = True;
-		val = m->virtual_scr.VxMax + m->virtual_scr.MyDisplayWidth;
+		val = m->virtual_scr.VxMax + monitor_get_all_widths();
 		break;
 	case VAR_DESK_HEIGHT:
 		is_numeric = True;
-		val = m->virtual_scr.VyMax + m->virtual_scr.MyDisplayHeight;
+		val = m->virtual_scr.VyMax + monitor_get_all_heights();
 		break;
 	case VAR_DESK_PAGESX:
 		is_numeric = True;
-		val = (int)(m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth) + 1;
+		val = (int)(m->virtual_scr.VxMax / monitor_get_all_widths()) + 1;
 		break;
 	case VAR_DESK_PAGESY:
 		is_numeric = True;
-		val = (int)(m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight) + 1;
+		val = (int)(m->virtual_scr.VyMax / monitor_get_all_heights()) + 1;
 		break;
 	case VAR_VP_X:
 		is_numeric = True;
@@ -614,11 +614,11 @@ static signed int expand_vars_extended(
 		break;
 	case VAR_VP_WIDTH:
 		is_numeric = True;
-		val = m->virtual_scr.MyDisplayWidth;
+		val = monitor_get_all_widths();
 		break;
 	case VAR_VP_HEIGHT:
 		is_numeric = True;
-		val = m->virtual_scr.MyDisplayHeight;
+		val = monitor_get_all_heights();
 		break;
 	case VAR_WA_HEIGHT:
 		is_numeric = True;

--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -478,8 +478,8 @@ static void warp_to_fvwm_window(
 		cx = t->g.frame.x + t->g.frame.width/2;
 		cy = t->g.frame.y + t->g.frame.height/2;
 	}
-	dx = (cx + m->virtual_scr.Vx) / m->virtual_scr.MyDisplayWidth * m->virtual_scr.MyDisplayWidth;
-	dy = (cy + m->virtual_scr.Vy) / m->virtual_scr.MyDisplayHeight * m->virtual_scr.MyDisplayHeight;
+	dx = (cx + m->virtual_scr.Vx) / monitor_get_all_widths() * monitor_get_all_widths();
+	dy = (cy + m->virtual_scr.Vy) / monitor_get_all_heights() * monitor_get_all_heights();
 	if (dx != m->virtual_scr.Vx || dy != m->virtual_scr.Vy)
 	{
 		MoveViewport(m, dx, dy, True);
@@ -499,11 +499,11 @@ static void warp_to_fvwm_window(
 	}
 	else
 	{
-		if (x_unit != m->virtual_scr.MyDisplayWidth && warp_x >= 0)
+		if (x_unit != monitor_get_all_widths() && warp_x >= 0)
 		{
 			x = t->g.frame.x + warp_x;
 		}
-		else if (x_unit != m->virtual_scr.MyDisplayWidth)
+		else if (x_unit != monitor_get_all_widths())
 		{
 			x = t->g.frame.x + t->g.frame.width + warp_x;
 		}
@@ -518,11 +518,11 @@ static void warp_to_fvwm_window(
 				(t->g.frame.width - 1) * (100 + warp_x) / 100;
 		}
 
-		if (y_unit != m->virtual_scr.MyDisplayHeight && warp_y >= 0)
+		if (y_unit != monitor_get_all_heights() && warp_y >= 0)
 		{
 			y = t->g.frame.y + warp_y;
 		}
-		else if (y_unit != m->virtual_scr.MyDisplayHeight)
+		else if (y_unit != monitor_get_all_heights())
 		{
 			y = t->g.frame.y + t->g.frame.height + warp_y;
 		}
@@ -546,8 +546,8 @@ static void warp_to_fvwm_window(
 	/* If the window is still not visible, make it visible! */
 	if (t->g.frame.x + t->g.frame.width  < 0 ||
 	    t->g.frame.y + t->g.frame.height < 0 ||
-	    t->g.frame.x >= m->virtual_scr.MyDisplayWidth ||
-	    t->g.frame.y >= m->virtual_scr.MyDisplayHeight)
+	    t->g.frame.x >= monitor_get_all_widths() ||
+	    t->g.frame.y >= monitor_get_all_heights())
 	{
 		frame_setup_window(
 			t, 0, 0, t->g.frame.width, t->g.frame.height, False);
@@ -698,16 +698,16 @@ static void __activate_window_by_command(
 			cy = fw->g.frame.y + fw->g.frame.height/2;
 		}
 		if (
-			cx < 0 || cx >= m->virtual_scr.MyDisplayWidth ||
-			cy < 0 || cy >= m->virtual_scr.MyDisplayHeight)
+			cx < 0 || cx >= monitor_get_all_widths() ||
+			cy < 0 || cy >= monitor_get_all_heights())
 		{
 			int dx;
 			int dy;
 
-			dx = ((cx + m->virtual_scr.Vx) / m->virtual_scr.MyDisplayWidth) *
-				m->virtual_scr.MyDisplayWidth;
-			dy = ((cy + m->virtual_scr.Vy) / m->virtual_scr.MyDisplayHeight) *
-				m->virtual_scr.MyDisplayHeight;
+			dx = ((cx + m->virtual_scr.Vx) / monitor_get_all_widths()) *
+				monitor_get_all_widths();
+			dy = ((cy + m->virtual_scr.Vy) / monitor_get_all_heights()) *
+				monitor_get_all_heights();
 			MoveViewport(m, dx, dy, True);
 		}
 #if 0 /* can not happen */
@@ -1276,7 +1276,7 @@ void CMD_WarpToWindow(F_CMD_ARGS)
 				free(token);
 				return;
 			}
-			if (val1_unit != m->virtual_scr.MyDisplayWidth)
+			if (val1_unit != monitor_get_all_widths())
 			{
 				x = val1;
 			}
@@ -1284,7 +1284,7 @@ void CMD_WarpToWindow(F_CMD_ARGS)
 			{
 				x = (ww - 1) * val1 / 100;
 			}
-			if (val2_unit != m->virtual_scr.MyDisplayHeight)
+			if (val2_unit != monitor_get_all_heights())
 			{
 				y = val2;
 			}

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -659,8 +659,8 @@ void maximize_adjust_offset(FvwmWindow *fw)
 	m = fw->m;
 	off_x = fw->g.normal.x - fw->g.max.x - fw->g.max_offset.x;
 	off_y = fw->g.normal.y - fw->g.max.y - fw->g.max_offset.y;
-	dw = m->virtual_scr.MyDisplayWidth;
-	dh = m->virtual_scr.MyDisplayHeight;
+	dw = monitor_get_all_widths();
+	dh = monitor_get_all_heights();
 	if (off_x >= dw)
 	{
 		fw->g.normal.x -= (off_x / dw) * dw;
@@ -949,7 +949,7 @@ void constrain_size(
 		}
 		else if (
 			xmotion < 0 && e->xmotion.x_root >=
-			m->virtual_scr.MyDisplayWidth - round_up.width)
+			monitor_get_all_widths() - round_up.width)
 		{
 			d.width -= inc.width;
 		}
@@ -959,7 +959,7 @@ void constrain_size(
 		}
 		else if (
 			ymotion < 0 && e->xmotion.y_root >=
-			m->virtual_scr.MyDisplayHeight - round_up.height)
+			monitor_get_all_heights() - round_up.height)
 		{
 			d.height -= inc.height;
 		}
@@ -1360,14 +1360,14 @@ void get_page_offset_rectangle(FvwmWindow *fw,
 
 	/* FIXME: broadcast if global monitor in use. */
 
-	int xoff = m->virtual_scr.Vx % m->virtual_scr.MyDisplayWidth;
-	int yoff = m->virtual_scr.Vy % m->virtual_scr.MyDisplayHeight;
+	int xoff = m->virtual_scr.Vx % monitor_get_all_widths();
+	int yoff = m->virtual_scr.Vy % monitor_get_all_heights();
 
 	/* maximize on the page where the center of the window is */
 	*ret_page_x = truncate_to_multiple(
-		r->x + r->width / 2 + xoff, m->virtual_scr.MyDisplayWidth) - xoff;
+		r->x + r->width / 2 + xoff, monitor_get_all_widths()) - xoff;
 	*ret_page_y = truncate_to_multiple(
-		r->y + r->height / 2 + yoff, m->virtual_scr.MyDisplayHeight) - yoff;
+		r->y + r->height / 2 + yoff, monitor_get_all_heights()) - yoff;
 
 	return;
 }

--- a/fvwm/icons.c
+++ b/fvwm/icons.c
@@ -1661,12 +1661,12 @@ void AutoPlaceIcon(
     base_x = 0;
     base_y = 0;
     /*Also, if its a stickyWindow, put it on the current page! */
-    new_x = t->g.frame.x % t->m->virtual_scr.MyDisplayWidth;
-    new_y = t->g.frame.y % t->m->virtual_scr.MyDisplayHeight;
+    new_x = t->g.frame.x % monitor_get_all_widths();
+    new_y = t->g.frame.y % monitor_get_all_heights();
     if (new_x + t->g.frame.width <= 0)
-      new_x += t->m->virtual_scr.MyDisplayWidth;
+      new_x += monitor_get_all_widths();
     if (new_y + t->g.frame.height <= 0)
-      new_y += t->m->virtual_scr.MyDisplayHeight;
+      new_y += monitor_get_all_heights();
     frame_setup_window(
 	    t, new_x, new_y, t->g.frame.width, t->g.frame.height, False);
   }
@@ -1678,9 +1678,9 @@ void AutoPlaceIcon(
   else
   {
     base_x = ((t->g.frame.x + t->m->virtual_scr.Vx + (t->g.frame.width >> 1)) /
-      t->m->virtual_scr.MyDisplayWidth) * t->m->virtual_scr.MyDisplayWidth;
+      monitor_get_all_widths()) * monitor_get_all_widths();
     base_y= ((t->g.frame.y + t->m->virtual_scr.Vy + (t->g.frame.height >> 1)) /
-      t->m->virtual_scr.MyDisplayHeight) * t->m->virtual_scr.MyDisplayHeight;
+      monitor_get_all_heights()) * monitor_get_all_heights();
     /* limit icon position to desktop */
     if (base_x > t->m->virtual_scr.VxMax)
       base_x = t->m->virtual_scr.VxMax;
@@ -1710,15 +1710,15 @@ void AutoPlaceIcon(
     dy = g.y;
 
     /* just make sure the icon is on this page */
-    g.x = g.x % t->m->virtual_scr.MyDisplayWidth + base_x;
-    g.y = g.y % t->m->virtual_scr.MyDisplayHeight + base_y;
+    g.x = g.x % monitor_get_all_widths() + base_x;
+    g.y = g.y % monitor_get_all_heights() + base_y;
     if (g.x < 0)
     {
-      g.x += t->m->virtual_scr.MyDisplayWidth;
+      g.x += monitor_get_all_widths();
     }
     if (g.y < 0)
     {
-      g.y += t->m->virtual_scr.MyDisplayHeight;
+      g.y += monitor_get_all_heights();
     }
     dx = g.x - dx;
     dy = g.y - dy;
@@ -2358,11 +2358,11 @@ void DeIconify(FvwmWindow *fw)
 					t->g.frame.x -=
 						truncate_to_multiple(
 							t->g.frame.x,
-							t->m->virtual_scr.MyDisplayWidth);
+							monitor_get_all_widths());
 					t->g.frame.y -=
 						truncate_to_multiple(
 							t->g.frame.y,
-							t->m->virtual_scr.MyDisplayHeight);
+							monitor_get_all_heights());
 					XMoveWindow(
 						dpy, FW_W_FRAME(t),
 						t->g.frame.x, t->g.frame.y);

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -1183,7 +1183,7 @@ static void size_menu_horizontally(MenuSizingParameters *msp)
 	struct monitor	*m = monitor_get_current();
 	for (i = 0; i < MAX_MENU_ITEM_LABELS; i++)
 	{
-		label_offset[i] = 2 * m->virtual_scr.MyDisplayWidth;
+		label_offset[i] = 2 * monitor_get_all_widths();
 	}
 
 	x = MST_BORDER_WIDTH(msp->menu);
@@ -6170,8 +6170,8 @@ void do_menu(MenuParameters *pmp, MenuReturn *pmret)
 			struct monitor	*m = monitor_get_current();
 			FWarpPointer(
 				dpy, 0, Scr.Root, 0, 0,
-				m->virtual_scr.MyDisplayWidth,
-				m->virtual_scr.MyDisplayHeight,
+				monitor_get_all_widths(),
+				monitor_get_all_heights(),
 				x_start, y_start);
 			if ((*pmp->pexc)->x.elast->type == KeyPress)
 			{

--- a/fvwm/misc.c
+++ b/fvwm/misc.c
@@ -78,8 +78,8 @@ int GetTwoArguments(
 	char *action, int *val1, int *val2, int *val1_unit, int *val2_unit)
 {
 	struct monitor	*m = monitor_get_current();
-	*val1_unit = m->virtual_scr.MyDisplayWidth;
-	*val2_unit = m->virtual_scr.MyDisplayHeight;
+	*val1_unit = monitor_get_all_widths();
+	*val2_unit = monitor_get_all_heights();
 
 	return GetTwoPercentArguments(action, val1, val2, val1_unit, val2_unit);
 }
@@ -434,9 +434,9 @@ Bool IsRectangleOnThisPage(struct monitor *m, const rectangle *rec, int desk)
 
 	//if (m->virtual_scr.CurrentDesk == desk &&
 	if (rec->x + (signed int)rec->width > 0 &&
-		(rec->x < 0 || rec->x < m->virtual_scr.MyDisplayWidth) &&
+		(rec->x < 0 || rec->x < monitor_get_all_widths()) &&
 		rec->y + (signed int)rec->height > 0 &&
-		(rec->y < 0 || rec->y < m->virtual_scr.MyDisplayHeight)) {
+		(rec->y < 0 || rec->y < monitor_get_all_heights())) {
 			return (True);
 	}
 	return (False);

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -283,8 +283,8 @@ static void send_desktop_geometry(fmodule *module)
 	struct monitor	*m = monitor_get_current();
 
 	sprintf(msg, "DesktopSize %d %d\n",
-		m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth + 1,
-		m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight + 1);
+		m->virtual_scr.VxMax / monitor_get_all_widths() + 1,
+		m->virtual_scr.VyMax / monitor_get_all_heights() + 1);
 	SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
 
 	return;

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -474,8 +474,8 @@ void BroadcastMonitorList(fmodule *this)
 				m->si->name,
 				(int)m->si->rr_output,
 				m == monitor_get_current(),
-				m->virtual_scr.MyDisplayWidth,
-				m->virtual_scr.MyDisplayHeight,
+				monitor_get_all_widths(),
+				monitor_get_all_heights(),
 				m->virtual_scr.Vx,
 				m->virtual_scr.Vy,
 				m->virtual_scr.VxMax,
@@ -893,10 +893,11 @@ void CMD_Send_WindowList(F_CMD_ARGS)
 			(long)m->si->rr_output);
 		SendPacket(
 			mod, M_NEW_PAGE, 8, (long)m->virtual_scr.Vx, (long)m->virtual_scr.Vy,
-			(long)m->virtual_scr.CurrentDesk, (long)m->virtual_scr.MyDisplayWidth,
-			(long)m->virtual_scr.MyDisplayHeight,
-			(long)((m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth) + 1),
-			(long)((m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight) + 1),
+			(long)m->virtual_scr.CurrentDesk,
+			(long) monitor_get_all_widths(),
+			(long) monitor_get_all_heights(),
+			(long)((m->virtual_scr.VxMax / monitor_get_all_widths()) + 1),
+			(long)((m->virtual_scr.VyMax / monitor_get_all_heights()) + 1),
 			(long)m->si->rr_output);
 
 		if (Scr.Hilite != NULL)

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -440,8 +440,8 @@ int GetMoveArguments(FvwmWindow *fw,
 	struct monitor	*m = fw->m ? fw->m : monitor_get_current();
 	int scr_x = 0;
 	int scr_y = 0;
-	int scr_w = m->virtual_scr.MyDisplayWidth;
-	int scr_h = m->virtual_scr.MyDisplayHeight;
+	int scr_w = monitor_get_all_widths();
+	int scr_h = monitor_get_all_heights();
 	Bool use_working_area = True;
 	Bool global_flag_parsed = False;
 	int retval = 0;
@@ -544,11 +544,11 @@ int GetMoveArguments(FvwmWindow *fw,
 		/* not enough arguments, switch to current page. */
 		while (*pFinalX < 0)
 		{
-			*pFinalX = fw->m->virtual_scr.MyDisplayWidth + *pFinalX;
+			*pFinalX = monitor_get_all_widths() + *pFinalX;
 		}
 		while (*pFinalY < 0)
 		{
-			*pFinalY = fw->m->virtual_scr.MyDisplayHeight + *pFinalY;
+			*pFinalY = monitor_get_all_heights() + *pFinalY;
 		}
 	}
 
@@ -793,12 +793,12 @@ static int GetResizeArguments(FvwmWindow *fw,
 	m = fw->m;
 	n = 0;
 	n += ParseOneResizeArgument(
-		s1, m->virtual_scr.MyDisplayWidth,
+		s1, monitor_get_all_widths(),
 		m->Desktops->ewmh_working_area.width,
 		m->Desktops->ewmh_dyn_working_area.width, w_base, w_inc,
 		w_add, pFinalW);
 	n += ParseOneResizeArgument(
-		s2, m->virtual_scr.MyDisplayHeight,
+		s2, monitor_get_all_heights(),
 		m->Desktops->ewmh_working_area.height,
 		m->Desktops->ewmh_dyn_working_area.height, h_base, h_inc,
 		h_add, pFinalH);
@@ -1248,8 +1248,8 @@ static void InteractiveMove(
 		struct monitor *m = exc->w.fw->m;
 
 		areapct = 100.0;
-		areapct *= ((float)DragWidth / (float)m->virtual_scr.MyDisplayWidth);
-		areapct *= ((float)DragHeight / (float)m->virtual_scr.MyDisplayHeight);
+		areapct *= ((float)DragWidth / (float) monitor_get_all_widths());
+		areapct *= ((float)DragHeight / (float) monitor_get_all_heights());
 		/* round up */
 		areapct += 0.1;
 		if (Scr.OpaqueSize < 0 ||
@@ -1793,8 +1793,8 @@ static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
 		}
 		s.x = page_x - m->virtual_scr.Vx;
 		s.y = page_y - m->virtual_scr.Vy;
-		s.width = m->virtual_scr.MyDisplayWidth;
-		s.height = m->virtual_scr.MyDisplayHeight;
+		s.width = monitor_get_all_widths();
+		s.height = monitor_get_all_heights();
 		fvwmrect_move_into_rectangle(&r, &s);
 		FinalX = r.x;
 		FinalY = r.y;
@@ -1825,8 +1825,8 @@ static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
 		r.height = height;
 		p.x = page_x - m->virtual_scr.Vx;
 		p.y = page_y - m->virtual_scr.Vy;
-		p.width = m->virtual_scr.MyDisplayWidth;
-		p.height = m->virtual_scr.MyDisplayHeight;
+		p.width = monitor_get_all_widths();
+		p.height = monitor_get_all_heights();
 		/* move to page first */
 		fvwmrect_move_into_rectangle(&r, &p);
 		/* then move to screen */
@@ -1981,8 +1981,8 @@ static void DoSnapAttract(
 	if (m == NULL)
 		m = monitor_get_current();
 
-	scr_w = m->virtual_scr.MyDisplayWidth;
-	scr_h = m->virtual_scr.MyDisplayHeight;
+	scr_w = monitor_get_all_widths();
+	scr_h = monitor_get_all_heights();
 
 	/*
 	 * Snap grid handling
@@ -2367,8 +2367,8 @@ Bool __move_loop(
 	m = fw->m;
 	vx = m->virtual_scr.Vx;
 	vy = m->virtual_scr.Vy;
-	dx = m->virtual_scr.EdgeScrollX ? m->virtual_scr.EdgeScrollX : m->virtual_scr.MyDisplayWidth;
-	dy = m->virtual_scr.EdgeScrollY ? m->virtual_scr.EdgeScrollY : m->virtual_scr.MyDisplayHeight;
+	dx = m->virtual_scr.EdgeScrollX ? m->virtual_scr.EdgeScrollX : monitor_get_all_widths();
+	dy = m->virtual_scr.EdgeScrollY ? m->virtual_scr.EdgeScrollY : monitor_get_all_heights();
 
 	if (!GrabEm(cursor, GRAB_NORMAL))
 	{
@@ -2717,8 +2717,8 @@ Bool __move_loop(
 			       (xl >= 0 && xl2 <  0) ||
 			       (yt <  0 && yt2 >= 0) ||
 			       (yt >= 0 && yt2 <  0)) &&
-			      (abs(xl - xl2) > m->virtual_scr.MyDisplayWidth / 2 ||
-			       abs(yt - yt2) > m->virtual_scr.MyDisplayHeight / 2)))
+			      (abs(xl - xl2) > monitor_get_all_widths() / 2 ||
+			       abs(yt - yt2) > monitor_get_all_heights() / 2)))
 			{
 				xl = xl2;
 				yt = yt2;
@@ -2754,14 +2754,14 @@ Bool __move_loop(
 				(e.xmotion.state & Mod1Mask) ? False : True;
 			xl = e.xmotion.x_root;
 			yt = e.xmotion.y_root;
-			if (xl > 0 && xl < m->virtual_scr.MyDisplayWidth - 1)
+			if (xl > 0 && xl < monitor_get_all_widths() - 1)
 			{
 				/* pointer was moved away from the left/right
 				 * border with the mouse, reset the virtual x
 				 * offset */
 				x_virtual_offset = 0;
 			}
-			if (yt > 0 && yt < m->virtual_scr.MyDisplayHeight - 1)
+			if (yt > 0 && yt < monitor_get_all_heights() - 1)
 			{
 				/* pointer was moved away from the top/bottom
 				 * border with the mouse, reset the virtual y
@@ -3665,8 +3665,8 @@ static Bool __resize_window(F_CMD_ARGS)
 	int warp_x = 0;
 	int warp_y = 0;
 
-	dx = mon->virtual_scr.EdgeScrollX ? mon->virtual_scr.EdgeScrollX : mon->virtual_scr.MyDisplayWidth;
-	dy = mon->virtual_scr.EdgeScrollY ? mon->virtual_scr.EdgeScrollY : mon->virtual_scr.MyDisplayHeight;
+	dx = mon->virtual_scr.EdgeScrollX ? mon->virtual_scr.EdgeScrollX : monitor_get_all_widths();
+	dy = mon->virtual_scr.EdgeScrollY ? mon->virtual_scr.EdgeScrollY : monitor_get_all_heights();
 
 	bad_window = False;
 	ResizeWindow = FW_W_FRAME(fw);
@@ -4448,16 +4448,16 @@ static void move_sticky_window_to_same_page(FvwmWindow *fw,
 	{
 		while (*x11 >= x22)
 		{
-			*x11 -= m->virtual_scr.MyDisplayWidth;
-			*x12 -= m->virtual_scr.MyDisplayWidth;
+			*x11 -= monitor_get_all_widths();
+			*x12 -= monitor_get_all_widths();
 		}
 	}
 	else if (*x12 <= x21)
 	{
 		while (*x12 <= x21)
 		{
-			*x11 += m->virtual_scr.MyDisplayWidth;
-			*x12 += m->virtual_scr.MyDisplayWidth;
+			*x11 += monitor_get_all_widths();
+			*x12 += monitor_get_all_widths();
 		}
 	}
 	/* make sure the y coordinate is on the same page as the reference
@@ -4466,16 +4466,16 @@ static void move_sticky_window_to_same_page(FvwmWindow *fw,
 	{
 		while (*y11 >= y22)
 		{
-			*y11 -= m->virtual_scr.MyDisplayHeight;
-			*y12 -= m->virtual_scr.MyDisplayHeight;
+			*y11 -= monitor_get_all_heights();
+			*y12 -= monitor_get_all_heights();
 		}
 	}
 	else if (*y12 <= y21)
 	{
 		while (*y12 <= y21)
 		{
-			*y11 += m->virtual_scr.MyDisplayHeight;
-			*y12 += m->virtual_scr.MyDisplayHeight;
+			*y11 += monitor_get_all_heights();
+			*y12 += monitor_get_all_heights();
 		}
 	}
 

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -1504,9 +1504,9 @@ static int __place_get_nowm_pos(
 		 * then 2) readjust relative to the current page. */
 		if (attr_g->x < 0)
 		{
-			attr_g->x += m->virtual_scr.MyDisplayWidth;
+			attr_g->x += monitor_get_all_widths();
 		}
-		attr_g->x %= m->virtual_scr.MyDisplayWidth;
+		attr_g->x %= monitor_get_all_widths();
 		attr_g->x -= pdeltax;
 		/* Noticed a quirk here. With some apps (e.g., xman), we find
 		 * the placement has moved 1 pixel away from where we
@@ -1515,9 +1515,9 @@ static int __place_get_nowm_pos(
 		 * -borderwidth 100 */
 		if (attr_g->y < 0)
 		{
-			attr_g->y += m->virtual_scr.MyDisplayHeight;
+			attr_g->y += monitor_get_all_heights();
 		}
-		attr_g->y %= m->virtual_scr.MyDisplayHeight;
+		attr_g->y %= monitor_get_all_heights();
 		attr_g->y -= pdeltay;
 		if (attr_g->x != old_x || attr_g->y != old_y)
 		{
@@ -1876,8 +1876,8 @@ static int __place_window(
 			px = start_style.page_x - 1;
 			py = start_style.page_y - 1;
 			reason->page.reason = PR_PAGE_STYLE;
-			px *= m->virtual_scr.MyDisplayWidth;
-			py *= m->virtual_scr.MyDisplayHeight;
+			px *= monitor_get_all_widths();
+			py *= monitor_get_all_heights();
 			if (!win_opts->flags.do_override_ppos &&
 			    !DO_NOT_SHOW_ON_MAP(fw))
 			{

--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -1372,8 +1372,8 @@ LoadWindowStates(char *filename)
 			matches[num_match - 1].h = 100;
 			matches[num_match - 1].x_max = 0;
 			matches[num_match - 1].y_max = 0;
-			matches[num_match - 1].w_max = m->virtual_scr.MyDisplayWidth;
-			matches[num_match - 1].h_max = m->virtual_scr.MyDisplayHeight;
+			matches[num_match - 1].w_max = monitor_get_all_widths();
+			matches[num_match - 1].h_max = monitor_get_all_heights();
 			matches[num_match - 1].width_defect_max = 0;
 			matches[num_match - 1].height_defect_max = 0;
 			matches[num_match - 1].icon_x = 0;

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -665,8 +665,8 @@ int HandlePaging(
 	struct monitor	*m = monitor_get_current();
 	int mwidth, mheight;
 
-	mwidth = m->virtual_scr.MyDisplayWidth;
-	mheight = m->virtual_scr.MyDisplayHeight;
+	mwidth = monitor_get_all_widths();
+	mheight = monitor_get_all_heights();
 
 
 	*delta_x = 0;
@@ -1387,8 +1387,8 @@ void MoveViewport(struct monitor *m, int newx, int newy, Bool grab)
 	  Identify the bounding rectangle that will be moved into
 	  the viewport.
 	*/
-	PageBottom    =  m->virtual_scr.MyDisplayHeight - deltay - 1;
-	PageRight     =  m->virtual_scr.MyDisplayWidth  - deltax - 1;
+	PageBottom    =  monitor_get_all_heights() - deltay - 1;
+	PageRight     =  monitor_get_all_widths()  - deltax - 1;
 	PageTop       =  0 - deltay;
 	PageLeft      =  0 - deltax;
 
@@ -1419,10 +1419,10 @@ void MoveViewport(struct monitor *m, int newx, int newy, Bool grab)
 				(long)mloop->virtual_scr.Vx,
 				(long)mloop->virtual_scr.Vy,
 				(long)mloop->virtual_scr.CurrentDesk,
-				(long)mloop->virtual_scr.MyDisplayWidth,
-				(long)mloop->virtual_scr.MyDisplayHeight,
-				(long)((mloop->virtual_scr.VxMax / mloop->virtual_scr.MyDisplayWidth ) + 1),
-				(long)((mloop->virtual_scr.VyMax / mloop->virtual_scr.MyDisplayHeight) + 1),
+				(long) monitor_get_all_widths(),
+				(long) monitor_get_all_heights(),
+				(long)((mloop->virtual_scr.VxMax / monitor_get_all_widths()) + 1),
+				(long)((mloop->virtual_scr.VyMax / monitor_get_all_heights()) + 1),
 				(long)mloop->si->rr_output);
 		}
 		/*
@@ -1748,8 +1748,8 @@ Bool get_page_arguments(FvwmWindow *fw, char *action, int *page_x, int *page_y, 
 	if (mret != NULL)
 		*mret = m;
 
-	mw = m->virtual_scr.MyDisplayWidth;
-	mh = m->virtual_scr.MyDisplayHeight;
+	mw = monitor_get_all_widths();
+	mh = monitor_get_all_heights();
 
 	for (; ; action = taction)
 	{
@@ -1854,12 +1854,12 @@ Bool get_page_arguments(FvwmWindow *fw, char *action, int *page_x, int *page_y, 
 		while (*page_x < 0)
 		{
 			*page_x += m->virtual_scr.VxMax +
-				m->virtual_scr.MyDisplayWidth;
+				monitor_get_all_widths();
 		}
 		while (*page_x > m->virtual_scr.VxMax)
 		{
 			*page_x -= m->virtual_scr.VxMax +
-				m->virtual_scr.MyDisplayWidth;
+				monitor_get_all_widths();
 		}
 	}
 	if (limitdesky && !wrapy)
@@ -1878,12 +1878,12 @@ Bool get_page_arguments(FvwmWindow *fw, char *action, int *page_x, int *page_y, 
 		while (*page_y < 0)
 		{
 			*page_y += m->virtual_scr.VyMax +
-				m->virtual_scr.MyDisplayHeight;
+				monitor_get_all_heights();
 		}
 		while (*page_y > m->virtual_scr.VyMax)
 		{
 			*page_y -= m->virtual_scr.VyMax +
-				m->virtual_scr.MyDisplayHeight;
+				monitor_get_all_heights();
 		}
 	}
 
@@ -2233,8 +2233,8 @@ void CMD_DesktopConfiguration(F_CMD_ARGS)
 			xasprintf(&cmd, "GotoDeskAndPage %s %d %d %d",
 				m_loop->si->name,
 				m->virtual_scr.CurrentDesk,
-				m->virtual_scr.Vx / m->virtual_scr.MyDisplayWidth,
-				m->virtual_scr.Vy / m->virtual_scr.MyDisplayHeight);
+				m->virtual_scr.Vx / monitor_get_all_widths(),
+				m->virtual_scr.Vy / monitor_get_all_heights());
 
 			execute_function_override_window(NULL, NULL, cmd, 0, NULL);
 			free(cmd);
@@ -2260,9 +2260,9 @@ void
 calculate_page_sizes(struct monitor *m, int dx, int dy)
 {
 	m->virtual_scr.VxMax = dx *
-		m->virtual_scr.MyDisplayWidth - m->virtual_scr.MyDisplayWidth;
+		monitor_get_all_widths() - monitor_get_all_widths();
 	m->virtual_scr.VyMax = dy *
-		m->virtual_scr.MyDisplayHeight - m->virtual_scr.MyDisplayHeight;
+		monitor_get_all_heights() - monitor_get_all_heights();
 }
 
 void CMD_DesktopSize(F_CMD_ARGS)
@@ -2289,10 +2289,10 @@ void CMD_DesktopSize(F_CMD_ARGS)
 			(long)m->virtual_scr.Vx,
 			(long)m->virtual_scr.Vy,
 			(long)m->virtual_scr.CurrentDesk,
-			(long)m->virtual_scr.MyDisplayWidth,
-			(long)m->virtual_scr.MyDisplayHeight,
-			(long)((m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth) + 1),
-			(long)((m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight) + 1),
+			(long) monitor_get_all_widths(),
+			(long) monitor_get_all_heights(),
+			(long)((m->virtual_scr.VxMax / monitor_get_all_widths()) + 1),
+			(long)((m->virtual_scr.VyMax / monitor_get_all_heights()) + 1),
 			(long)m->si->rr_output);
 
 		EWMH_SetDesktopGeometry(m);
@@ -2374,8 +2374,8 @@ void CMD_GotoDeskAndPage(F_CMD_ARGS)
 	}
 	else if (GetIntegerArguments(action, NULL, val, 3) == 3)
 	{
-		val[1] *= m->virtual_scr.MyDisplayWidth;
-		val[2] *= m->virtual_scr.MyDisplayHeight;
+		val[1] *= monitor_get_all_widths();
+		val[2] *= monitor_get_all_heights();
 	}
 	else
 	{
@@ -2530,20 +2530,20 @@ void CMD_Scroll(F_CMD_ARGS)
 	{
 		int xpixels;
 
-		xpixels = (m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth + 1) *
-			m->virtual_scr.MyDisplayWidth;
+		xpixels = (m->virtual_scr.VxMax / monitor_get_all_widths() + 1) *
+			monitor_get_all_widths();
 		x %= xpixels;
-		y += m->virtual_scr.MyDisplayHeight * (1+((x-m->virtual_scr.VxMax-1)/xpixels));
+		y += monitor_get_all_heights() * (1+((x-m->virtual_scr.VxMax-1)/xpixels));
 		if (y > m->virtual_scr.VyMax)
 		{
-			y %= (m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight + 1) *
-				m->virtual_scr.MyDisplayHeight;
+			y %= (m->virtual_scr.VyMax / monitor_get_all_heights() + 1) *
+				monitor_get_all_heights();
 		}
 	}
 	if (((val1 <= -100000)||(val1 >= 100000))&&(x<0))
 	{
 		x = m->virtual_scr.VxMax;
-		y -= m->virtual_scr.MyDisplayHeight;
+		y -= monitor_get_all_heights();
 		if (y < 0)
 		{
 			y=m->virtual_scr.VyMax;
@@ -2551,20 +2551,20 @@ void CMD_Scroll(F_CMD_ARGS)
 	}
 	if (((val2 <= -100000)||(val2>= 100000))&&(y>m->virtual_scr.VyMax))
 	{
-		int ypixels = (m->virtual_scr.VyMax / m->virtual_scr.MyDisplayHeight + 1) *
-			m->virtual_scr.MyDisplayHeight;
+		int ypixels = (m->virtual_scr.VyMax / monitor_get_all_heights() + 1) *
+			monitor_get_all_heights();
 		y %= ypixels;
-		x += m->virtual_scr.MyDisplayWidth * (1+((y-m->virtual_scr.VyMax-1)/ypixels));
+		x += monitor_get_all_widths() * (1+((y-m->virtual_scr.VyMax-1)/ypixels));
 		if (x > m->virtual_scr.VxMax)
 		{
-			x %= (m->virtual_scr.VxMax / m->virtual_scr.MyDisplayWidth + 1) *
-				m->virtual_scr.MyDisplayWidth;
+			x %= (m->virtual_scr.VxMax / monitor_get_all_widths() + 1) *
+				monitor_get_all_widths();
 		}
 	}
 	if (((val2 <= -100000)||(val2>= 100000))&&(y<0))
 	{
 		y = m->virtual_scr.VyMax;
-		x -= m->virtual_scr.MyDisplayWidth;
+		x -= monitor_get_all_widths();
 		if (x < 0)
 		{
 			x=m->virtual_scr.VxMax;

--- a/fvwm/windowlist.c
+++ b/fvwm/windowlist.c
@@ -935,7 +935,7 @@ void CMD_WindowList(F_CMD_ARGS)
 					sprintf(loc, "+%d",
 						(mon->virtual_scr.Vx + t->g.frame.x +
 						 t->g.frame.width / 2) /
-						mon->virtual_scr.MyDisplayWidth);
+						monitor_get_all_widths());
 					strcat(tname, loc);
 				}
 				if (flags & SHOW_PAGE_Y)
@@ -943,7 +943,7 @@ void CMD_WindowList(F_CMD_ARGS)
 					sprintf(loc, "+%d",
 						(mon->virtual_scr.Vy + t->g.frame.y +
 						 t->g.frame.height/2) /
-						mon->virtual_scr.MyDisplayHeight);
+						monitor_get_all_heights());
 					strcat(tname, loc);
 				}
 				if (!(flags & NO_LAYER))

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -450,8 +450,6 @@ set_coords:
 			m->flags |= MONITOR_PRIMARY;
 		else
 			m->flags &= ~MONITOR_PRIMARY;
-		m->virtual_scr.MyDisplayWidth = monitor_get_all_widths();
-		m->virtual_scr.MyDisplayHeight = monitor_get_all_heights();
 
 		XFree(name);
 	}
@@ -567,10 +565,10 @@ monitor_dump_state(struct monitor *m)
 			   m2->virtual_scr.EdgeScrollX,
 			   m2->virtual_scr.EdgeScrollY,
 			   m2->virtual_scr.CurrentDesk,
-			   (int)(m2->virtual_scr.Vx / m2->virtual_scr.MyDisplayWidth),
-			   (int)(m2->virtual_scr.Vy / m2->virtual_scr.MyDisplayHeight),
-			   m2->virtual_scr.MyDisplayWidth,
-			   m2->virtual_scr.MyDisplayHeight,
+			   (int)(m2->virtual_scr.Vx / monitor_get_all_widths()),
+			   (int)(m2->virtual_scr.Vy / monitor_get_all_heights()),
+			   monitor_get_all_widths(),
+			   monitor_get_all_heights(),
 			   m2->Desktops ? "yes" : "no",
 			   monitor_mode == MONITOR_TRACKING_G ? "global" :
 			   monitor_mode == MONITOR_TRACKING_M ? "per-monitor" :
@@ -956,14 +954,14 @@ int FScreenParseGeometry(
 	if (rc & XValue)
 	{
 		if (rc & XNegative)
-			*x_return -= (m->virtual_scr.MyDisplayWidth - w - x);
+			*x_return -= (monitor_get_all_widths() - w - x);
 		else
 			*x_return += x;
 	}
 	if (rc & YValue)
 	{
 		if (rc & YNegative)
-			*y_return -= (m->virtual_scr.MyDisplayHeight - h - y);
+			*y_return -= (monitor_get_all_heights() - h - y);
 		else
 			*y_return += y;
 	}

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -131,8 +131,6 @@ struct monitor {
                 int prev_desk_and_page_desk;
                 int prev_desk_and_page_page_x;
                 int prev_desk_and_page_page_y;
-		int MyDisplayWidth;
-		int MyDisplayHeight;
         } virtual_scr;
 
 	PanFrame PanFrameTop;


### PR DESCRIPTION
Don't store the display's width and height in struct monitor, as this is
not unique per-monitor.  Instead, use the functions
monitor_get_all_widths() and monitor_get_all_heights().

The coccinelle script used to perform this translation is part of this
commit.
