### PR TITLE
Fix potential buffer overflow in session handling code.

### DIFF
--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -373,7 +373,7 @@ static Bool VerifyVersionInfo(char *filename)
 		if (!strcmp(s1, "[FVWM_VERSION]"))
 		{
 			char *current_v = get_version_string();
-			sscanf(s, "%*s %[^\n]", s1);
+			sscanf(s, "%*s %4095[^\n]", s1);
 			if (strcmp(s1, current_v) == 0)
 			{
 				does_file_version_match = True;
@@ -1222,7 +1222,7 @@ LoadGlobalState(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			is_key = fxstrdup(s1);
 		}
 		else if (!strcmp(s1, "[VALUE]"))
@@ -1233,7 +1233,7 @@ LoadGlobalState(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			is_value = fxstrdup(s1);
 
 			if (is_key != NULL && is_value != NULL)
@@ -1347,7 +1347,7 @@ LoadWindowStates(char *filename)
 		if (!SessionSupport /* migo: temporarily */ &&
 		    !strcmp(s1, "[REAL_STATE_FILENAME]"))
 		{
-			sscanf(s, "%*s %s", s1);
+			sscanf(s, "%*s %4095s", s1);
 			set_sm_properties(sm_conn, s1, FSmRestartIfRunning);
 			set_real_state_filename(s1);
 		}
@@ -1466,7 +1466,7 @@ LoadWindowStates(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			matches[num_match - 1].client_id = duplicate(s1);
 		}
 		else if (!strcmp(s1, "[WINDOW_ROLE]"))
@@ -1476,7 +1476,7 @@ LoadWindowStates(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			matches[num_match - 1].window_role = duplicate(s1);
 		}
 		else if (!strcmp(s1, "[RES_NAME]"))
@@ -1486,7 +1486,7 @@ LoadWindowStates(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			matches[num_match - 1].res_name = duplicate(s1);
 		}
 		else if (!strcmp(s1, "[RES_CLASS]"))
@@ -1496,7 +1496,7 @@ LoadWindowStates(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			matches[num_match - 1].res_class = duplicate(s1);
 		}
 		else if (!strcmp(s1, "[WM_NAME]"))
@@ -1506,7 +1506,7 @@ LoadWindowStates(char *filename)
 			{
 				s2++;
 			}
-			sscanf(s2, "%[^\n]", s1);
+			sscanf(s2, "%4095[^\n]", s1);
 			matches[num_match - 1].wm_name = duplicate(s1);
 		}
 		else if (!strcmp(s1, "[WM_COMMAND]"))
@@ -1520,7 +1520,7 @@ LoadWindowStates(char *filename)
 			for (i = 0;
 			     i < matches[num_match - 1].wm_command_count; i++)
 			{
-				sscanf (s+pos, "%s%n", s1, &pos1);
+				sscanf (s+pos, "%4095s%n", s1, &pos1);
 				pos += pos1;
 				matches[num_match - 1].wm_command[i] =
 					duplicate (s1);


### PR DESCRIPTION
This buffer overflow is fixed by including field width limits in the format strings passed to `sscanf`.

sscanf's %s and %[ format specifiers can overflow the output buffer unless a
field width limit is given. if sscanf encounters a string without
spaces (with %s) or without the characters in the set given (with %[) and this
string is longer than the output buffer, it will overflow the buffer.

* **What does this PR do?**
Fixes potential buffer overflow in session handling code.

Cppcheck 2.4.1 warnings:
```
fvwm\session.c:376:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s, "%*s %[^\n]", s1);
   ^
fvwm\session.c:1225:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1236:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1350:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s, "%*s %s", s1);
   ^
fvwm\session.c:1469:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1479:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1489:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1499:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1509:4: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
   sscanf(s2, "%[^\n]", s1);
   ^
fvwm\session.c:1523:5: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
    sscanf (s+pos, "%s%n", s1, &pos1);
    ^
```

Cppcheck warning explanation:
```
CWE: 119
sscanf() without field width limits can crash with huge input data. Add a field width specifier to fix this problem.

Sample program that can crash:

#include <stdio.h>
int main()
{
    char c[5];
    scanf("%s", c);
    return 0;
}

Typing in 5 or more characters may make the program crash. The correct usage here is 'scanf("%4s", c);', as the maximum field width does not include the terminating null byte.
Source: http://linux.die.net/man/3/scanf
Source: http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/libkern/stdio/scanf.c
```
* **Screenshots (if applicable)**

* **Issue number(s)**
#107 
If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
