### PR TITLE
absolute_geometry: clamp check to shaded windows

### DIFF
--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -607,7 +607,8 @@ void update_absolute_geometry(FvwmWindow *fw)
 	 * bypass some of the sanity checks, and the screen assignment gets
 	 * outdated.
 	 */
-	UPDATE_FVWM_SCREEN(fw);
+	if (IS_SHADED(fw))
+		UPDATE_FVWM_SCREEN(fw);
 	m = (fw && fw->m) ? fw->m : monitor_get_current();
 
 	/* store orig values in absolute coords */


### PR DESCRIPTION
When updating a window's active monitor, the absolute geometry only
needs to be rechecked if the window is shaded, and at no other time.

This builds on a previous commit, and again fixes #473
