### PR TITLE
IRC: move from Freenode -> Libera.chat

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "IRC #fvwm on irc.freenode.net"
-    url: https://webchat.freenode.net/#fvwm
+  - name: "IRC #fvwm on irc.libera.chat"
+    url: https://libera.chat/guides/connect
     about: Chat with fvwm users/developers

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,6 +51,8 @@ jobs:
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'pull_request'
         with:
+          server: "irc.libera.chat"
+          notice: true
           channel: "#fvwm"
           nickname: fvwm3-gh
           message: "PR: [${{ github.event.pull_request.number }}]: ${{ github.event.pull_request.title }} -- [${{ github.event.pull_request.user.login }}]"
@@ -58,6 +60,8 @@ jobs:
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         with:
+          server: "irc.libera.chat"
+          notice: true
           channel: "#fvwm"
           nickname: fvwm-gh
           message: ${{ github.actor }} tagged ${{ github.repository }} ${{ github.event.ref }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [the installation instructions](./dev-docs/INSTALL.md)
 Help & Support
 --------------
 
-We have a strong community on IRC (freenode), in the `#fvwm` channel if you
+We have a strong community on IRC (libera.chat), in the `#fvwm` channel if you
 fancy a chat.
 
 There is also the [Fvwm Forums](https://fvwmforums.org) where you can ask


### PR DESCRIPTION
Due to politics at Freenode, Libera.chat is the way to go.
