### PR TITLE
Ensure make uninstall removes default-config links.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,3 +37,6 @@ distcheck2: distcheck
 	fi
 
 distclean2: distclean
+
+uninstall-hook:
+	-rmdir @FVWM_DATADIR@

--- a/default-config/Makefile.am
+++ b/default-config/Makefile.am
@@ -1,7 +1,7 @@
 ## Process this file with automake to create Makefile.in
 
 configdir = @FVWM_DATADIR@/default-config
-inst_location = $(DESTDIR)@FVWM_DATADIR@/default-config
+inst_location = $(DESTDIR)@FVWM_DATADIR@
 config_DATA = config \
 	      .stalonetrayrc \
 	      FvwmScript-DateTime \
@@ -16,10 +16,13 @@ EXTRA_DIST  = images \
 	      FvwmScript-ConfirmCopyConfig
 
 install-data-hook:
-	cp -r $(srcdir)/images $(inst_location)
-	ln -sf default-config/FvwmScript-DateTime $(inst_location)/..
-	ln -sf default-config/FvwmScript-ConfirmQuit $(inst_location)/..
-	ln -sf default-config/FvwmScript-ConfirmCopyConfig $(inst_location)/..
+	cp -r $(srcdir)/images $(inst_location)/default-config
+	ln -sf default-config/FvwmScript-DateTime $(inst_location)
+	ln -sf default-config/FvwmScript-ConfirmQuit $(inst_location)
+	ln -sf default-config/FvwmScript-ConfirmCopyConfig $(inst_location)
 
 uninstall-hook:
 	rm -fr $(DESTDIR)/$(configdir)
+	rm -f $(inst_location)/FvwmScript-DateTime
+	rm -f $(inst_location)/FvwmScript-ConfirmQuit
+	rm -f $(inst_location)/FvwmScript-ConfirmCopyConfig

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -4,3 +4,7 @@ SUBDIRS = \
 	FvwmAnimate FvwmAuto FvwmBacker FvwmButtons FvwmConsole FvwmEvent \
 	FvwmForm FvwmIconMan FvwmIdent FvwmPager FvwmPerl FvwmRearrange \
 	FvwmScript FvwmMFL
+
+uninstall-hook:
+	-rmdir @FVWM_MODULEDIR@
+	-rmdir ${pkglibexecdir}


### PR DESCRIPTION
Update make uninstall to remove the FvwmScript links from the default-config from $FVWM_DATADIR and remove both
FVWM_MODULEDIR and FVWM_DATADIR if empty.

Closes #422