### PR TITLE
Manpages renamed by automakes renaming options.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,11 +1,10 @@
 docdir = @FVWM_DOCDIR@
 MODULE_ADOCS = $(wildcard fvwm3/fvwm3.adoc bin/*.adoc modules/*.adoc)
 
-man_MANS = $(patsubst %.adoc,%.1, $(MODULE_ADOCS))
 EXTRA_DIST = $(MODULE_ADOCS)
 
 if FVWM_BUILD_MANDOC
-BUILD_MANS = $(man_MANS)
+BUILD_MANS = $(patsubst %.adoc,%, $(MODULE_ADOCS))
 else
 BUILD_MANS =
 endif
@@ -14,22 +13,28 @@ all: docs
 docs: $(BUILD_MANS)
 
 clean:
-	rm -f $(BUILD_MANS)
+	rm -fr man1/
 
 distclean-local: clean
 
 if FVWM_BUILD_MANDOC
-QUIET_ASCIIDOC = @echo '  ' DOC '    ' $@;
+QUIET_ASCIIDOC = @echo '  ' DOC '    ' $@'.1';
 
-%.1: %.adoc
-	$(QUIET_ASCIIDOC)$(ASCIIDOC) -b manpage $< -o $@
+%: %.adoc
+	$(QUIET_ASCIIDOC) \
+	NAME=`basename "$@" | "$(SED)" -e "${transform}"`; \
+	$(ASCIIDOC) -b manpage $< -o "man1/$$NAME.1"
 
 install-data-local:
 	install -d -m 755 $(DESTDIR)$(mandir)/man1/
-	install -m 644 $(BUILD_MANS) $(DESTDIR)$(mandir)/man1/
+	@for i in $(notdir $(BUILD_MANS)); do \
+		NAME=`basename "$$i" | "$(SED)" -e "${transform}"`; \
+		install -m 644 "man1/$$NAME.1" $(DESTDIR)$(mandir)/man1/; \
+	done
 
 uninstall-local:
 	@for i in $(notdir $(BUILD_MANS)); do \
-		rm -f "$(DESTDIR)$(mandir)/man1/$$i"; \
+		NAME=`basename "$$i" | "$(SED)" -e "${transform}"`; \
+		rm -f "$(DESTDIR)$(mandir)/man1/$$NAME.1"; \
 	done
 endif


### PR DESCRIPTION
Asciidoc manpages are now renamed using ./configure --program-prefix=, --program-suffix=, and --program-transform-name= options. Closes #492

It is now possible to rename all binaries and man pages using the above options to make fvwm3 installable along side fvwm2.

For example the following will build the manpages and make all the binaries and manpages named `Fvwm3stuff` or `fvwm3-stuff`.

```
./configure --enable-mandocs --program-transform-name='/vwm[^3] s/vwm/vwm3/'
```

Note this will not modify the actual module names (since they live in an isolated directory already) only their manpages. In addition due to helper programs like `fvwm-menu-desktop` becoming `fvwm3-menu-desktop`, the default-config or other configurations will need to be updated if this is used.