### PR TITLE
Recapture: fix erroneous maximizing of windows

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2770,9 +2770,9 @@ FvwmWindow *AddWindow(
 			fw, fw->g.frame.x, fw->g.frame.y, fw->g.frame.width,
 			fw->g.frame.height, 0, False);
 	}
-	if (
-		HAS_EWMH_INIT_MAXVERT_STATE(fw) == EWMH_STATE_HAS_HINT ||
-		HAS_EWMH_INIT_MAXHORIZ_STATE(fw) == EWMH_STATE_HAS_HINT)
+	if (IS_MAXIMIZED(fw) &&
+		(HAS_EWMH_INIT_MAXVERT_STATE(fw) == EWMH_STATE_HAS_HINT ||
+		HAS_EWMH_INIT_MAXHORIZ_STATE(fw) == EWMH_STATE_HAS_HINT))
 	{
 		int h;
 		int v;


### PR DESCRIPTION
During a recapture of windows (such as when restarting fvwm3), if a
window had been previous maximized (but is no longer), then fvwm3 would
think that window should still be maximized.  This is because of a
missing check to see if the window needs to be maximized.

Fixes #143
