### PR TITLE
libs: remove reference to Fft.h

### DIFF
--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -7,7 +7,7 @@ libfvwm3_a_SOURCES = \
 	BidiJoin.h Bindings.h ClientMsg.h ColorUtils.h Colorset.h \
 	CombineChars.h Cursor.h Event.h FBidi.h FEvent.h FGettext.h FImage.h \
 	FRender.h FRenderInit.h FRenderInterface.h FSMlib.h FScreen.h \
-	FShape.h FShm.h FTips.h Fcursor.h Fft.h FftInterface.h Ficonv.h \
+	FShape.h FShm.h FTips.h Fcursor.h FftInterface.h Ficonv.h \
 	Flocale.h FlocaleCharset.h Fpng.h Fsvg.h Fxpm.h Grab.h \
 	Graphics.h Module.h Parse.h Picture.h PictureBase.h \
 	PictureDitherMatrice.h PictureGraphics.h PictureImageLoader.h \


### PR DESCRIPTION
Fft.h is no longer in the repository and shouldn't be mentioned in the
Makefile.
