### PR TITLE
Retire FvwmTile and FvwmCascade wrappers.

### DIFF
--- a/doc/modules/FvwmRearrange.adoc
+++ b/doc/modules/FvwmRearrange.adoc
@@ -6,6 +6,8 @@ FvwmRearrange - rearrange fvwm windows
 
 == SYNOPSIS
 
+Module FvwmRearrange [-cascade | -tile] [options] [bounding box]
+
 FvwmRearrange is spawned by fvwm, so no command line invocation will
 work.
 
@@ -50,11 +52,7 @@ and down the screen. Windows will be constrained to 80 by 70 percent of
 the screen dimensions. Since the _resize_ is also specified, windows
 will be resized to the given constrained width and height.
 
-FvwmRearrange can be called as FvwmTile or FvwmCascade. This is
-equivalent to providing the -tile or -cascade option. This form is
-obsolete and supplied for backwards compatibility only.
-
-Command-line arguments passed to FvwmRearrange are described here.
+== OPTIONS
 
 -a::
   Causes _all_ window types to be affected, even ones with the
@@ -130,6 +128,9 @@ Windows will only shrink to fit the maximal width and height (if given).
   When rearranging windows, make the calculation ignore the working
   area, such as EwmhBaseStruts; by default, FvwmRearrange will honour
   the working area.
+
+
+== BOUNDING BOX
 
 Up to four numbers can be placed on the command line that are not
 switches. The first pair specify an x and y offset to start the first

--- a/modules/FvwmRearrange/FvwmRearrange.c
+++ b/modules/FvwmRearrange/FvwmRearrange.c
@@ -87,8 +87,8 @@ int do_maximize = 0;
 int do_animate = 0;
 int do_ewmhiwa = 0;
 
-char FvwmTile;
-char FvwmCascade;
+int FvwmTile = 0;
+int FvwmCascade = 1;
 
 
 RETSIGTYPE DeadPipe(int sig)
@@ -402,8 +402,14 @@ void parse_args(char *s, int argc, char *argv[], int argi)
   /* parse args */
   for (; argi < argc; ++argi)
   {
-    if (!strcmp(argv[argi], "-tile") || !strcmp(argv[argi], "-cascade")) {
-      /* ignore */
+    if (!strcmp(argv[argi], "-tile")) {
+      FvwmTile = 1;
+      FvwmCascade = 0;
+      resize = 1;
+    }
+    else if (!strcmp(argv[argi], "-cascade")) {
+      FvwmCascade = 1;
+      FvwmTile = 0;
     }
     else if (!strcmp(argv[argi], "-u")) {
       untitled = 1;
@@ -500,15 +506,11 @@ void parse_args(char *s, int argc, char *argv[], int argi)
       } else if (nsargc == 2) {
 	ofsy = atopixel(argv[argi], dheight);
       } else if (nsargc == 3) {
-	if (FvwmCascade)
-	  maxw = atopixel(argv[argi], dwidth);
-	else /* FvwmTile */
-	  maxx = atopixel(argv[argi], dwidth);
+	maxw = atopixel(argv[argi], dwidth);
+	maxx = maxw;
       } else if (nsargc == 4) {
-	if (FvwmCascade)
-	  maxh = atopixel(argv[argi], dheight);
-	else /* FvwmTile */
-	  maxy = atopixel(argv[argi], dheight);
+	maxh = atopixel(argv[argi], dheight);
+	maxy = maxh;
       }
     }
   }
@@ -558,17 +560,6 @@ int main(int argc, char *argv[])
   }
   FScreenGetScrRect(NULL, FSCREEN_CURRENT, &dx, &dy, &dwidth, &dheight);
 
-  if (strcmp(module->name, "FvwmCascade") &&
-      (!strcmp(module->name, "FvwmTile") ||
-       (argc >= 7 && !strcmp(argv[6], "-tile")))) {
-    FvwmTile = 1;
-    FvwmCascade = 0;
-    resize = 1;
-  } else {
-    FvwmCascade = 1;
-    FvwmTile = 0;
-    resize = 0;
-  }
   parse_args("module args", module->user_argc, module->user_argv, 0);
 
   SetMessageMask(fd,

--- a/modules/FvwmRearrange/Makefile.am
+++ b/modules/FvwmRearrange/Makefile.am
@@ -6,24 +6,6 @@ program_transform_name =
 moduledir = @FVWM_MODULEDIR@
 module_PROGRAMS = FvwmRearrange
 
-## These modules were made obsolete in November, 1998.
-## Remove from fvwm distribution no later than October, 1999.
-module_SCRIPTS = FvwmCascade FvwmTile
-
-FvwmCascade: ../../config.h Makefile
-	echo "#!/bin/sh" > $@
-	echo 'modargs="$$1 $$2 $$3 $$4 $$5"' >> $@
-	echo 'shift;shift;shift;shift;shift' >> $@
-	echo exec ${moduledir}'/FvwmRearrange $$modargs -cascade $$@' >> $@
-
-FvwmTile: ../../config.h Makefile
-	echo "#!/bin/sh" > $@
-	echo 'modargs="$$1 $$2 $$3 $$4 $$5"' >> $@
-	echo 'shift;shift;shift;shift;shift' >> $@
-	echo exec ${moduledir}'/FvwmRearrange $$modargs -tile $$@' >> $@
-
-CLEANFILES = $(module_SCRIPTS)
-
 FvwmRearrange_SOURCES = FvwmRearrange.c
 FvwmRearrange_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 


### PR DESCRIPTION
Finally retiring the backwards compatibility wrappers for
FvwmRearrange. Use FvwmRearrange -title or FvwmRearrange -cascade
instead of the wrappers.