### PR TITLE
EdgeScroll: a few improvements

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -4089,6 +4089,7 @@ void dispatch_event(XEvent *e)
 			XRRUpdateConfiguration(e);
 			monitor_update_ewmh();
 			monitor_emit_broadcast();
+			initPanFrames();
 			break;
 		}
 	}

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -92,6 +92,9 @@ struct screen_info	*screen_info_by_name(const char *);
 #define MONITOR_CHANGED 0x10
 #define MONITOR_ALL (MONITOR_DISABLED|MONITOR_ENABLED|MONITOR_CHANGED)
 
+#define MONITOR_OUTSIDE_EDGE 0
+#define MONITOR_INSIDE_EDGE 1
+
 struct monitor {
 	struct screen_info	*si;
 	int			 flags;
@@ -118,6 +121,13 @@ struct monitor {
                 } BaseStrut;
 
         } ewmhc;
+
+	struct {
+		bool top;
+		bool bottom;
+		bool left;
+		bool right;
+	} edge;
 
         struct {
                 int VxMax;


### PR DESCRIPTION
This addresses some edgescroll improvements and simplifies the logic
between how panframes are handled between being in global and per-monitor
mode.

Now, monitor edges which border one another don't have a panframe added
for global mode (only the outside edges are).  With the same logic,
per-screen panframes are drawn for all edges.

This also helps to reduce problems where some screens have different
resolutions, and so now dead spave between monitors is handled much
better.

Fixes #523
