### PR TITLE
EWMH_GetWorkArea use monitor dimensions.

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -958,7 +958,6 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 	int bottom = m->ewmhc.BaseStrut.bottom;
 	int x,y,width,height;
 	FvwmWindow *fw;
-	int w, h;
 
 	/* FIXME: needs broadcast if global monitor in use. */
 
@@ -980,11 +979,9 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 
 	x = left;
 	y = top;
-	w = monitor_get_all_widths();
-	h = monitor_get_all_heights();
 
-	width =  w - (left + right);
-	height = h - (top + bottom);
+	width =  m->si->w - (left + right);
+	height = m->si->h - (top + bottom);
 
 	fvwm_debug(__func__, "monitor '%s': {l: %d, r: %d, t: %d, b: %d} "
 		"{x: %d, y: %d, w: %d, h: %d}\n", m->si->name,
@@ -1017,7 +1014,6 @@ void ewmh_HandleDynamicWorkArea(struct monitor *m)
 	int dyn_bottom = m->ewmhc.BaseStrut.bottom;
 	int x,y,width,height;
 	FvwmWindow *fw;
-	int w,h;
 
 	/* FIXME: needs broadcast if global monitor in use. */
 
@@ -1039,11 +1035,9 @@ void ewmh_HandleDynamicWorkArea(struct monitor *m)
 
 	x = dyn_left;
 	y = dyn_top;
-	w = monitor_get_all_widths();
-	h = monitor_get_all_heights();
 
-	width  = w - (dyn_left + dyn_right);
-	height = h - (dyn_top + dyn_bottom);
+	width  = m->si->w - (dyn_left + dyn_right);
+	height = m->si->h - (dyn_top + dyn_bottom);
 
 	if (
 		m->Desktops->ewmh_dyn_working_area.x != x ||
@@ -1107,10 +1101,10 @@ void EWMH_GetWorkAreaIntersection(
 		area_w = m->Desktops->ewmh_dyn_working_area.width;
 		area_h = m->Desktops->ewmh_dyn_working_area.height;
 	}
-	nx = max(*x, area_x);
-	ny = max(*y, area_y);
-	nw = min(*x + *w, area_x + area_w) - nx;
-	nh = min(*y + *h, area_y + area_h) - ny;
+	nx = max(*x, area_x + m->si->x);
+	ny = max(*y, area_y + m->si->y);
+	nw = min(*x + *w, area_x + area_w) - nx + m->si->x;
+	nh = min(*y + *h, area_y + area_h) - ny + m->si->y;
 
 	*x = nx;
 	*y = ny;


### PR DESCRIPTION
Use the screen dimensions to compute the working area for `EWMHBaseStruts` instead of global dimensions. Fixes #66.

* This changes how `EWMHBaseStruts` have worked in fvwm (as struts for the global monitor) and now struts are always per-monitor.
* Calling `EWMHBaseStruts` without specifying a screen will set the same struts for all monitors. This will also destroy any previous defined struts, so the order this command is read can affect the outcome.
* Callinig `EWMH_GetWorkAreaIntersection` using the `monitor_global` should function as before (though I do not think anything does this currently).