### PR TITLE
Add a screen option to the Scroll command.

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -7705,7 +7705,7 @@ GotoPage prev
 GotoPage +2p -1p
 ....
 
-*Scroll* [_horizonal_[p] _vertical_[p] | reverse]::
+*Scroll* [screen RANDRNAME] [_horizonal_[p] _vertical_[p] | reverse]::
 	Scrolls the virtual desktop's viewport by _horizontal_ pages in the
 	x-direction and _vertical_ pages in the y-direction or starts
 	interactive scrolling of the viewport. Either or both entries may be
@@ -7763,6 +7763,11 @@ Mouse 1 A CM Scroll reverse
 +
 gives an effect of grabbing and dragging the viewport with button 1 if Control
 and Meta is pressed.
++
+If _screen_ is given, followed by the RANDRNAME of a given display, then
+the specified screen is scrolled. This is only useful if using per-monitor
+or shared _DesktopConfiguration_ and wanting to scroll a monitor other than
+the current monitor. Interactive scrolling always scrolls the current monitor.
 
 === User Functions and Shell Commands
 

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2706,13 +2706,28 @@ void CMD_Scroll(F_CMD_ARGS)
 {
 	int x,y;
 	int val1, val2, val1_unit, val2_unit;
+	char *option;
 	struct monitor  *m = monitor_get_current();
+
+	option = PeekToken(action, NULL);
+	if (StrEquals(option, "screen")) {
+		/* Skip literal 'screen' */
+		option = PeekToken(action, &action);
+		/* Actually get the screen value. */
+		option = PeekToken(action, &action);
+
+		m = monitor_resolve_name(option);
+		if (strcmp(m->si->name, option) != 0) {
+		fvwm_debug(__func__,
+			"Invalid screen: %s", option);
+		return;
+		}
+	}
 
 	if (GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit) != 2)
 	{
 		/* less then two integer parameters implies interactive
 		 * scroll check if we are scrolling in reverse direction */
-		char *option;
 		int scroll_speed = 1;
 
 		option = PeekToken(action, NULL);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -144,7 +144,7 @@ static void do_scroll(int sx, int sy, Bool do_send_message,
 	static int psx = 0;
 	static int psy = 0;
 	static int messages_sent = 0;
-	char command[256];
+	char command[256], screen[32] = "";
 	psx+=sx;
 	psy+=sy;
 	if (is_message_recieved)
@@ -160,7 +160,9 @@ static void do_scroll(int sx, int sy, Bool do_send_message,
 	if ((do_send_message || messages_sent < MAX_UNPROCESSED_MESSAGES) &&
 	    ( psx != 0 || psy != 0 ))
 	{
-		sprintf(command, "Scroll %dp %dp", psx, psy);
+		if (monitor_to_track != NULL)
+			sprintf(screen, "screen %s", monitor_to_track);
+		sprintf(command, "Scroll %s %dp %dp", screen, psx, psy);
 		SendText(fd, command, 0);
 		messages_sent++;
 		SendText(fd, "Send_Reply ScrollDone", 0);
@@ -2411,7 +2413,7 @@ void Scroll(int window_w, int window_h, int x, int y, int Desk,
 	}
 	if (Wait == 0 || last_sx != sx || last_sy != sy)
 	{
-		do_scroll(sx, sy, False, False);
+		do_scroll(sx, sy, True, False);
 
 		/* Here we need to track the view offset on the desk. */
 		/* sx/y are are pixels on the screen to scroll. */


### PR DESCRIPTION
This extends the Scroll command by adding an 'screen RANDRNAME' option
to specify which monitor to scroll. This is useful when using per-monitor
or shared DesktopConfiguration and wanting to scroll a monitor other
than the current monitor. Mostly used by FvwmPager when tracking a single
monitor to scroll the correct monitor no matter which screen the pager is on.
