### PR TITLE
RandR: fix const correctness

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1814,7 +1814,7 @@ void
 monitor_emit_broadcast(void)
 {
 	struct monitor	*m;
-	const char	*randrfunc = "RandRFunc";
+	char		*randrfunc = "RandRFunc";
 
 	TAILQ_FOREACH (m, &monitor_q, entry) {
 		if (m->emit & MONITOR_CHANGED) {


### PR DESCRIPTION
Remove "const char *" qualifier, as the corresponding variable is
modified.
