### PR TITLE
placement: fix mouse positioning

### DIFF
--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -1367,6 +1367,9 @@ static int __place_get_wm_pos(
 	arg.style = pstyle;
 	arg.reason = reason;
 	arg.place_fw = exc->w.fw;
+
+	if (arg.place_fw->m == NULL)
+		arg.place_fw->m = monitor_get_current();
 	arg.place_g = arg.place_fw->g.frame;
 	arg.screen_g = screen_g;
 	arg.page_p1.x = arg.screen_g.x - pdeltax;


### PR DESCRIPTION
When defining certain window placements, ensure that the target window
has a monitor assigned.
