### PR TITLE
Move: disable working area when screen given

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -468,6 +468,13 @@ int GetMoveArguments(FvwmWindow *fw,
 		token = PeekToken(action, &action);
 		parg.name = token;
 
+		/* When being asked to move a window to coordinates which are
+		 * relative to a given screen, don't assume to use the
+		 * screen's working area, as the coordinates given are not
+		 * relative to that.
+		 */
+		use_working_area = False;
+
 		FScreenGetScrRect(&parg, FSCREEN_BY_NAME, &scr_x, &scr_y,
 				  &scr_w, &scr_h);
 		action = GetNextToken(action, &s1);


### PR DESCRIPTION
When a user asks for a window's coordinates to be placed relative to a
screen, such as:

    Move screen DP1-1-8 +50w +-10p

don't clobber the calculations for it by assuming they're relative to
the EWMH Working Area.  Instead, disable that.  This is equivalent to:

    Move screen DP1-1-8 +50w +-10p ewmhiwa
