### PR TITLE
Rework FvwmPager to move windows easier

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -114,8 +114,8 @@ int BalloonBorderWidth = 1;
 int BalloonYOffset = 3;
 Window BalloonView = None;
 
-int window_w=0, window_h=0, window_x=0, window_y=0;
-int icon_x=-10000, icon_y=-10000, icon_w=0, icon_h=0;
+rectangle pwindow = {0, 0, 0, 0};
+rectangle icon = {-10000, -10000, 0, 0};
 int usposition = 0,uselabel = 1;
 int xneg = 0, yneg = 0;
 int icon_xneg = 0, icon_yneg = 0;
@@ -404,12 +404,12 @@ int main(int argc, char **argv)
   if (is_transient)
   {
     if (FQueryPointer(
-	  dpy, Scr.Root, &JunkRoot, &JunkChild, &window_x, &window_y, &JunkX,
+	  dpy, Scr.Root, &JunkRoot, &JunkChild, &pwindow.x, &pwindow.y, &JunkX,
 	  &JunkY, &JunkMask) == False)
     {
       /* pointer is on a different screen */
-      window_x = 0;
-      window_y = 0;
+      pwindow.x = 0;
+      pwindow.y = 0;
     }
     usposition = 1;
     xneg = 0;
@@ -522,7 +522,7 @@ void Loop(int *fd)
       int x,y;
 
       if(XGetGeometry(dpy,Scr.Pager_w,&root,&x,&y,
-		      (unsigned *)&window_w,(unsigned *)&window_h,
+		      (unsigned *)&pwindow.width,(unsigned *)&pwindow.height,
 		      &border_width,&depth)==0)
       {
 	/* does not return */
@@ -1956,25 +1956,25 @@ void ParseOptions(void)
     }
     else if (StrEquals(resource, "Geometry"))
     {
-      window_w = 0;
-      window_h = 0;
-      window_x = 0;
-      window_y = 0;
+      pwindow.width = 0;
+      pwindow.height = 0;
+      pwindow.x = 0;
+      pwindow.y = 0;
       xneg = 0;
       yneg = 0;
       usposition = 0;
       flags = FScreenParseGeometry(arg1,&g_x,&g_y,&width,&height);
       if (flags & WidthValue)
       {
-	window_w = width;
+	pwindow.width = width;
       }
       if (flags & HeightValue)
       {
-	window_h = height;
+	pwindow.height = height;
       }
       if (flags & XValue)
       {
-	window_x = g_x;
+	pwindow.x = g_x;
 	usposition = 1;
 	if (flags & XNegative)
 	{
@@ -1983,7 +1983,7 @@ void ParseOptions(void)
       }
       if (flags & YValue)
       {
-	window_y = g_y;
+	pwindow.y = g_y;
 	usposition = 1;
 	if (flags & YNegative)
 	{
@@ -1993,20 +1993,20 @@ void ParseOptions(void)
     }
     else if (StrEquals(resource, "IconGeometry"))
     {
-      icon_w = 0;
-      icon_h = 0;
-      icon_x = -10000;
-      icon_y = -10000;
+      icon.width = 0;
+      icon.height = 0;
+      icon.x = -10000;
+      icon.y = -10000;
       icon_xneg = 0;
       icon_yneg = 0;
       flags = FScreenParseGeometry(arg1,&g_x,&g_y,&width,&height);
       if (flags & WidthValue)
-	icon_w = width;
+	icon.width = width;
       if (flags & HeightValue)
-	icon_h = height;
+	icon.height = height;
       if (flags & XValue)
       {
-	icon_x = g_x;
+	icon.x = g_x;
 	if (flags & XNegative)
 	{
 	  icon_xneg = 1;
@@ -2014,7 +2014,7 @@ void ParseOptions(void)
       }
       if (flags & YValue)
       {
-	icon_y = g_y;
+	icon.y = g_y;
 	if (flags & YNegative)
 	{
 	  icon_yneg = 1;

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -87,7 +87,7 @@ char *WindowHiFore = NULL;
 char *WindowLabelFormat = NULL;
 
 unsigned int WindowBorderWidth = DEFAULT_PAGER_WINDOW_BORDER_WIDTH;
-unsigned int MinSize = 2 * DEFAULT_PAGER_WINDOW_BORDER_WIDTH + 1;
+unsigned int MinSize = 2 * DEFAULT_PAGER_WINDOW_BORDER_WIDTH + 5;
 Bool WindowBorders3d = False;
 
 Bool UseSkipList = False;
@@ -2292,7 +2292,7 @@ void ParseOptions(void)
     else if (StrEquals(resource, "WindowBorderWidth"))
     {
       sscanf(arg1, "%d", &WindowBorderWidth);
-      MinSize = 2 * WindowBorderWidth + 1;
+      MinSize = 2 * WindowBorderWidth + 5;
     }
     else if (StrEquals(resource, "Window3dBorders"))
     {

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -216,8 +216,7 @@ void MoveResizePagerView(PagerWindow *t, Bool do_force_redraw);
 void ChangeDeskForWindow(PagerWindow *t,long newdesk);
 void MoveStickyWindow(Bool is_new_page, Bool is_new_desk);
 void Hilight(PagerWindow *, int);
-void Scroll(int window_w, int window_h, int x, int y, int Desk,
-	    Bool do_scroll_icon);
+void Scroll(int x, int y, int Desk, Bool do_scroll_icon);
 void MoveWindow(XEvent *Event);
 void BorderWindow(PagerWindow *t);
 void BorderIconWindow(PagerWindow *t);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -130,14 +130,6 @@ extern void ExitPager(void);
 
 Pixmap default_pixmap = None;
 
-#ifdef DEBUG
-#define MYFPRINTF(X) \
-  fprintf X;\
-  fflush (stderr);
-#else
-#define MYFPRINTF(X)
-#endif
-
 #define  MAX_UNPROCESSED_MESSAGES 1
 /* sums up pixels to scroll. If do_send_message is True a Scroll command is
  * sent back to fvwm. The function shall be called with is_message_recieved
@@ -1037,10 +1029,6 @@ void initialize_pager(void)
 
     /* get font for balloon */
     Desks[i].balloon.Ffont = balloon_font;
-    if (Desks[i].balloon.Ffont == NULL)
-    {
-      fprintf(stderr, "%s: No fonts available, giving up!.\n", MyName);
-    }
     Desks[i].balloon.height = Desks[i].balloon.Ffont->height + 1;
   }
   initialize_balloon_window();
@@ -1690,7 +1678,6 @@ void MovePage(Bool is_new_desk)
     if (FlocaleTextListToTextProperty(
 	  dpy, &sptr, 1, XStdICCTextStyle, &name) == 0)
     {
-      fprintf(stderr,"%s: cannot allocate window name", MyName);
       return;
     }
     XSetWMIconName(dpy,Scr.Pager_w,&name);
@@ -1981,7 +1968,6 @@ void SwitchToDesk(int Desk)
 
 	sprintf(command, "GotoDesk %s 0 %d", monitor_to_track ? m->name : "",
 			Desk + desk1);
-	fprintf(stderr, "%s: cmd: %s\n", __func__, command);
 	SendText(fd,command,0);
 }
 
@@ -2007,7 +1993,6 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
     mon->virtual_scr.Vy = vy * mon->virtual_scr.MyDisplayHeight;
     sprintf(command, "GotoDeskAndPage %s %d %d %d",
 		monitor_to_track ? mon->name : "", Desk + desk1, vx, vy);
-    fprintf(stderr, "%s: cmd: %s\n", __func__, command);
     SendText(fd, command, 0);
 
   }
@@ -2035,7 +2020,6 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
     if (y * mon->virtual_scr.MyDisplayHeight > mon->virtual_scr.VyMax)
       y = mon->virtual_scr.VyMax / mon->virtual_scr.MyDisplayHeight;
     sprintf(command, "GotoPage %s %d %d", monitor_to_track ? mon->name : "", x, y);
-    fprintf(stderr, "%s: cmd: %s\n", __func__, command);
     SendText(fd, command, 0);
   }
   Wait = 1;
@@ -2052,7 +2036,6 @@ void IconSwitchPage(XEvent *Event)
 		  (icon.width * mon->virtual_scr.MyDisplayWidth),
 	  Event->xbutton.y * mon->virtual_scr.VHeight /
 		  (icon.height * mon->virtual_scr.MyDisplayHeight));
-  fprintf(stderr, "%s: cmd: %s\n", __func__, command);
   SendText(fd, command, 0);
   Wait = 1;
 }
@@ -2463,8 +2446,6 @@ void Scroll(int x, int y, int Desk, Bool do_scroll_icon)
 	{
 		sy = (y * mon->virtual_scr.VHeight / window_h - MyVy);
 	}
-	MYFPRINTF((stderr,"[scroll]: %d %d %d %d %d %d\n", window_w, window_h,
-		   x, y, sx, sy));
 	if (sx == 0 && sy == 0)
 	{
 		return;

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1167,7 +1167,7 @@ void DispatchEvent(XEvent *Event)
 	  {
 	    /* pointer is on a different screen - that's okay here */
 	  }
-	  Scroll(desk_w, desk_h, x, y, i, False);
+	  Scroll(x, y, i, False);
 	}
       }
       if(Event->xany.window == icon_win)
@@ -1177,7 +1177,7 @@ void DispatchEvent(XEvent *Event)
 	{
 	  /* pointer is on a different screen - that's okay here */
 	}
-	Scroll(icon.width, icon.height, x, y, 0, True);
+	Scroll(x, y, -1, True);
       }
       /* Flush any pending scroll operations */
       do_scroll(0, 0, True, False);
@@ -1228,7 +1228,7 @@ void DispatchEvent(XEvent *Event)
 	  {
 	    /* pointer is on a different screen - that's okay here */
 	  }
-	  Scroll(desk_w, desk_h, x, y, mon->virtual_scr.CurrentDesk, False);
+	  Scroll(x, y, mon->virtual_scr.CurrentDesk, False);
 	  if (mon->virtual_scr.CurrentDesk != i + desk1)
 	  {
 	    Wait = 0;
@@ -1244,7 +1244,7 @@ void DispatchEvent(XEvent *Event)
 	{
 	  /* pointer is on a different screen - that's okay here */
 	}
-	Scroll(icon.width, icon.height, x, y, 0, True);
+	Scroll(x, y, -1, True);
       }
     }
     break;
@@ -1264,7 +1264,7 @@ void DispatchEvent(XEvent *Event)
 	  {
 	    /* pointer is on a different screen - that's okay here */
 	  }
-	  Scroll(desk_w, desk_h, x, y, i, False);
+	  Scroll(x, y, i, False);
 	}
       }
       if(Event->xany.window == icon_win)
@@ -1274,7 +1274,7 @@ void DispatchEvent(XEvent *Event)
 	{
 	  /* pointer is on a different screen - that's okay here */
 	}
-	Scroll(icon.width, icon.height, x, y, 0, True);
+	Scroll(x, y, -1, True);
       }
 
     }
@@ -2379,14 +2379,11 @@ void Hilight(PagerWindow *t, int on)
 }
 
 /* Use Desk == -1 to scroll the icon window */
-void Scroll(int window_w, int window_h, int x, int y, int Desk,
-	    Bool do_scroll_icon)
+void Scroll(int x, int y, int Desk, Bool do_scroll_icon)
 {
 	static int last_sx = -999999;
 	static int last_sy = -999999;
-	int sx;
-	int sy;
-	int adjx,adjy;
+	int window_w = desk_w, window_h = desk_h, sx, sy, adjx, adjy;
 	struct fpmonitor *mon = fpmonitor_this();
 
 	/* Desk < 0 means we want to scroll an icon window */
@@ -2395,9 +2392,13 @@ void Scroll(int window_w, int window_h, int x, int y, int Desk,
 		return;
 	}
 
+	if (do_scroll_icon) {
+		window_w = icon.width;
+		window_h = icon.height;
+	}
 	/* center around mouse */
-	adjx = (desk_w / (1 + mon->virtual_scr.VxMax / mon->virtual_scr.MyDisplayWidth));
-	adjy = (desk_h / (1 + mon->virtual_scr.VyMax / mon->virtual_scr.MyDisplayHeight));
+	adjx = (window_w / (1 + mon->virtual_scr.VxMax / mon->virtual_scr.MyDisplayWidth));
+	adjy = (window_h / (1 + mon->virtual_scr.VyMax / mon->virtual_scr.MyDisplayHeight));
 	x -= adjx/2;
 	y -= adjy/2;
 


### PR DESCRIPTION
- FvwmPager code cleanup, use more rectangles.
- FvwmPager restructure math computations.
- Fix Scroll for FvwmPager Iconify View
- Update MoveWindow to deal with per-monitor setups.
- Update IconMoveWindow to deal with per-monitor setups.
- Remove old debugging output.
