### PR TITLE
Fix compiler warnings in modules/FvwmScript/Instructions.c

### DIFF
--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -56,7 +56,7 @@ extern Atom propriete;
 extern char *LastString;
 char *FvwmUserDir = NULL;
 char *BufCom;
-char Command[255]="None";
+char Command[256]="None";
 time_t TimeCom=0;
 
 /*

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -1740,9 +1740,7 @@ static void WriteToFile (int NbArg,long *TabArg)
   }
   if (CurrPos==size)
   {
-    sprintf(buf,"%s\n%s%d\n",buf,StrBegin,getpid());
-    sprintf(buf,"%s%s",buf,arg[1]);
-    sprintf(buf,"%s%s\n",buf,StrEnd);
+    sprintf(buf + strlen(buf),"\n%s%d\n%s%s\n",StrBegin,getpid(),arg[1],StrEnd);
   }
   else
   {


### PR DESCRIPTION
This pull request has a couple of simple commits that fix the following compiler warnings that I see with gcc (Debian 8.3.0-6) 8.3.0:

```
Instructions.c: In function ‘FuncGetOutput’:
Instructions.c:366:7: warning: ‘strncpy’ specified bound 255 equals destination size [-Wstringop-truncation]
       strncpy(Command,cmndbuf,255);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
Instructions.c: In function ‘WriteToFile’:
    Instructions.c:1743:5: warning: passing argument 1 to restrict-qualified parameter aliases with argument 3 [-Wrestrict]
     sprintf(buf,"%s\n%s%d\n",buf,StrBegin,getpid());
     ^~~~~~~
Instructions.c:1744:5: warning: passing argument 1 to restrict-qualified parameter aliases with argument 3 [-Wrestrict]
     sprintf(buf,"%s%s",buf,arg[1]);
     ^~~~~~~
Instructions.c:1745:5: warning: passing argument 1 to restrict-qualified parameter aliases with argument 3 [-Wrestrict]
     sprintf(buf,"%s%s\n",buf,StrEnd);
     ^~~~~~~
```

I believe these to be genuine bugs, not just the compiler being over-enthusiastic. The caveat is that because I don't use FvwmScript myself I don't have any way of testing my fixes. I opted for the simplest changes that fix the bugs, retaining the old-school string handling rather than attempting any kind of rewrite to something less bug-prone. (My motivation for sending in this fix was mostly just as a warm-up task before I have a look into issue #409, which I've been running into.)
