### PR TITLE
Unmaximize: restore _NET_WM_STATE

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -4689,6 +4689,7 @@ static void unmaximize_fvwm_window(
 	 * window being restored from fullscreen to a non-maximized state.
 	 */
 	apply_decor_change(fw);
+	EWMH_SetWMState(fw, True);
 	return;
 }
 


### PR DESCRIPTION
When a window comes out of being maximized (or fullscreened), ensure we
restore the _NET_WM_STATE property to what it was before being
maximized.  Not doing so keeps the maximized hint on the window when it
isn't in that state.

Fixes #545
