### PR TITLE
FvwmPager: Improvments with dealing with tiny windows on tiny pagers.

### DIFF
--- a/doc/modules/FvwmPager.adoc
+++ b/doc/modules/FvwmPager.adoc
@@ -347,6 +347,9 @@ done about this - except not using SloppyFocus in the pager.
   Specifies the width of the border drawn around the mini windows. This
   also affects the minimum size of the mini windows, which will be
   2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 1.
+*FvwmPager: HideSmallWindows::
+  Tells FvwmPager to not show windows that are the minimum size. Useful
+  for tiny pagers where small windows will appear out of place.
 *FvwmPager: Window3DBorders::
   Specifies that the mini windows should have a 3d borders based on the
   mini window background. This option only works if *FvwmPager:

--- a/doc/modules/FvwmPager.adoc
+++ b/doc/modules/FvwmPager.adoc
@@ -339,10 +339,14 @@ done about this - except not using SloppyFocus in the pager.
   Uses colorsets in the same way as *FvwmPager: WindowColors. The shadow
   and hilight colors of the colorset are only used for the window
   borders if the *FvwmPager: Window3DBorders is specified too.
+*FvwmPager: WindowMinSize n::
+  Specifies the minimum size as _n_ pixels of the mini windows. This does
+  not include the width of the border, so the actual minimum size is
+  2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 3.
 *FvwmPager: WindowBorderWidth n::
   Specifies the width of the border drawn around the mini windows. This
-  also sets the minimum size of the mini windows to (2 * _n_ + 1). The
-  default is 1.
+  also affects the minimum size of the mini windows, which will be
+  2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 1.
 *FvwmPager: Window3DBorders::
   Specifies that the mini windows should have a 3d borders based on the
   mini window background. This option only works if *FvwmPager:

--- a/libs/defaults.h
+++ b/libs/defaults.h
@@ -106,10 +106,6 @@
 #define DEFAULT_CURSOR_FORE_COLOR         "black"
 #define DEFAULT_CURSOR_BACK_COLOR         "white"
 
-/*** pager ***/
-#define DEFAULT_MOVE_THRESHOLD             3 /* pixels */
-#define DEFAULT_PAGER_WINDOW_BORDER_WIDTH  1 /* pixels */
-
 /*** fonts ***/
 #define EXTRA_TITLE_FONT_HEIGHT            3 /* pixels */
 #define EXTRA_TITLE_FONT_WIDTH             3 /* pixels */

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -93,6 +93,8 @@ Bool WindowBorders3d = False;
 
 Bool UseSkipList = False;
 
+Bool HideSmallWindows = False;
+
 FvwmPicture *PixmapBack = NULL;
 
 char *ImagePath = NULL;
@@ -2305,6 +2307,10 @@ void ParseOptions(void)
         MinSize = 2 * WindowBorderWidth + MinSize;
       else
         MinSize = 2 * WindowBorderWidth + DEFAULT_PAGER_WINDOW_MIN_SIZE;
+    }
+    else if (StrEquals(resource, "HideSmallWindows"))
+    {
+      HideSmallWindows = true;
     }
     else if (StrEquals(resource, "Window3dBorders"))
     {

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -87,7 +87,8 @@ char *WindowHiFore = NULL;
 char *WindowLabelFormat = NULL;
 
 unsigned int WindowBorderWidth = DEFAULT_PAGER_WINDOW_BORDER_WIDTH;
-unsigned int MinSize = 2 * DEFAULT_PAGER_WINDOW_BORDER_WIDTH + 5;
+unsigned int MinSize = (2 * DEFAULT_PAGER_WINDOW_BORDER_WIDTH +
+	DEFAULT_PAGER_WINDOW_MIN_SIZE);
 Bool WindowBorders3d = False;
 
 Bool UseSkipList = False;
@@ -96,7 +97,6 @@ FvwmPicture *PixmapBack = NULL;
 
 char *ImagePath = NULL;
 
-#define DEFAULT_PAGER_MOVE_THRESHOLD 3
 int MoveThreshold = DEFAULT_PAGER_MOVE_THRESHOLD;
 
 int ShowBalloons = 0, ShowPagerBalloons = 0, ShowIconBalloons = 0;
@@ -2291,8 +2291,20 @@ void ParseOptions(void)
     }
     else if (StrEquals(resource, "WindowBorderWidth"))
     {
+      MinSize = MinSize - 2*WindowBorderWidth;
       sscanf(arg1, "%d", &WindowBorderWidth);
-      MinSize = 2 * WindowBorderWidth + 5;
+      if (WindowBorderWidth > 0)
+        MinSize = 2 * WindowBorderWidth + MinSize;
+      else
+        MinSize = 2 * DEFAULT_PAGER_WINDOW_BORDER_WIDTH + MinSize;
+    }
+    else if (StrEquals(resource, "WindowMinSize"))
+    {
+      sscanf(arg1, "%d", &MinSize);
+      if (MinSize > 0)
+        MinSize = 2 * WindowBorderWidth + MinSize;
+      else
+        MinSize = 2 * WindowBorderWidth + DEFAULT_PAGER_WINDOW_MIN_SIZE;
     }
     else if (StrEquals(resource, "Window3dBorders"))
     {

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -8,6 +8,10 @@
 #include "libs/Flocale.h"
 #include "libs/Module.h"
 
+#define DEFAULT_PAGER_WINDOW_BORDER_WIDTH 1
+#define DEFAULT_PAGER_WINDOW_MIN_SIZE 3
+#define DEFAULT_PAGER_MOVE_THRESHOLD 3
+
 struct fpmonitor {
 	char		*name;
 	int		 is_primary, output;

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -66,6 +66,7 @@ extern unsigned int WindowBorderWidth;
 extern unsigned int MinSize;
 extern Bool WindowBorders3d;
 extern Bool UseSkipList;
+extern Bool HideSmallWindows;
 extern FvwmPicture *PixmapBack;
 extern FvwmPicture *HilightPixmap;
 extern int HilightDesks;
@@ -1739,10 +1740,13 @@ void ReConfigureIcons(Bool do_reconfigure_desk_only)
     t->icon_view_y = rec.y;
     t->icon_view_width = rec.width;
     t->icon_view_height = rec.height;
-    if(mon->virtual_scr.CurrentDesk == t->desk)
-      XMoveResizeWindow(dpy, t->IconView, rec.x, rec.y, rec.width, rec.height);
-    else
-      XMoveResizeWindow(dpy, t->IconView, -32768, -32768, rec.width, rec.height);
+    if ((mon->virtual_scr.CurrentDesk != t->desk) ||
+        (HideSmallWindows && (rec.width == MinSize || rec.height == MinSize)))
+    {
+      rec.x = -32768;
+      rec.y = -32768;
+    }
+    XMoveResizeWindow(dpy, t->IconView, rec.x, rec.y, rec.width, rec.height);
   }
 }
 
@@ -2059,6 +2063,12 @@ void AddNewWindow(PagerWindow *t)
 	attributes.background_pixel = t->back;
 	attributes.event_mask = ExposureMask;
 
+	if (HideSmallWindows && (rec.width == MinSize || rec.height == MinSize))
+	{
+		rec.x = -32768;
+		rec.y = -32768;
+	}
+
 	/* ric@giccs.georgetown.edu -- added Enter and Leave events for
 	   popping up balloon window */
 	attributes.event_mask =
@@ -2101,7 +2111,9 @@ void AddNewWindow(PagerWindow *t)
 	t->icon_view_y = rec.y;
 	t->icon_view_width = rec.width;
 	t->icon_view_height = rec.height;
-	if(mon->virtual_scr.CurrentDesk != t->desk)
+	if((mon->virtual_scr.CurrentDesk != t->desk) ||
+		(HideSmallWindows && (rec.width == MinSize ||
+		rec.height == MinSize)))
 	{
 		rec.x = -32768;
 		rec.y = -32768;
@@ -2168,6 +2180,12 @@ void ChangeDeskForWindow(PagerWindow *t,long newdesk)
   t->pager_view_width = rec.width;
   t->pager_view_height = rec.height;
 
+  if (HideSmallWindows && (rec.width == MinSize || rec.height == MinSize))
+  {
+    rec.x = -32768;
+    rec.y = -32768;
+  }
+
   if ((i >= 0) && (i < ndesks))
   {
     int cset;
@@ -2197,6 +2215,11 @@ void ChangeDeskForWindow(PagerWindow *t,long newdesk)
   t->icon_view_y = rec.y;
   t->icon_view_width = rec.width;
   t->icon_view_height = rec.height;
+  if (HideSmallWindows && (rec.width == MinSize || rec.height == MinSize))
+  {
+    rec.x = -32768;
+    rec.y = -32768;
+  }
   if(mon->virtual_scr.CurrentDesk != t->desk)
     XMoveResizeWindow(dpy,t->IconView,-32768,-32768,rec.width,rec.height);
   else
@@ -2252,6 +2275,11 @@ void MoveResizePagerView(PagerWindow *t, Bool do_force_redraw)
     {
       int cset;
 
+      if (HideSmallWindows && (rec.width == MinSize || rec.height == MinSize))
+      {
+        rec.x = -32768;
+        rec.y = -32768;
+      }
       XMoveResizeWindow(dpy, t->PagerView, rec.x, rec.y, rec.width, rec.height);
       cset = (t != FocusWin) ? windowcolorset : activecolorset;
       if (cset > -1 && (size_changed || CSET_IS_TRANSPARENT(cset)))
@@ -2281,6 +2309,11 @@ void MoveResizePagerView(PagerWindow *t, Bool do_force_redraw)
   {
     int cset;
 
+    if (HideSmallWindows && (rec.width == MinSize || rec.height == MinSize))
+    {
+      rec.x = -32768;
+      rec.y = -32768;
+    }
     XMoveResizeWindow(dpy, t->IconView, rec.x, rec.y, rec.width, rec.height);
     cset = (t != FocusWin) ? windowcolorset : activecolorset;
     if (cset > -1 && (size_changed || CSET_IS_TRANSPARENT(cset)))

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -226,8 +226,35 @@ static rectangle CalcGeom(PagerWindow *t, bool is_icon)
 
 	fvwmrec_to_pager(&rec, is_icon);
 
-	rec.width = max(MinSize, rec.width);
-	rec.height = max(MinSize, rec.height);
+	/* Set geometry to MinSize and snap to page boundary if needed */
+	if (rec.width < MinSize)
+	{
+		int page_w = desk_w;
+		if (is_icon)
+			page_w = icon.width;
+		page_w = page_w / m->virtual_scr.VxPages;
+
+		rec.width = MinSize;
+		if (rec.x > page_w - MinSize &&
+			(rec.x + rec.width)%page_w < MinSize)
+		{
+			rec.x = ((rec.x / page_w) + 1)*page_w - MinSize + 1;
+		}
+	}
+	if (rec.height < MinSize)
+	{
+		int page_h = desk_h;
+		if (is_icon)
+			page_h = icon.height;
+		page_h = page_h / m->virtual_scr.VyPages;
+
+		rec.height = MinSize;
+		if (rec.y > page_h - MinSize &&
+			(rec.y + rec.height)%page_h < MinSize)
+		{
+			rec.y = ((rec.y / page_h) + 1)*page_h - MinSize + 1;
+		}
+	}
 	return rec;
 }
 

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -2758,7 +2758,7 @@ static void draw_window_border(PagerWindow *t, Window w, int width, int height)
     {
       XSetForeground(dpy, Scr.NormalGC, Scr.black);
       RelieveRectangle(
-	dpy, w, 0, 0, width - 1, t->pager_view_height - 1,
+	dpy, w, 0, 0, width - 1, height - 1,
 	Scr.NormalGC, Scr.NormalGC, WindowBorderWidth);
     }
     else if (t == FocusWin)

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -569,6 +569,8 @@ set_vp_size_and_loc(void)
 	vp.height = desk_h / VyPages;
 	vp.x = (Vx * desk_w) / vWidth + offset_x;
 	vp.y = (Vy * desk_h) / vHeight + offset_y;
+	vp.x = vp.x / VxPages;
+	vp.y = vp.y / VyPages;
 
 	return vp;
 }


### PR DESCRIPTION
Due to setting mini windows to a minimum size if their relative size got too small, there were issues with the windows appearing out of place and their relative size to other windows and pages. This adds some improvements and options to better work with tiny windows on tiny pagers.

+ Ensure that windows set to the minimum size do not push into the next page, by snapping them to page boundaries. Fixes #541.
+ Add an option to configure the minimum window size instead of hard coding it. Fixes #542.
+ Add an option to hide windows set to the minimum size.