### PR TITLE
Add command: Move shuffle [flags] direction(s)

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -510,6 +510,27 @@ Mouse 1	I    A RaiseMoveX Move "Iconify off"
 Mouse 3	T    A Menu MenuWindowOps
 Mouse 3 I    A Menu MenuIconOps
 
+# Shuffle moves a window in a given direction until it hits another window.
+# These bindings will shuffle a window using the arrow keys.
+#    Ctrl-Alt Up_Arrow     - Shuffle window up
+#    Ctrl-Alt Right_Arrow  - Shuffle window right
+#    Ctrl-Alt Down_Arrow   - Shuffle window down
+#    Ctrl-Alt Left_Arrow   - Shuffle window left
+# Holding shift (Ctrl-Alt-Shift) will grow the window in the given direction.
+DestroyFunc ShuffleDir
+AddToFunc   ShuffleDir
++ I Move shuffle layers $[w.layer] $[w.layer] snap windows $0
++ I WarpToWindow 50 50
+
+Key Up      WTSF    CM  ShuffleDir up
+Key Down    WTSF    CM  ShuffleDir down
+Key Left    WTSF    CM  ShuffleDir left
+Key Right   WTSF    CM  ShuffleDir right
+Key Up      WTSF    CSM Maximize True 0 growup
+Key Down    WTSF    CSM Maximize True 0 growdown
+Key Right   WTSF    CSM Maximize True growright 0
+Key Left    WTSF    CSM Maximize True growleft 0
+
 #######
 # 6: Window Decor
 #

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4052,27 +4052,22 @@ AddToFunc lower-to-bottom
  + I Lower
 ....
 
-*Move* [[screen _screen_] [w | m]_x_[p | w] ... [w | m]_y_[p | w] ...  [Warp]] | [pointer] | [ewmhiwa]::
-	Allows the user to move a window. If called from somewhere in a window
-	or its border, then that window is moved. If called from the root
-	window then the user is allowed to select the target window. By
-	default, the EWMH working area is honoured.
+*Move* [_options_]::
+	Allows the user to move a window. If called from somewhere in a
+	window or its border, then that window is moved. If called from
+	the root window, then the user is allowed to select the target
+	window.	Move can be called with various options to either start
+	an interactive move, specify the position to move, or a direction.
 +
-If the literal option _screen_ followed by a _screen_ argument is
-specified, the coordinates are interpreted as relative to the given
-screen. The width and height of the screen are used for the
-calculations instead of the display dimensions. The _screen_ as
-interpreted as in the *MoveToScreen* command. If the optional argument
-_Warp_ is specified the pointer is warped with the window. If the
-single argument _pointer_ is given, the top left corner of the window
-is moved to the pointer position before starting the operation; this
-is mainly intended for internal use by modules like *FvwmPager*. If
-the optional argument _ewmhiwa_ is given, then the window position
-will ignore the working area (such as ignoring any values set via
-*EwmhBaseStruts*).
+Calling *Move* by itself with no options starts an interactive move.
+When moving a window interactively, the window may snap to other windows
+and screen boundaries, configurable via the *SnapAttraction* style. Holding
+down _Alt_ whilst moving the window will disable snap attraction during
+the move. Moving a window to the edge of the screen can be used to drag the
+window to other pages, see *EdgeScroll*, and the *EdgeMoveDelay* style
+for more information.
 +
-The operation can be aborted with
-+
+The interactive move operation can be aborted with Escape 
 or any mouse button not set to place the window. By default mouse
 button 2 is set to cancel the move operation. To change this you may
 use the *Mouse* command with special context 'P' for Placement.
@@ -4081,18 +4076,75 @@ The window condition _PlacedByButton_ can be used to check if a
 specific button was pressed to place the window (see *Current*
 command).
 +
-If the optional arguments _x_ and _y_ are provided, then the window is
-moved immediately without user interaction. Each argument can specify
-an absolute or relative position from either the left/top or
-right/bottom of the screen. By default, the numeric value given is
-interpreted as a percentage of the screen width/height, but a trailing
-'_p_' changes the interpretation to mean pixels, while a trailing
-'_w_' means precent of the window width/height. To move the window
-relative to its current position, add the '_w_' (for "window") prefix
-before the _x_ and/or _y_ value. To move the window to a position
-relative to the current location of the pointer, add the '_m_' (for
-"mouse") prefix. To leave either coordinate unchanged, "_keep_" can be
-specified in place of _x_ or _y_.
+If the single argument _pointer_ is given, the top left corner of the
+window is moved to the pointer position before starting an interactive
+move; this is mainly intended for internal use by modules like *FvwmPager*.
++
+
+> *Move* pointer
+
++
+To move a window in a given direction until it hits another window, icon,
+or screen boundary use:
++
+
+> *Move* shuffle [Warp] [snap _type_] [layers _min_ _max_] _direction_(s)
+
++
+The _direction_ can be _North_/_N_/_Up_/_U_, _East_/_E_/_Right_/_R_,
+_South_/_S_/_Down_/_D_, or _West_/_W_/_Left_/_L_. The window will move
+in the given direction until it hits another window, the *EwmhBaseStruts*,
+or the screen boundary. If multiple _direction_(s) are given, the window
+will move the directions in the order of the sequence stated.
++
+The literal option _Warp_ will warp the mouse pointer to the window.
+If the literal option _snap_ followed by a snap _type_ of _windows_,
+_icons_, or _same_ is given, then the window will only stop if it hits
+another window, icon, or the same type. If the literal option _layers_
+followed by a _min_ layer and _max_ layer is given, then only windows on
+the layers between _min_ and _max_ layers will stop the window. For example:
++
+
+....
+# Shuffle the window Right.
+Move shuffle Right
+# Shuffle Up, only consider windows on Layer 3.
+Move shuffle layers 3 3 Up
+# Shuffle Left then Up
+Move shuffle Left Up
+# Shuffle Up then Left (may not be same position as above)
+Move shuffle Up Left
+....
+
++
+*Move* can be used to moved a window to a specified position:
++
+
+> *Move* [screen _S_] \[w | m]_x_[p | w] \[w | m]_y_[p | w] [Warp] [ewmhiwa]
+
++
+This will move the window to the _x_ and _y_ position (see below).
+By default, the EWMH working area is honoured. If he trailing option
+_ewmhiwa_ is given, then the window position will ignore the working
+area (such as ignoring any values set via *EwmhBaseStruts*). If the
+option _Warp_ is given then the pointer is warped to the window.
++
+If the literal option _screen_ followed by a RandR screen name _S_ is
+specified, the coordinates are interpreted as relative to the given
+screen. The width and height of the screen are used for the
+calculations instead of the display dimensions. The _screen_ is
+interpreted as in the *MoveToScreen* command.
++
+The positional arguments _x_ and _y_ can specify an absolute or relative
+position from either the left/top or right/bottom of the screen. By default,
+the numeric value given is interpreted as a percentage of the screen
+width/height, but a trailing '_p_' changes the interpretation to mean pixels,
+while a trailing '_w_' means percent of the window width/height. To move the
+window relative to its current position, add the '_w_' (for "window") prefix
+before the _x_ and/or _y_ value. To move the window to a position relative to
+the current location of the pointer, add the '_m_' (for "mouse") prefix. To
+leave either coordinate unchanged, "_keep_" can be specified in place of
+_x_ or _y_.
 +
 For advanced uses, the arguments _x_ and _y_ can be used multiple
 times, but without the prefix '_m_' or '_w_'. (See complex examples
@@ -4136,16 +4188,13 @@ Move 40p w-10p
 Move m+0 m+0
 
 # Move window to center of screen (50% of screen
-# poition minus 50% of widow size).
+# position minus 50% of widow size).
 Move 50-50w 50-50w
 ....
 
 +
-Note: In order to obtain moving windows which do not snap to screen,
-with interactive move, hold down _Alt_ whilst moving the window to
-disable snap attraction if it's defined.
-+
 See also the *AnimatedMove* command.
++
 
 *MoveToDesk* [prev | _arg1_ [_arg2_] [_min_ _max_]]::
 	Moves the selected window to another desktop. The arguments are the

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -1408,10 +1408,10 @@ void get_page_offset_check_visible(
 	{
 		get_page_offset(ret_page_x, ret_page_y, fw);
 	}
-
+#if 0
 	fprintf(stderr, "%s: MON: %s {page_x: %d, page_y: %d}\n",
 		__func__, fw->m->si->name, *ret_page_x, *ret_page_y);
-
+#endif
 	return;
 }
 


### PR DESCRIPTION
Extend the Move command to be able to shuffle the window to the closest window (it is not currently touching) in a given direction. The flags can be used to make it consider either windows or icons, and which layer(s) the windows must be on. Closes #540