### PR TITLE
GNOME: remove DO_IGNORE_GNOME_HINTS

### DIFF
--- a/fvwm/window_flags.h
+++ b/fvwm/window_flags.h
@@ -237,8 +237,6 @@
 	((fw)->flags.common.s.has_override_size)
 #define DO_ICONIFY_WINDOW_GROUPS(fw) \
 	((fw)->flags.common.s.do_iconify_window_groups)
-#define DO_IGNORE_GNOME_HINTS(fw) \
-	((fw)->flags.common.s.do_ignore_gnome_hints)
 #define DO_IGNORE_RESTACK(fw) \
 	((fw)->flags.common.s.do_ignore_restack)
 #define DO_IGNORE_ICON_BOXES(fw) \


### PR DESCRIPTION
GnomeHints was originally added to fvwm2 when GNOME 1.x had non-standard window hints which fvwm2 would track for compatibility.
The days of GNOME 1.x are long gone, so we can safely remove the check for this hint; surrounding code has already been removed.