### PR TITLE
Add local configuration file to the default-config.

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -656,3 +656,11 @@ DestroyModuleConfig FvwmIconMan:*
 DestroyModuleConfig EventNewDesk:*
 *EventNewDesk: PassID
 *EventNewDesk: new_desk ChangeDesk
+
+# Local configuration file. For use with the default-config.
+#
+# If $FVWMUSER_DIR/local.config ($HOME/.fvwm/local.config by default)
+# exists, then read it. This allows changes to default-config settings
+# without needing a full copy of the default-config. This will also allow
+# default-config changes to get used after upgrades (if applicable).
+Test (f $[FVWM_USERDIR]/local.config) Read $[FVWM_USERDIR]/local.config


### PR DESCRIPTION
Allow users of the default-config to be able to modify the default configuration via a local configuration file. This can simplify learning fvwm for new users, as they can add their changes to this file and not need a full copy of the default config. It will also allow users of the default-config to be able to get future changes to the default-config if they only want to change a few of its settings.

