### PR TITLE
Add commands to configure the size/position window.

### DIFF
--- a/dev-docs/PARSING.md
+++ b/dev-docs/PARSING.md
@@ -1029,6 +1029,15 @@ CMD_FOCUSSTYLE = "FocusStyle" STYLEOPTIONS
 CMD_FUNCTION = "Function" [FUNCNAME]
 ```
 ```
+CMD_GEOMETRYWINDOW = "GeometryWindow" GEOMWIN_CMD
+GEOMWIN_CMD = "Hide" [GEOMWIN_HIDEOPT]
+GEOMWIN_CMD =/ "Show" [GEOMWIN_HIDEOPT]
+GEOMWIN_CMD =/ "Colorset" INT
+GEOMWIN_CMD =/ "Position" [+/-]INT[p] [+/-]INT[p]
+GEOMWIN_CMD =/ "Screen" XRANDRMONITORNAME
+GEOMWIN_HIDEOPT = "Never" / "Move" / "Resize"
+```
+```
 CMD_GOTODESK = "GotoDesk" DESKNUMBER
 DESKNUMBER = ["prev" / (INT [INT [INT [INT]]])]
 ```
@@ -1041,12 +1050,6 @@ PAGE_ARGUMENTS = ["prev" / ([OPTIONS] 2(PAGECCORD[PAGESUFFIX])
 OPTIONS = ["!"] ("wrapx" / "wrapy" / "nodesklimitx" / "nodesklimity")
 PAGECOORD = INT
 PAGESUFFIX = "p"
-```
-```
-CMD_HIDEGEOMETRYWINDOW = "HideGeometryWindow" [HIDEGEOMETRYWINDOWCOMMAND]
-HIDEGEOMETRYWINDOWCOMMAND = "Never"
-HIDEGEOMETRYWINDOWCOMMAND =/ "Move"
-HIDEGEOMETRYWINDOWCOMMAND =/ "Resize"
 ```
 ```
 CMD_HILIGHTCOLORSET = "HilightColorset" [COLORSET_NUM]
@@ -1817,6 +1820,7 @@ CMD_WINDOWSDESK = "WindowsDesk" ; See 'MoveToDesk'
 CMD_DESK = "Desk" ; See 'Gotodesk'
 CMD_EDGERESISTANCE = "EdgeResistance" ; Style * EdgeMoveDelay, EdgeMoveResistance
 CMD_GLOBALOPTS = "GlobalOpts" ; Various Style options
+CMD_HIDEGEOMETRYWINDOW = "HideGeometryWindow" ; GeometryWindow Hide
 CMD_HILIGHTCOLOR = "HilightColor" ; Style
 CMD_ICONFONT = "IconFont" FONTNAME ; Style
 CMD_ICONPATH = "IconPath" ; ImagePath

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4026,11 +4026,69 @@ consider the windows with _WindowListSkip_ style.)
 	the optional argument _Warp_ is specified the pointer is warped with
 	the window.
 
+*GeometryWindow* Hide | Show | Colorset _n_ | Position _x_ _y_ | Screen _S_::
+	Configures the position or size window that is usually shown when a
+	window is moved or resized interactively. This can be used to hide,
+	show, change the colorset, change the location, or change the screen
+	of the geometry window. Multiple options can be set at once separated
+	by spaces. Details of each option are described below.
++
+> *GeometryWindow* Hide [Never | Move | Resize]
++
+Hides or switches off the geometry window. If the optional parameters _Move_
+or _Resize_ are given, it will only hide the geometry window during the
+respective operation. The parameter _Never_ will switch the geometry back on
+again (equivalent to _Show_).
++
+> *GeometryWindow* Show [Never | Move | Resize]
++
+Shows or switches on the geometry window (equivalent to _Hide Never_). If
+the optional parameters _Move_ or _Resize_ are given, it will only show the
+geometry window during the respective operation. The parameter _Never_ will
+switch the geometry window off (equivalent to _Hide_).
++
+> *GeometryWindow* Colorset _cset_
++
+Sets colorset of the gometry window to _cset_. Use the literal option
+_default_ for _cset_ to use the default colorset.
++
+> *GeometryWindow* Position \[\+|-]_x_[p] \[+|-]_y_[p]
++
+Configures the position the geometry window appears. _x_ and _y_ are the
+relative coordinates as a percentage of the screen size. If a leading '-'
+is provided the coordinates are computed from the left/bottom of the screen
+respectively. If the coordinates are appended with a 'p', they are interpreted
+as the number of pixels from the respective screen edge. If no position
+arguments are given, the geometry window's position will return to its default
+state of the upper left corner or the center if emulating MWM.
++
+> *GeometryWindow* Screen _RANDRNAME_
++
+Configure which screen the geometry window is shown on. By default the
+geometry window is shown on the current screen. If a valid _RANDRNAME_
+is provided, the geometry window will always be shown on that screen.
+Use _current_ as the _RANDRNAME_ to return the default.
++
+Examples:
++
+
+....
+# Position the geometry window in the center of the screen
+GeometryWindow Position 50 50
+# Position the geometry window next to the RightPanel
+GeometryWindow Position -120p 0
+# Use colorset 2 for the geometry window
+GeometryWindow Colorset 2
+# Only show the geometry window on the primary monitor
+GeometryWindow Screen $[monitor.primary]
+# Hide the geometry window
+GeometryWindow Hide
+....
+
+
 *HideGeometryWindow* [Never | Move | Resize]::
-	Hides the position or size window that is usually shown when a window
-	is moved or resized interactively. To switch it off only for move or
-	resize operations the optional parameters _Move_ and _Resize_ can be
-	used respectively. To switch both on again use the _Never_ option.
+	This command has been depreciated and is now obsolete. Use
+        *GeometryWindow Hide* instead.
 
 *Layer* [_arg1_ _arg2_] | [default]::
 	Puts the current window in a new layer. If _arg1_ is non zero then the

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -1487,7 +1487,7 @@ void ApplyDefaultFontAndColors(void)
 			dpy, Scr.NoFocusWin, gcm, &gcv);
 	}
 	/* update the geometry window for move/resize */
-	if (Scr.SizeWindow != None)
+	if (Scr.SizeWindow.win != None)
 	{
 		resize_geometry_window();
 	}
@@ -3891,6 +3891,12 @@ void CMD_Emulate(F_CMD_ARGS)
 		fvwm_debug(__func__, "Unknown style '%s'", style);
 		return;
 	}
+	/* This command might have been issued after any GeometryWindow
+	 * commands, in which case set those values to their defaults.
+	 */
+	Scr.SizeWindow.is_configured = false;
+	Scr.SizeWindow.m = NULL;
+
 	Scr.flags.do_need_window_update = 1;
 	Scr.flags.has_default_font_changed = 1;
 	Scr.flags.has_default_color_changed = 1;

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -68,6 +68,7 @@ enum
 	F_FAKE_KEYPRESS,
 	F_FOCUSSTYLE,
 	F_FUNCTION,
+	F_GEOMWINDOW,
 	F_GLOBAL_OPTS,
 	F_GOTO_DESK,
 	F_GOTO_PAGE,
@@ -274,6 +275,7 @@ void CMD_FlipFocus(F_CMD_ARGS);
 void CMD_Focus(F_CMD_ARGS);
 void CMD_FocusStyle(F_CMD_ARGS);
 void CMD_Function(F_CMD_ARGS);
+void CMD_GeometryWindow(F_CMD_ARGS);
 void CMD_GlobalOpts(F_CMD_ARGS);
 void CMD_GotoDesk(F_CMD_ARGS);
 void CMD_GotoDeskAndPage(F_CMD_ARGS);

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -282,6 +282,9 @@ const func_t func_table[] =
 	CMD_ENT("function", CMD_Function, F_FUNCTION, 0, 0),
 	/* Function - Execute a user defined function, see AddToFunc */
 
+	CMD_ENT("geometrywindow", CMD_GeometryWindow, F_GEOMWINDOW, 0, 0),
+	/* - Configuration settings for position/size window */
+
 	CMD_ENT("globalopts", CMD_GlobalOpts, F_GLOBAL_OPTS, 0, 0),
 	/* - (obsolete, use corresponding Style * instead) */
 
@@ -296,7 +299,7 @@ const func_t func_table[] =
 
 	CMD_ENT("hidegeometrywindow", CMD_HideGeometryWindow,
 		F_HIDEGEOMWINDOW, 0, 0),
-	/* - Hide/show the position/size window */
+	/* - (obsolete, use GeometryWindow Hide instead) */
 
 	CMD_ENT("hilightcolor", CMD_HilightColor, F_HICOLOR, 0, 0),
 	/* - (obsolete, use Style * HighlightFore/Back) */

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1136,7 +1136,10 @@ static void InitVariables(void)
 	Scr.BusyCursor = BUSY_NONE;
 	Scr.Hilite = NULL;
 	Scr.DefaultFont = NULL;
-	Scr.SizeWindow = None;
+
+	memset(&Scr.SizeWindow, 0, sizeof Scr.SizeWindow);
+	Scr.SizeWindow.m = NULL;
+	Scr.SizeWindow.cset = -1;
 
 	Scr.ScrollDelay = DEFAULT_SCROLL_DELAY;
 	Scr.OpaqueSize = DEFAULT_OPAQUE_MOVE_SIZE;
@@ -2540,7 +2543,7 @@ int main(int argc, char **argv)
 	attributes.border_pixel = 0;
 	valuemask = CWBackPixel | CWColormap | CWBorderPixel;
 
-	Scr.SizeWindow = XCreateWindow(
+	Scr.SizeWindow.win = XCreateWindow(
 		dpy, Scr.Root, 0, 0, 1, 1, 0, Pdepth,
 		InputOutput, Pvisual, valuemask, &attributes);
 	resize_geometry_window();

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -609,9 +609,9 @@ static pl_penalty_t __pl_manual_get_pos_simple(
 		DragWidth = arg->place_g.width;
 		DragHeight = arg->place_g.height;
 
-		if (Scr.SizeWindow != None)
+		if (Scr.SizeWindow.win != None)
 		{
-			XMapRaised(dpy, Scr.SizeWindow);
+			XMapRaised(dpy, Scr.SizeWindow.win);
 		}
 		FScreenGetScrRect(NULL, FSCREEN_GLOBAL, &mx, &my, NULL, NULL);
 		if (__move_loop(
@@ -620,9 +620,9 @@ static pl_penalty_t __pl_manual_get_pos_simple(
 		{
 			ret->flags.do_resize_too = 1;
 		}
-		if (Scr.SizeWindow != None)
+		if (Scr.SizeWindow.win != None)
 		{
-			XUnmapWindow(dpy, Scr.SizeWindow);
+			XUnmapWindow(dpy, Scr.SizeWindow.win);
 		}
 		MyXUngrabKeyboard(dpy);
 		MyXUngrabServer(dpy);

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -307,8 +307,21 @@ typedef struct ScreenInfo
 	FvwmWindow FvwmRoot;
 	/* the root window */
 	Window Root;
-	/* the resize dimensions window */
-	Window SizeWindow;
+	/* the resize dimensions window and options */
+	struct
+	{
+		Window win;
+		struct monitor *m;
+		int cset;
+		int StringWidth; /* minimum width */
+		int x;
+		int y;
+		bool xneg;
+		bool yneg;
+		bool xrel;
+		bool yrel;
+		bool is_configured;
+	} SizeWindow;
 	/* Window which will own focus when no other windows have it */
 	Window NoFocusWin;
 
@@ -372,8 +385,6 @@ typedef struct ScreenInfo
 	GC ScratchGC4;
 	GC TitleGC;
 	GC BordersGC;
-	/* minimum width of size window */
-	int SizeStringWidth;
 
 	/* decoration style(s) */
 	FvwmDecor DefaultDecor;


### PR DESCRIPTION
Adds a single command GeometryWindow that is used to configure the
size/position window. The new commands are:

GeometryWindow Hide [[Never | Move | Resize]]
GeometryWindow Show [[Never | Move | Resize]]
GeometryWindow Colorset cset
GeometryWindow Position [+|-]x[p] [+|-]y[p]
GeometryWindow Screen RANDRNAME

This also deprecates the old HideGeometryWindow command, marks it as
obsolete, and uses HideGeometryWindow as an alias for GeometryWindow Hide.