### PR TITLE
Add more columns to default-config menu ItemFormat.

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -291,7 +291,7 @@ Colorset 14 fg #a8988f, bg #2b4e5e, hi #aaaaaa, sh #999999, Plain, NoShape
 MenuStyle * MenuColorset 5, ActiveColorset 6, GreyedColorset 7, TitleColorset 8
 MenuStyle * Hilight3DOff, HilightBack, HilightTitleBack, SeparatorsLong
 MenuStyle * TrianglesSolid, TrianglesUseFore
-MenuStyle * ItemFormat "%|%3.1i%5.3l%5.3>%|"
+MenuStyle * ItemFormat "%|%3.1i%5.3l%5l%5r%5.3>%|"
 MenuStyle * Font "xft:Sans:Bold:size=8:antialias=True"
 
 # Root Menu
@@ -472,7 +472,7 @@ AddToMenu   MenuFvwmManPages "Help" Title
 # Silent suppresses any errors (such as keyboards with no Menu key).
 Silent Key F1 A M Menu MenuFvwmRoot
 Silent Key Menu A A Menu MenuFvwmRoot
-Silent Key Tab A M WindowList Root c c NoDeskSort, SelectOnRelease Meta_L
+Silent Key Tab A M WindowList Root c c NoDeskSort, NoGeometry, SelectOnRelease Meta_L
 Silent Key F1 A C GotoDesk 0 0
 Silent Key F2 A C GotoDesk 0 1
 Silent Key F3 A C GotoDesk 0 2


### PR DESCRIPTION
The default-config MenuStyle ItemFormat only included a single column, which would cause issues with WindowList. The  WindowList would not show geometries or window names if certain options were provided. This adds all three columns back to the ItemFormat so WindowList and other Menus which use more than three columns will display the desired information.

Fixes #151