### PR TITLE
Allow Min/Max WindowSize style to use client size

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -6140,22 +6140,27 @@ character size in many applications). This can be handy for broken
 applications that refuse to be resized. Do not use it if you do not
 need it. The default (opposite) style is _NoResizeOverride_.
 +
-_MinWindowSize [ width [ p ] height [ p ] ]_ Tells fvwm the minimum
-width and height of a window. The values are the percentage of the
-total screen area. If the letter '_p_' is appended to either of the
-values, the numbers are interpreted as pixels. This command is useful
-for certain versions of xemacs which freak out if their windows become
-too small. If you omit he parameters or their values are invalid, both
-limits are set to 0 pixels (which is the default value).
+_MinWindowSize [ width [ p | c ] height [ p | c ] ]_ Tells fvwm the
+minimum width and height of a window. The values are the percentage of
+the total screen area. If the letter '_p_' is appended to either of the
+values, the numbers are interpreted as pixels. If the letter '_c_' is
+appended to either of the values, the numbers are in terms of the client
+window's size hints, which can be useful for windows such as terminals to
+specify the number of rows or columns. This command is useful to deal with
+windows that freak out if their window becomes too small. If you omit the
+parameters or their values are invalid, both limits are set to 0 pixels
+(which is the default value).
 +
-_MaxWindowSize [ width [ p ] height [ p ] ]_ Tells fvwm the maximum
-width and height of a window. The values are the percentage of the
-total screen area. If the letter '_p_' is appended to either of the
-values, the numbers are interpreted as pixels. This command is useful
-to force large application windows to be fully visible. Neither
-_height_ nor _width_ may be less than 100 pixels. If you omit the
-parameters or their values are invalid, both limits are set to 32767
-pixels (which is the default).
+_MaxWindowSize [ width [ p | c ] height [ p | c ] ]_ Tells fvwm the
+maximum width and height of a window. The values are the percentage of
+the total screen area. If the letter '_p_' is appended to either of the
+values, the numbers are interpreted as pixels. If the letter '_c_' is
+appended to either of the values, the numbers are in terms of the client
+window's size hints, which can be useful for windows such as terminals to
+specify the number of rows or columns. This command is useful to force
+large application windows to be fully visible. Neither _height_ nor _width_
+may be less than 100 pixels. If you omit the parameters or their values
+are invalid, both limits are set to 32767 pixels (which is the default).
 +
 With _IconifyWindowGroups_ all windows in the same window group are
 iconified and deiconified at once when any window in the group is

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2095,7 +2095,13 @@ void setup_frame_size_limits(FvwmWindow *fw, window_style *pstyle)
 	if (SHAS_MIN_WINDOW_SIZE(&pstyle->flags))
 	{
 		fw->min_window_width = SGET_MIN_WINDOW_WIDTH(*pstyle);
+		if (SGET_MIN_WINDOW_WIDTH_IS_C(*pstyle))
+			fw->min_window_width = fw->min_window_width *
+				fw->hints.width_inc + fw->hints.base_width;
 		fw->min_window_height = SGET_MIN_WINDOW_HEIGHT(*pstyle);
+		if (SGET_MIN_WINDOW_HEIGHT_IS_C(*pstyle))
+			fw->min_window_height = fw->min_window_width *
+				fw->hints.height_inc + fw->hints.base_height;
 	}
 	else
 	{
@@ -2105,7 +2111,23 @@ void setup_frame_size_limits(FvwmWindow *fw, window_style *pstyle)
 	if (SHAS_MAX_WINDOW_SIZE(&pstyle->flags))
 	{
 		fw->max_window_width = SGET_MAX_WINDOW_WIDTH(*pstyle);
+		if (SGET_MAX_WINDOW_WIDTH_IS_C(*pstyle))
+			fw->max_window_width = fw->max_window_width *
+				fw->hints.width_inc + fw->hints.base_width;
 		fw->max_window_height = SGET_MAX_WINDOW_HEIGHT(*pstyle);
+		if (SGET_MAX_WINDOW_HEIGHT_IS_C(*pstyle))
+			fw->max_window_height = fw->max_window_height *
+				fw->hints.height_inc + fw->hints.base_height;
+
+		/* Checking size now that the client window is known. */
+		if (fw->max_window_width < DEFAULT_MIN_MAX_WINDOW_WIDTH)
+			fw->max_window_width = DEFAULT_MIN_MAX_WINDOW_WIDTH;
+		if (fw->max_window_width > DEFAULT_MAX_MAX_WINDOW_WIDTH)
+			fw->max_window_width = DEFAULT_MAX_MAX_WINDOW_WIDTH;
+		if (fw->max_window_height < DEFAULT_MIN_MAX_WINDOW_HEIGHT)
+			fw->max_window_height = DEFAULT_MIN_MAX_WINDOW_HEIGHT;
+		if (fw->max_window_width > DEFAULT_MAX_MAX_WINDOW_HEIGHT)
+			fw->max_window_height = DEFAULT_MAX_MAX_WINDOW_HEIGHT;
 	}
 	else
 	{

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -680,6 +680,11 @@ typedef struct window_style
 	int min_window_height;
 	int max_window_width;
 	int max_window_height;
+	/* sizes are in terms of client window size hints */
+	bool min_window_width_is_c;
+	bool min_window_height_is_c;
+	bool max_window_width_is_c;
+	bool max_window_height_is_c;
 	int shade_anim_steps;
 #if 1 /*!!!*/
 	snap_attraction_t snap_attraction;

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -827,6 +827,8 @@ void constrain_size(
 	FvwmWindow *fw, const XEvent *e, int *widthp, int *heightp,
 	int xmotion, int ymotion, int flags)
 {
+	int tmp;
+	window_style style;
 	size_rect min;
 	size_rect max;
 	size_rect inc;
@@ -863,28 +865,35 @@ void constrain_size(
 	d.width -= b.total_size.width;
 	d.height -= b.total_size.height;
 
+	/* Need to know if using client size for Min/Max WindowSize
+	 * styles to decided if border width is included in the size.
+	 */
+	lookup_style(fw, &style);
+
 	min.width = fw->hints.min_width;
 	min.height = fw->hints.min_height;
-	if (min.width < fw->min_window_width - b.total_size.width)
+	tmp = SGET_MIN_WINDOW_WIDTH_IS_C(style) ? 0 : b.total_size.width;
+	if (min.width < fw->min_window_width - tmp)
 	{
-		min.width = fw->min_window_width - b.total_size.width;
+		min.width = fw->min_window_width - tmp;
 	}
-	if (min.height < fw->min_window_height - b.total_size.height)
+	tmp = SGET_MIN_WINDOW_HEIGHT_IS_C(style) ? 0 : b.total_size.height;
+	if (min.height < fw->min_window_height - tmp)
 	{
-		min.height =
-			fw->min_window_height - b.total_size.height;
+		min.height = fw->min_window_height - tmp;
 	}
 
 	max.width = fw->hints.max_width;
 	max.height =  fw->hints.max_height;
-	if (max.width > fw->max_window_width - b.total_size.width)
+	tmp = SGET_MAX_WINDOW_WIDTH_IS_C(style) ? 0 : b.total_size.width;
+	if (max.width > fw->max_window_width - tmp)
 	{
-		max.width = fw->max_window_width - b.total_size.width;
+		max.width = fw->max_window_width - tmp;
 	}
-	if (max.height > fw->max_window_height - b.total_size.height)
+	tmp = SGET_MAX_WINDOW_HEIGHT_IS_C(style) ? 0 : b.total_size.height;
+	if (max.height > fw->max_window_height - tmp)
 	{
-		max.height =
-			fw->max_window_height - b.total_size.height;
+		max.height = fw->max_window_height - tmp;
 	}
 
 	if (min.width > max.width)

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -546,20 +546,36 @@
 	((s).icon_title_relief = (x))
 #define SGET_MIN_WINDOW_WIDTH(s) \
 	((s).min_window_width)
+#define SGET_MIN_WINDOW_WIDTH_IS_C(s) \
+	((s).min_window_width_is_c)
 #define SSET_MIN_WINDOW_WIDTH(s,x) \
 	((s).min_window_width = (x))
+#define SSET_MIN_WINDOW_WIDTH_IS_C(s,x) \
+	((s).min_window_width_is_c = (x))
 #define SGET_MAX_WINDOW_WIDTH(s) \
 	((s).max_window_width)
+#define SGET_MAX_WINDOW_WIDTH_IS_C(s) \
+	((s).max_window_width_is_c)
 #define SSET_MAX_WINDOW_WIDTH(s,x) \
 	((s).max_window_width = (x))
+#define SSET_MAX_WINDOW_WIDTH_IS_C(s,x) \
+	((s).max_window_width_is_c = (x))
 #define SGET_MIN_WINDOW_HEIGHT(s) \
 	((s).min_window_height)
+#define SGET_MIN_WINDOW_HEIGHT_IS_C(s) \
+	((s).min_window_height_is_c)
 #define SSET_MIN_WINDOW_HEIGHT(s,x) \
 	((s).min_window_height = (x))
+#define SSET_MIN_WINDOW_HEIGHT_IS_C(s,x) \
+	((s).min_window_height_is_c = (x))
 #define SGET_MAX_WINDOW_HEIGHT(s) \
 	((s).max_window_height)
+#define SGET_MAX_WINDOW_HEIGHT_IS_C(s) \
+	((s).max_window_height_is_c)
 #define SSET_MAX_WINDOW_HEIGHT(s,x) \
 	((s).max_window_height = (x))
+#define SSET_MAX_WINDOW_HEIGHT_IS_C(s,x) \
+	((s).max_window_height_is_c = (x))
 #define SGET_WINDOW_SHADE_STEPS(s) \
 	((s).shade_anim_steps)
 #define SSET_WINDOW_SHADE_STEPS(s,x) \


### PR DESCRIPTION
Adds the option to the MinWindowSize and MaxWindowSize style to state the size in terms of the clients size increment hints by using the suffix 'c'. For example to give xterm minimum size to be 80x24 use.

Style xterm MinWindowSize 80c 24c

Fixes #145