### PR TITLE
Remove *FvwmPager: Label configuration option.

### DIFF
--- a/doc/modules/FvwmPager.adoc
+++ b/doc/modules/FvwmPager.adoc
@@ -221,21 +221,6 @@ size may be slightly different than the specified size.
   window. Possible flags are: %t, %i, %c, and %r for the window's title,
   icon title, class, or resource name, respectively. The default is
   "%i".
-*FvwmPager: Label desk label::
-  Assigns the text _label_ to desk _desk_ (or the current desk if desk
-  is "*") in the pager window. Useful for assigning symbolic names to
-  desktops, i.e.
-+
-....
-*FvwmPager: Label 1 Mail
-*FvwmPager: Label 2 Maker
-*FvwmPager: Label * Matlab
-....
-+
-*Note*: There is currently a much better way to specify desk names
-globally (and not just in FvwmPager) using *DesktopName* command, so you
-should not use this option anymore.
-
 *FvwmPager: DeskColor desk color::
   Assigns the color _color_ to desk _desk_ (or the current desk if desk
   is "*") in the pager window. This replaces the background color for

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -2023,20 +2023,6 @@ void ParseOptions(void)
 	}
       }
     }
-    else if (StrEquals(resource, "Label"))
-    {
-      if (StrEquals(arg1, "*"))
-      {
-	desk = 0;
-      }
-      else
-      {
-	desk = desk1;
-	sscanf(arg1,"%d",&desk);
-      }
-      TAILQ_FOREACH(m, &fp_monitor_q, entry)
-	      SetDeskLabel(m, desk, (const char *)arg2);
-    }
     else if (StrEquals(resource, "Font"))
     {
       if (font_string)


### PR DESCRIPTION
Removes the obsolete FvwmPager configuration option `*FvwmPager: Label n name`. FvwmPager already uses the `DesktopName` setting from fvwm and should honor those names and not have its own naming option.

Fixes #342
