### PR TITLE
Menu: add option to grey entries out

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -2128,6 +2128,9 @@ fail and may screw up your menus. See the *Silent* command.
 *Warning* Do not issue *MenuStyle* commands as dynamic menu actions.
 Chances are good that this crashes fvwm.
 +
+The keyword _Greyed_ will still render the menu item, but will grey it out
+making the option unselectable.
++
 There are several configurable scripts installed together with fvwm
 for automatic menu generation. They have their own man pages. Some of
 them, specifically *fvwm-menu-directory* and *fvwm-menu-desktop*, may
@@ -4125,7 +4128,7 @@ the move. Moving a window to the edge of the screen can be used to drag the
 window to other pages, see *EdgeScroll*, and the *EdgeMoveDelay* style
 for more information.
 +
-The interactive move operation can be aborted with Escape 
+The interactive move operation can be aborted with Escape
 or any mouse button not set to place the window. By default mouse
 button 2 is set to cancel the move operation. To change this you may
 use the *Mouse* command with special context 'P' for Placement.

--- a/fvwm/menuitem.c
+++ b/fvwm/menuitem.c
@@ -438,12 +438,13 @@ void menuitem_paint(
 
 	off_cs = ST_HAS_MENU_CSET(ms) ? ST_CSET_MENU(ms) : -1;
 	/* Note: it's ok to pass a NULL label to is_function_allowed. */
-	if (
-		!IS_EWMH_DESKTOP_FW(mpip->fw) &&
+	if (MI_SHOULD_BE_GREYED(mi) ||
+		(!IS_EWMH_DESKTOP_FW(mpip->fw) &&
 		!is_function_allowed(
 			MI_FUNC_TYPE(mi), MI_LABEL(mi)[0], mpip->fw,
-			RQORIG_PROGRAM_US, False))
+			RQORIG_PROGRAM_US, False)))
 	{
+		MI_IS_SELECTABLE(mi) = False;
 		gcs = ST_MENU_STIPPLE_GCS(ms);
 		off_gcs = gcs;
 		off_cs = ST_HAS_GREYED_CSET(ms) ? ST_CSET_GREYED(ms) : -1;

--- a/fvwm/menuitem.h
+++ b/fvwm/menuitem.h
@@ -37,6 +37,7 @@
 #define MI_HAS_HOTKEY(i)        ((i)->flags.has_hotkey)
 #define MI_IS_HOTKEY_AUTOMATIC(i) ((i)->flags.is_hotkey_automatic)
 #define MI_IS_SELECTABLE(i)     ((i)->flags.is_selectable)
+#define MI_SHOULD_BE_GREYED(i)	((i)->flags.must_grey)
 /* temporary flags */
 #define MI_WAS_DESELECTED(i)    ((i)->flags.was_deselected)
 
@@ -92,6 +93,7 @@ typedef struct MenuItem
 		unsigned has_hotkey : 1;
 		unsigned is_hotkey_automatic : 1;
 		unsigned is_selectable : 1;
+		unsigned must_grey : 1;
 		/* temporary flags */
 		unsigned was_deselected : 1;
 	} flags;

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -6606,6 +6606,7 @@ void AddToMenu(
 	int i;
 	int is_empty;
 	Bool do_replace_title;
+	Bool greyed = False;
 
 	if (MR_MAPPED_COPIES(mr) > 0)
 	{
@@ -6673,6 +6674,14 @@ void AddToMenu(
 			MR_MISSING_SUBMENU_FUNC(mr) = stripcpy(action);
 		}
 		return;
+	}
+	else if (StrEquals(item, "Greyed"))
+	{
+		greyed = True;
+		free(item);
+
+		GetNextToken(action, &item);
+		action = "Nop";
 	}
 
 	/*
@@ -6800,6 +6809,10 @@ void AddToMenu(
 	 * Set the type flags
 	 */
 
+	if (greyed)
+	{
+		MI_SHOULD_BE_GREYED(tmp) = True;
+	}
 	if (is_continuation_item)
 	{
 		MI_IS_CONTINUATION(tmp) = True;


### PR DESCRIPTION
    Menu: add option to grey entries out
    
    This adds a "Greyed" option to the menu syntax to explicitly have
    entries in a menu which are present but not selectable.  This can
    sometimes be useful to indicate options yet to be implemented.
    
    For example:
    
            AddToMenu Foo
            + I Greyed "Hello" Exec exec xterm