### PR TITLE
Configure a colorset for XDGMenu options.

### DIFF
--- a/bin/fvwm-menu-desktop-config.fpl
+++ b/bin/fvwm-menu-desktop-config.fpl
@@ -50,6 +50,8 @@ foreach my $path (@all_filelist) {
 
 my $fvwmform_commands = "
 DestroyModuleConfig  ${modname}: *
+*${modname}: Colorset 5
+*${modname}: ItemColorset 5
 *${modname}: Title      \"\$[gt.Fvwm XDGMenu Config]\"
 *${modname}: WarpPointer
 #*${modname}: Line       center

--- a/modules/FvwmForm/FvwmForm-XDGMenuHelp
+++ b/modules/FvwmForm/FvwmForm-XDGMenuHelp
@@ -1,6 +1,8 @@
 # FvwmForm-XDGMenuHelp - Help Text for fvwm-menu-desktop-config XDGMenu
 # V 1.0.4
 DestroyModuleConfig  FvwmForm-XDGMenuHelp: *
+*FvwmForm-XDGMenuHelp:   Colorset 5
+*FvwmForm-XDGMenuHelp:   ItemColorset 5
 *FvwmForm-XDGMenuHelp:   Title   "$[gt.XDGMenu Help]"
 *FvwmForm-XDGMenuHelp:   WarpPointer
 # Layout

--- a/modules/FvwmForm/FvwmForm-XDGOptionsHelp
+++ b/modules/FvwmForm/FvwmForm-XDGOptionsHelp
@@ -1,6 +1,8 @@
 # FvwmForm-XDGOptionsHelp - Help Text for fvwm-menu-desktop-config XDGMenu Options
 # V 1.0.3
 DestroyModuleConfig  FvwmForm-XDGOptionsHelp: *
+*FvwmForm-XDGOptionsHelp:   Colorset 5
+*FvwmForm-XDGOptionsHelp:   ItemColorset 5
 *FvwmForm-XDGOptionsHelp:   Title   "$[gt.XDGMenu Options Help]"
 *FvwmForm-XDGOptionsHelp:   WarpPointer
 # Layout


### PR DESCRIPTION
The FvwmForms for the XDGMenu options and help didn't have a colorset configured and due to this was hard to read (white on grey). Update these Forms to use the menu colorset to match the menu they are configuring.
