### PR TITLE
Cleanup SetRCDefaults()

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1345,34 +1345,30 @@ static void SetRCDefaults(void)
 		{ "TitleStyle Centered -- Raised", "", "" },
 		{ "Style * Color lightgrey/dimgrey", "", "" },
 		{ "Style * HilightFore black, HilightBack grey", "", "" },
-		{ "DestroyFunc FvwmMakeMissingDesktopMenu", "", "" },
-		{ "AddToFunc   FvwmMakeMissingDesktopMenu I PipeRead 'fvwm-menu-desktop --enable-mini-icons --fvwm-icons'", "", "" },
+		{ "AddToFunc LoadDefaultConfig", "", "" },
+		{ "+ I Read "FVWM_DATADIR"/default-config/config", "", "" },
+		{ "+ I StartFunction", "", "" },
 		{
 			"AddToMenu MenuFvwmRoot \"",
 			_("Builtin Menu"),
 			"\" Title"
 		},
-                { "+ MissingSubmenuFunction FvwmMakeMissingDesktopMenu","",""},
-		{ "+ \"&1. XTerm\" Exec xterm", "", ""},
+		{ "+ \"&1. XTerm\" Exec xterm", "", "" },
+		{ "+ \"&2. FvwmConsole\" Module FvwmConsole", "", "" },
 		{
-			"+ \"&2. ",
-			_("Issue fvwm commands"),
-			"\" Module FvwmConsole"
+			"+ \"&3. ",
+			_("Load Default Config"),
+			"\" LoadDefaultConfig"
 		},
 		{
-			"+ \"&D. ",
-			_("Desktop Menu"),
-			"\" Popup FvwmMenu"
+			"+ \"&4. ",
+			_("Restart"),
+			" Fvwm\" Restart"
 		},
 		{
-			"+ \"&R. ",
-			_("Restart fvwm"),
-			"\" Restart"
-		},
-		{
-			"+ \"&X. ",
-			_("Exit fvwm"),
-			"\" Quit"
+			"+ \"&5. ",
+			_("Quit"),
+			" Fvwm\" Quit"
 		},
 		{ "Mouse 1 R A Menu MenuFvwmRoot", "", "" },
 		/* default menu navigation */

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1403,7 +1403,8 @@ static void SetRCDefaults(void)
 		ecc.type = Restarting ? EXCT_RESTART : EXCT_INIT;
 		ecc.w.wcontext = C_ROOT;
 		exc = exc_create_context(&ecc, ECC_TYPE | ECC_WCONTEXT);
-		xasprintf(&cmd, defaults[i][0], defaults[i][1], defaults[i][2]);
+		xasprintf(&cmd, "%s%s%s", defaults[i][0], defaults[i][1],
+			defaults[i][2]);
 		execute_function(NULL, exc, cmd, 0);
 		free(cmd);
 		exc_destroy_context(exc);


### PR DESCRIPTION
This function creates a minimum config if an empty config is loaded and is the starting point for all configs. This fixes the minimum config to ensure that users who end up here have a minimum menu that can access xterm, FvwmConsole, load the default-config, or quit fvwm.