### PR TITLE
Fix pass through binding logic.

### DIFF
--- a/fvwm/bindings.c
+++ b/fvwm/bindings.c
@@ -392,6 +392,8 @@ static int ParseBinding(
 	if (action != NULL)
 	{
 		action = SkipSpaces(action, NULL, 0);
+		if (action != NULL)
+			is_pass_through = is_pass_through_action(action);
 	}
 	if (
 		action == NULL || *action == 0 ||
@@ -399,27 +401,23 @@ static int ParseBinding(
 	{
 		is_unbind_request = True;
 	}
-	else
+	else if (is_pass_through)
 	{
-		is_pass_through = is_pass_through_action(action);
-		if (is_pass_through)
+		/* pass-through actions indicate that the event be
+		 * allowed to pass through to the underlying window. */
+		if (window_name == NULL)
 		{
-			/* pass-through actions indicate that the event be
-			 * allowed to pass through to the underlying window. */
-			if (window_name == NULL)
+			/* It doesn't make sense to have a pass-through
+			 * action on global bindings. */
+			if (!is_silent)
 			{
-				/* It doesn't make sense to have a pass-through
-				 * action on global bindings. */
-				if (!is_silent)
-				{
-					fvwm_debug(
-						__func__,
-						"Invalid action for global "
-						"binding: %s", tline);
-				}
-
-				return 0;
+				fvwm_debug(
+					__func__,
+					"Invalid action for global "
+					"binding: %s", tline);
 			}
+
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Due to a bug in the binding logic, `-anything` was being processed as an unbind action, so `--` was being treated as an unbind operation and not pass through. This puts the test for `--` earlier in the logic chain to ensure that it gets correctly processed when defining a window specific pass through binding.

Note: This only ensures that `--` gets processed correctly, `-anything` will still be considered an unbind action, but I didn't change this since there are no other commands that start with `-`.