### PR TITLE
FvwmButtons: Shrink windows when honoring Hints.

### DIFF
--- a/modules/FvwmButtons/misc.c
+++ b/modules/FvwmButtons/misc.c
@@ -148,20 +148,20 @@ void ConstrainSize (XSizeHints *hints, int *widthp, int *heightp)
 		if (minAspectX * dheight > minAspectY * dwidth)
 		{
 			delta = makemult(
-				minAspectX * dheight / minAspectY - dwidth,
-				xinc);
-			if (dwidth + delta <= maxWidth)
+				dheight - minAspectY * dwidth / minAspectX,
+				yinc);
+			if (dheight - delta >= minHeight)
 			{
-				dwidth += delta;
+				dheight -= delta;
 			}
 			else
 			{
 				delta = makemult(
-					dheight - minAspectY*dwidth/minAspectX,
-					yinc);
-				if (dheight - delta >= minHeight)
+					minAspectX * dheight / minAspectY -
+					dwidth,	xinc);
+				if (dwidth + delta <= maxWidth)
 				{
-					dheight -= delta;
+					dwidth += delta;
 				}
 			}
 		}
@@ -169,20 +169,20 @@ void ConstrainSize (XSizeHints *hints, int *widthp, int *heightp)
 		if (maxAspectX * dheight < maxAspectY * dwidth)
 		{
 			delta = makemult(
-				dwidth * maxAspectY / maxAspectX - dheight,
-				yinc);
-			if (dheight + delta <= maxHeight)
+				dwidth - maxAspectX * dheight / maxAspectY,
+				xinc);
+			if (dwidth - delta >= minWidth)
 			{
-				dheight += delta;
+				dwidth -= delta;
 			}
 			else
 			{
 				delta = makemult(
-					dwidth - maxAspectX*dheight/maxAspectY,
-					xinc);
-				if (dwidth - delta >= minWidth)
+					dwidth * maxAspectY / maxAspectX -
+					dheight, yinc);
+				if (dheight + delta <= maxHeight)
 				{
-					dwidth -= delta;
+					dheight += delta;
 				}
 			}
 		}


### PR DESCRIPTION
When Swallowing a window and honoring size `Hints`, shrink the window to fit the button (instead of growing it) so the window fits inside the button and isn't cut off. Fallback to growing the window if shrinking makes it smaller than min size.

Note: Use `Swallow (NoHints)` to ignore window size hints and force windows to be the same size as the button if shrinking the window to fit is not wanted.

Fixes #573