### PR TITLE
Add force_icons_size kludge to .stalonetrayrc.

### DIFF
--- a/default-config/.stalonetrayrc
+++ b/default-config/.stalonetrayrc
@@ -1,6 +1,7 @@
 decorations none
 geometry 6x1
 icon_size 18
+kludges force_icons_size
 max_geometry 6x1
 parent_bg true
 transparent false


### PR DESCRIPTION
Add a kludge to ensure that misbehaved apps don't create too big icons in stalonetray.