### PR TITLE
Allow per monitor EdgeCommand and EdgeLeaveCommand

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4909,12 +4909,14 @@ modifiers. I.e. do not ignore
 if you have no problem with it. In the _FAQ_ you can find a better
 solution of this problem.
 
-*EdgeCommand* [_direction_ [_Function_]]::
+*EdgeCommand* [screen _RANDRNAME_] [_direction_ [_Function_]]::
 	Binds a specified fvwm command _Function_ to an edge of the screen.
 	Direction may be one of "_North_", "_Top_", "_West_", "_Left_",
 	"_South_", "_Bottom_", "_Right_" and "_East_". If _Function_ is
 	omitted the binding for this edge is removed. If EdgeCommand is called
-	without any arguments all edge bindings are removed.
+	without any arguments all edge bindings are removed. If the literal
+	option _screen_ followed by a RandR screen name _RANDRNAME_ is given,
+	the command is set only for the given monitor.
 +
 _Function_ is executed when the mouse pointer enters the invisible pan
 frames that surround the visible screen. The binding works only if
@@ -4966,12 +4968,15 @@ Normally, the invisible pan frames are only on the screen edges that
 border virtual pages. If a screen edge has a command bound to it, the
 pan frame is always created on that edge.
 
-*EdgeLeaveCommand* [_direction_ [_Function_]]::
+*EdgeLeaveCommand* [screen _RANDRNAME_] [_direction_ [_Function_]]::
 	Binds a specified fvwm command _Function_ to an edge of the screen.
 	Direction may be one of "_North_", "_Top_", "_West_", "_Left_",
 	"_South_", "_Bottom_", "_Right_" and "_East_". If _Function_ is
 	omitted the binding for this edge is removed. If EdgeLeaveCommand is
-	called without any arguments all edge bindings are removed.
+	called without any arguments all edge bindings are removed. If the
+	literal option _screen_ followed by a RandR screen name _RANDRNAME_
+	is given, the command is set only for the given monitor.
+
 +
 _Function_ is executed when the mouse pointer leaves the invisible pan
 frames that surround the visible screen. The binding works only if

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1983,23 +1983,29 @@ void CMD_EdgeCommand(F_CMD_ARGS)
 	initPanFrames();
 
 	/* get the direction */
-	direction = gravity_parse_dir_argument(action, &action, DIR_NONE);
+	action = SkipSpaces(action, NULL, 0);
+	if (action != NULL && *action != '\0') {
+		direction = gravity_parse_dir_argument(
+			action, &action, DIR_NONE);
 
-	if (direction < 0 || direction > DIR_MAJOR_MASK)
-	{
-		fvwm_debug(__func__, "EdgeCommand needs a direction\n");
-		return;
-	}
+		if (direction < 0 || direction > DIR_MAJOR_MASK)
+		{
+			fvwm_debug(__func__,
+				"EdgeLeaveCommand needs a valid direction.\n");
+			return;
+		}
 
-	/* check if the command does contain at least one token */
-	option = PeekToken(action, NULL);
-	if (option != NULL && *option != '\0')
-		command = action;
+		/* check if the command does contain at least one token */
+		option = PeekToken(action, NULL);
+		if (option != NULL && *option != '\0')
+			command = action;
+	} else
+		direction = DIR_C;
 
 	TAILQ_FOREACH(m_loop, &monitor_q, entry) {
 		/* assign command to the edge(s) */
 		if (m == NULL || m_loop == m) {
-			if (direction == DIR_N)
+			if (direction == DIR_N || direction == DIR_C)
 			{
 				free(m_loop->PanFrameTop.command);
 				m_loop->PanFrameTop.command = NULL;
@@ -2007,7 +2013,7 @@ void CMD_EdgeCommand(F_CMD_ARGS)
 					m_loop->PanFrameTop.command =
 						fxstrdup(command);
 			}
-			else if (direction == DIR_S)
+			if (direction == DIR_S || direction == DIR_C)
 			{
 				free(m_loop->PanFrameBottom.command);
 				m_loop->PanFrameBottom.command = NULL;
@@ -2015,7 +2021,7 @@ void CMD_EdgeCommand(F_CMD_ARGS)
 					m_loop->PanFrameBottom.command =
 						fxstrdup(command);
 			}
-			else if (direction == DIR_W)
+			if (direction == DIR_W || direction == DIR_C)
 			{
 				free(m_loop->PanFrameLeft.command);
 				m_loop->PanFrameLeft.command = NULL;
@@ -2023,19 +2029,13 @@ void CMD_EdgeCommand(F_CMD_ARGS)
 					m_loop->PanFrameLeft.command =
 						fxstrdup(command);
 			}
-			else if (direction == DIR_E)
+			if (direction == DIR_E || direction == DIR_C)
 			{
 				free(m_loop->PanFrameRight.command);
 				m_loop->PanFrameRight.command = NULL;
 				if (command != NULL)
 					m_loop->PanFrameRight.command =
 						fxstrdup(command);
-			}
-			else
-			{
-				/* this should never happen */
-				fvwm_debug(__func__,
-					   "Internal error in CMD_EdgeCommand");
 			}
 			checkPanFrames(m_loop);
 		}
@@ -2068,23 +2068,29 @@ void CMD_EdgeLeaveCommand(F_CMD_ARGS)
 	initPanFrames();
 
 	/* get the direction */
-	direction = gravity_parse_dir_argument(action, &action, DIR_NONE);
+	action = SkipSpaces(action, NULL, 0);
+	if (action != NULL && *action != '\0') {
+		direction = gravity_parse_dir_argument(
+			action, &action, DIR_NONE);
 
-	if (direction < 0 || direction > DIR_MAJOR_MASK)
-	{
-		fvwm_debug(__func__, "EdgeLeaveCommand needs a direction\n");
-		return;
-	}
+		if (direction < 0 || direction > DIR_MAJOR_MASK)
+		{
+			fvwm_debug(__func__,
+				"EdgeLeaveCommand needs a valid direction.\n");
+			return;
+		}
 
-	/* check if the command does contain at least one token */
-	option = PeekToken(action, NULL);
-	if (option != NULL && *option != '\0')
-		command = action;
+		/* check if the command does contain at least one token */
+		option = PeekToken(action, NULL);
+		if (option != NULL && *option != '\0')
+			command = action;
+	} else
+		direction = DIR_C;
 
 	TAILQ_FOREACH(m_loop, &monitor_q, entry) {
 		if (m == NULL || m == m_loop) {
 			/* assign command to the edge(s) */
-			if (direction == DIR_N)
+			if (direction == DIR_N || direction == DIR_C)
 			{
 				free(m_loop->PanFrameTop.command_leave);
 				m_loop->PanFrameTop.command_leave = NULL;
@@ -2092,7 +2098,7 @@ void CMD_EdgeLeaveCommand(F_CMD_ARGS)
 					m_loop->PanFrameTop.command_leave =
 						fxstrdup(command);
 			}
-			else if (direction == DIR_S)
+			if (direction == DIR_S || direction == DIR_C)
 			{
 				free(m_loop->PanFrameBottom.command_leave);
 				m_loop->PanFrameBottom.command_leave = NULL;
@@ -2100,7 +2106,7 @@ void CMD_EdgeLeaveCommand(F_CMD_ARGS)
 					m_loop->PanFrameBottom.command_leave =
 						fxstrdup(command);
 			}
-			else if (direction == DIR_W)
+			if (direction == DIR_W || direction == DIR_C)
 			{
 				free(m_loop->PanFrameLeft.command_leave);
 				m_loop->PanFrameLeft.command_leave = NULL;
@@ -2108,18 +2114,13 @@ void CMD_EdgeLeaveCommand(F_CMD_ARGS)
 					m_loop->PanFrameLeft.command_leave =
 						fxstrdup(command);
 			}
-			else if (direction == DIR_E)
+			if (direction == DIR_E || direction == DIR_C)
 			{
 				free(m_loop->PanFrameRight.command_leave);
 				m_loop->PanFrameRight.command_leave = NULL;
 				if (command != NULL)
 					m_loop->PanFrameRight.command_leave =
 						fxstrdup(command);
-			}
-			else
-			{
-				/* this should never happen */
-				fvwm_debug(__func__, "Internal error");
 			}
 			checkPanFrames(m_loop);
 		}


### PR DESCRIPTION
Add an option `screen RANDRNAME` to `EdgeCommand` and `EdgeLeaveCommand` to allow setting the edge command for only a single monitor.

In addition make `EdgeCommand` and `EdgeLeaveCommand` honor the manual page and remove all commands if given no options are given or remove all commands for a single monitor if only given the `screen RANDRNAME` option is given.