### PR TITLE
Remove Xinemera screen number from WindowId root.

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4671,11 +4671,11 @@ AddToFunc SelectWindow
 	reversed. This command works also with windows that are not managed by
 	fvwm. In this case fvwm does not bring the window onto the screen if
 	it is not visible. For example it is possible to warp the pointer to
-	the center of the root window on screen 1:
+	the center of the root window:
 +
 
 ....
-WindowId root 1 WarpToWindow 50 50
+WindowId root WarpToWindow 50 50
 ....
 
 
@@ -8615,11 +8615,10 @@ This command implies the conditions _CirculateHit_,
 _CirculateHitIcon_ and _CirculateHitShaded_. They can be turned off
 by specifying "!CirculateHit" etc. explicitly.
 +
-*WindowId* [_id_] [(_conditions_)] | [root [_screen_]] _command_:::
+*WindowId* [_id_ | root] [(_conditions_)] _command_:::
 	The *WindowId* command looks for a specific window _id_ and runs the
-	specified _command_ on it. The second form of syntax retrieves the
-	window id of the root window of the given _screen_. If no _screen_
-	is given, the current screen is assumed. The window indicated by
+	specified _command_ on it. If the literal option _root_ is given for
+	the window id, the root window is used. The window indicated by
 	_id_ may belong to a window not managed by fvwm or even a window on
 	a different screen. Although most commands can not operate on such
 	windows, there are some exceptions, for example the *WarpToWindow*
@@ -8635,7 +8634,7 @@ Examples:
 
 ....
 WindowId 0x34567890 Raise
-WindowId root 1 WarpToWindow 50 50
+WindowId root WarpToWindow 50 50
 WindowId $0 (Silly_Popup) Delete
 ....
 

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -1704,7 +1704,6 @@ void CMD_WindowId(F_CMD_ARGS)
 {
 	FvwmWindow *t;
 	char *token;
-	char *naction;
 	unsigned long win;
 	Bool use_condition = False;
 	Bool use_screenroot = False;
@@ -1716,32 +1715,9 @@ void CMD_WindowId(F_CMD_ARGS)
 
 	if (token && StrEquals(token, "root"))
 	{
-		int screen = Scr.screen;
-
 		free(token);
-		token = PeekToken(action, &naction);
-		if (!token || GetIntegerArguments(token, NULL, &screen, 1) != 1)
-		{
-			screen = Scr.screen;
-		}
-		else
-		{
-			action = naction;
-		}
 		use_screenroot = True;
-		if (screen < 0 || screen >= Scr.NumberOfScreens)
-		{
-			screen = 0;
-		}
-		win = XRootWindow(dpy, screen);
-		if (win == None)
-		{
-			if (cond_rc != NULL)
-			{
-				cond_rc->rc = COND_RC_ERROR;
-			}
-			return;
-		}
+		win = Scr.Root;
 	}
 	else if (token)
 	{


### PR DESCRIPTION
With RandR there is a single root window and not one per monitor, so specifying the screen number for the root window no longer has any effect. This removes the option of specifying the screen number for the root window reducing the command to 'WindowId root [command]'.