### PR TITLE
Github: move changelog generation to release workflow

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,31 +18,6 @@ jobs:
     - name: Build Package
       run: 'docker build -t fvwm3 .'
 
-  changelog:
-      name: Update Changelog
-      runs-on: ubuntu-20.04
-      needs: build
-      steps:
-          - name: Checkout code
-            if: github.ref == 'refs/heads/master'
-            uses: actions/checkout@v2
-            with:
-                ref: master
-          - name: Update CHANGELOG
-            if: github.ref == 'refs/heads/master'
-            run: |
-                    docker run -v $(pwd):$(pwd) ferrarimarco/github-changelog-generator --exclude-labels "skip:changelog" --breaking-labels "type:breaking" --enhancement-labels "type:enhancement","type:new-feature" --bug-labels "type:bug" -t ${{ secrets.GITHUB_TOKEN }} --user fvwmorg --project fvwm3 -o "$(pwd)/CHANGELOG.md"
-                    sed -i '/This Changelog was automatically generated/d' CHANGELOG.md
-          - name: Commit CHANGELOG
-            if: github.ref == 'refs/heads/master'
-            uses: stefanzweifel/git-auto-commit-action@v4
-            with:
-                commit_user_name: Fvwm Automation
-                commit_user_email: fvwm-automation@example.org
-                commit_author: Fvwm Automation <fvwm-automation@example.org>
-                commit_message: '[AUTO]: update CHANGELOG'
-                file_pattern: CHANGELOG.md
-
   notification:
     runs-on: ubuntu-20.04
     name: notifications

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Create Release Branch
+on:
+  workflow_dispatch:
+    inputs:
+      versionRelease:
+        description: 'Release version'
+        required: true
+jobs:
+  createrelease:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Create release branch
+      run: git checkout -b release/v${{ github.event.inputs.versionRelease }}
+    - name: Update CHANGELOG
+      run: |
+              docker run -v $(pwd):$(pwd) ferrarimarco/github-changelog-generator --exclude-labels "skip:changelog" --breaking-labels "type:breaking" --enhancement-labels "type:enhancement","type:new-feature" --bug-labels "type:bug" -t ${{ secrets.GITHUB_TOKEN }} --user fvwmorg --project fvwm3 -o "$(pwd)/CHANGELOG.md"
+              sed -i '/This Changelog was automatically generated/d' CHANGELOG.md
+    - name: Commit CHANGELOG
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+              commit_user_name: Fvwm Automation
+              commit_user_email: fvwm-automation@example.org
+              commit_author: Fvwm Automation <fvwm-automation@example.org>
+              commit_message: '[AUTO]: update CHANGELOG'
+              file_pattern: CHANGELOG.md
+    - name: Push new branch
+      run: git push origin release/v${{ github.event.inputs.versionName }}
+    - name: Create pull request into main
+      uses: thomaseizinger/create-pull-request@1.0.0
+      with:
+       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       head: release/v${{ github.event.inputs.versionName }}
+       base: master
+       title: v${{ github.event.inputs.versionRelease }} into master
+       reviewers: ${{ github.event.issue.user.login }}
+       body: |
+           Hello,
+           This PR was created in response workflow running.
+           I've updated the version name and code commit: ${{ steps.make-commit.outputs.commit }}.


### PR DESCRIPTION
Rather than running the Changelog generator on every commit, do this
only when releasing a new version.
