### PR TITLE
CMD_GeometryWindow: Move NULL check.

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -3269,13 +3269,14 @@ void CMD_OpaqueMoveSize(F_CMD_ARGS)
 
 static void set_geom_win_visible_val(char *token, bool val)
 {
-	if (token == NULL)
-		return;
-
 	Scr.gs.do_hide_position_window = !val;
 	Scr.gs.do_hide_resize_window = !val;
 
-	if (StrEquals(token, "never"))
+	if (token == NULL)
+	{
+		return;
+	}
+	else if (StrEquals(token, "never"))
 	{
 		Scr.gs.do_hide_position_window = val;
 		Scr.gs.do_hide_resize_window = val;


### PR DESCRIPTION
This moves the NULL check in the set_geom_win_visible_val helper function to ensure that the values are set correctly if no token is provided.

Fixes #589
