### PR TITLE
Wait: don't run until windows are captured

### DIFF
--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2617,6 +2617,9 @@ void CMD_Wait(F_CMD_ARGS)
 	char *wait_string, *rest;
 	FvwmWindow *t;
 
+	if (!Scr.flags.are_windows_captured)
+		return;
+
 	/* try to get a single token */
 	rest = GetNextToken(action, &wait_string);
 	if (wait_string)


### PR DESCRIPTION
When Fvwm starts up, if a Wait command is used outside of a function,
unpredictable results can happen.

Try and guard against that.

Fixes #590
