### PR TITLE
Bugfix: fvwm-menu-desktop --get-menus

### DIFF
--- a/bin/fvwm-menu-desktop.in
+++ b/bin/fvwm-menu-desktop.in
@@ -475,7 +475,6 @@ Standard output is a series Fvwm commands."""
         fh.write(current_theme)
         fh.close()
 
-    if force:
         for ent in desktop_entries:
             style_id = ent.getStartupWMClass()
             if not style_id:


### PR DESCRIPTION
`fvwm-menu-desktop --get-menus all` would print out addition MiniIcon Style lines that would cause the configuration FvwmForm to think there are more menus than there actually are. This ensures that the MiniIcon Style lines are not printed when getting the list of desktop menus on the system.