### PR TITLE
DesktopName: don't duplicate entries with same name

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2801,10 +2801,8 @@ store_desktop_cmd(int desk, char *name)
 	}
 
 	TAILQ_FOREACH(dc_loop, &desktop_cmd_q, entry) {
-		/* Update the name for an existing desktop, only if it
-		 * differs.
-		 */
-		if (dc_loop->desk == desk && (strcmp(dc_loop->name, name) != 0)) {
+		/* Update the name for an existing desktop. */
+		if (dc_loop->desk == desk) {
 			free(dc_loop->name);
 			dc_loop->name = fxstrdup(name);
 


### PR DESCRIPTION
If a DesktopName command was issued multiple times, such as:

FvwmCommand 'DesktopName 2 SirLoin'
FvwmCommand 'DesktopName 2 SirLoin'
FvwmCommand 'DesktopName 2 SirLoin'
FvwmCommand 'DesktopName 2 SirLoin'

Subsequent calls to change 'DesktopName 2' to something would take `n`
times, due to the fact that repeated calls to store the same DesktopName
for a given desktop were accumulating rather than replacing.

Change the logic for this such that there is no string comparison when
setting DesktopNames.

Fixes #606
