### PR TITLE
FvwmPrompt: add GOFLAGS to build stripped

### DIFF
--- a/bin/FvwmPrompt/Makefile.am
+++ b/bin/FvwmPrompt/Makefile.am
@@ -1,18 +1,19 @@
 if FVWM_BUILD_GOLANG
 GOCMD=go
 GOBUILD=$(GOCMD) build
+GOFLAGS=-ldflags="-s -w"
 GOCLEAN=$(GOCMD) clean
 BINARY_NAME=FvwmPrompt
 
 all: build
 build:
-	$(GOBUILD) -mod=vendor -o $(BINARY_NAME) -v
+	$(GOBUILD) $(GOFLAGS) -mod=vendor -o $(BINARY_NAME) -v
 clean:
 	$(GOCLEAN)
 	rm -f $(BINARY_NAME)
 	rm -f $(BINARY_UNIX)
 run:
-	$(GOBUILD) -mod=vendor -o $(BINARY_NAME) -v ./...
+	$(GOBUILD) $(GOFLAGS) -mod=vendor -o $(BINARY_NAME) -v ./...
 	./$(BINARY_NAME)
 
 install:


### PR DESCRIPTION
Fixes #618

* **What does this PR do?**

Add `GOFLAGS` with a default value of `ldflags="-s -w"` which causes the Go binary to be built stripped.
