### PR TITLE
docs:  change libxft-dev to core dependency

### DIFF
--- a/dev-docs/INSTALL.md
+++ b/dev-docs/INSTALL.md
@@ -24,6 +24,7 @@ FVWM3 has the following dependencies.
 * libxrandr-dev (>= 1.5)
 * libxrender-dev
 * libxt-dev
+* libxft-dev
 
 ## Optional dependencies
 
@@ -38,7 +39,6 @@ FVWM3 has the following dependencies.
 * libsm-dev
 * libxcursor-dev
 * libxext-dev
-* libxft-dev
 * libxi-dev
 * libxpm-dev
 * sharutils


### PR DESCRIPTION
A trivial error in the documentation, **`libxft-dev` cannot be optional**.  Otherwise it will fail to `make` :

```bash
FftInterface.h:23:2: error: unknown type name ‘XftFont’
   23 |  XftFont *fftfont[4]; /* Four rotations */
      |  ^~~~~~~
make[2]: *** [Makefile:572: Flocale.o] Error 1
```
