### PR TITLE
ta/dv2

### DIFF
--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -14,45 +14,30 @@ _config-file_] [*-r*] [*-s* [_screen_num_]] [*-V*] [*-C* _visual-class_
 
 == DESCRIPTION
 
-Fvwm is a window manager for X11. It is designed to minimize memory
-consumption, provide a 3D look to window frames, and a virtual desktop.
+Fvwm is a window manager for X11 optimised for speed.
 
 Note that there are several window managers around that have "fvwm" in
 their name. Fvwm3 is the successor to fvwm2, which preceded the 1.x
 versions of fvwm. This version is simply called fvwm throughout this
 document, while the main executable is named fvwm3.
 
-Fvwm is intended to have a small memory footprint but a rich feature
-set, be extremely customizable and extendible, and have a high degree of
-Motif mwm compatibility. Fvwm provides both a large _virtual desktop_
-and _multiple disjoint desktops_ which can be used separately or
-together. The virtual desktop allows you to pretend that your video
-screen is really quite large, and you can scroll around within the
-desktop. The multiple disjoint desktops allow you to pretend that you
-really have several screens to work at, but each screen is completely
-unrelated to the others.
+Fvwm is intended to have a small memory footprint and is extremely
+customizable and extendible.  A large _virtual desktop_ and
+_multiple disjoint desktops_ can be used separately or together.
+The virtual desktop pretends that the video screen is really quite
+large, and you can scroll around within the desktop.  The multiple
+disjoint desktops pretend there are really several screens to work
+at, but each screen is completely unrelated to the others.
 
-Fvwm provides _keyboard accelerators_ that allow you to perform most
-window manager functions, including moving and resizing windows and
+Fvwm provides _keyboard accelerators_ that allow to perform practically
+all window manager functions, including moving and resizing windows and
 operating the menus, using keyboard shortcuts.
 
-Fvwm has also overcome the distinction between configuration commands
-and action commands that most window managers make. Configuration
-commands typically set fonts, colors, menu contents, and key and mouse
-function bindings, while action commands do things like raise and lower
-windows. Fvwm makes no such distinction and allows anything to be
-changed at any time.
-
-Other noteworthy differences between fvwm and other X11 window managers
-are the introduction of the _SloppyFocus_ and _NeverFocus_ focus
-methods. Focus policy can be separately specified for different window
-groups. Windows using _SloppyFocus_ acquire focus when the pointer moves
-into them and retain focus until some other window acquires it. Such
-windows do not lose focus when the pointer moves into the root window.
-The _NeverFocus_ policy is provided for use with windows into which one
-never types (e.g. xclock, oclock, xbiff, xeyes, tuxeyes) - for example,
-if a SloppyFocus terminal window has focus, moving the pointer over a
-NeverFocus decoration window does not deprive the terminal of focus.
+Fvwm does not distinguish between configuration and action commands.
+Configuration commands typically set fonts, colors, menu contents, and
+key and mouse function bindings, while action commands do things like
+raising and lowering windows. Fvwm makes no such distinction and allows
+anything to be changed at any time.
 
 == OPTIONS
 

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -903,12 +903,6 @@ type "xprop | grep _NET_WM_STRUT" in a terminal and select the
 application. If four numbers appear then these numbers define the
 reserved space as explained in the *EwmhBaseStruts* command.
 
-== MWM COMPATIBILITY
-
-Fvwm provides options to emulate Motif Window Manager (Mwm) as well as
-possible. Please refer to the *Emulate* command as well as to the Mwm
-specific options of the *Style* and *MenuStyle* commands for details.
-
 == OPEN LOOK AND XVIEW COMPATIBILITY
 
 Fvwm supports all the Open Look decoration hints (except pushpins).

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -9189,27 +9189,6 @@ color (often based on the background color), background face (this
 includes images and all kinds of gradients). There is a way to render
 background face and specify other color operations.
 
-In the 2.4.x versions a special module *FvwmTheme* was introduced to
-manage colorsets. Starting with the 2.5.x beta version, the *FvwmTheme*
-functionality was moved to the core fvwm, so this module became
-obsolete. In 2.6.7 the *FvwmTheme* module was removed.
-
-The old syntax:
-
-....
-DestroyModuleConfig FvwmTheme: *
-*FvwmTheme: Colorset 0 fg black, bg rgb:b4/aa/94
-*FvwmTheme: Colorset 1 fg black, bg rgb:a1/b2/c8
-....
-
-corresponds to the new syntax:
-
-....
-CleanupColorsets
-Colorset 0 fg black, bg rgb:b4/aa/94
-Colorset 1 fg black, bg rgb:a1/b2/c8
-....
-
 *Colorset* _num_ [_options_]::
 	Creates or modifies colorset _num_. Colorsets are identified by this
 	number. The number can start at zero and can be a very large number.

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -1762,7 +1762,7 @@ $[...]::
 Some examples can be found in the description of the *AddToFunc*
 command.
 
-== SCRIPTING & COMPLEX FUNCTIONS
+== SCRIPTING AND COMPLEX FUNCTIONS
 
 To achieve the more complex effects, fvwm has a number of commands that
 improve its scripting abilities. Scripts can be read from a file with

--- a/doc/fvwm3/fvwm3.adoc
+++ b/doc/fvwm3/fvwm3.adoc
@@ -4131,16 +4131,15 @@ AddToFunc lower-to-bottom
 	window.	Move can be called with various options to either start
 	an interactive move, specify the position to move, or a direction.
 +
-Calling *Move* by itself with no options starts an interactive move.
-When moving a window interactively, the window may snap to other windows
-and screen boundaries, configurable via the *SnapAttraction* style. Holding
-down _Alt_ whilst moving the window will disable snap attraction during
-the move. Moving a window to the edge of the screen can be used to drag the
-window to other pages, see *EdgeScroll*, and the *EdgeMoveDelay* style
-for more information.
+*Move* without options starts an interactive move.  The window may snap to
+other windows and screen boundaries, configurable with the *SnapAttraction*
+style.  Moving a window to the edge of the screen can be used to drag the
+window to other pages.  (See *EdgeScroll*, and the _EdgeMoveDelay_ style for
+more information.)
 +
-The interactive move operation can be aborted with Escape
-or any mouse button not set to place the window. By default mouse
+Holding down _Alt_ disables snapping and allows to switch pages
+without any delay.  Interactive movement can be aborted with the
+_Escape_ key or any mouse button not set to place the window. By default mouse
 button 2 is set to cancel the move operation. To change this you may
 use the *Mouse* command with special context 'P' for Placement.
 +
@@ -4397,9 +4396,13 @@ where ontop is the highest layer used in your setup.
 	its border, then that window is resized. If called from the root
 	window then the user is allowed to select the target window.
 +
-The operation can be aborted with
+*Resize* without options starts an interactive resize.
 +
-or by pressing any mouse button (except button 1 which confirms it).
+If the _EdgeResizeDelay_ style is set or the _Alt_ key is held down,
+the window can be resized across the edge of the screen.
++
+The operation can be aborted with the _Escape_ key or by pressing
+any mouse button (except button 1 which confirms it).
 +
 If the optional arguments _width_ and _height_ are provided, then the
 window is resized so that its dimensions are _width_ by _height_. The

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2725,8 +2725,8 @@ Bool __move_loop(
 				ButtonMotionMask | ExposureMask, &e)))
 		{
 			XEvent le;
-			int x;
-			int y;
+			int px;
+			int py;
 			int delay;
 
 			UPDATE_FVWM_SCREEN(fw);
@@ -2761,11 +2761,11 @@ Bool __move_loop(
 			e.type = MotionNotify;
 			e.xmotion.time = fev_get_evtime();
 			if (FQueryPointer(
-				    dpy, Scr.Root, &JunkRoot, &JunkChild, &x,
-				    &y, &JunkX, &JunkY, &JunkMask) == True)
+				    dpy, Scr.Root, &JunkRoot, &JunkChild, &px,
+				    &py, &JunkX, &JunkY, &JunkMask) == True)
 			{
-				e.xmotion.x_root = x;
-				e.xmotion.y_root = y;
+				e.xmotion.x_root = px;
+				e.xmotion.y_root = py;
 			}
 			else
 			{

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2620,8 +2620,10 @@ Bool __move_loop(
 	m = fw->m;
 	vx = m->virtual_scr.Vx;
 	vy = m->virtual_scr.Vy;
-	dx = m->virtual_scr.EdgeScrollX ? m->virtual_scr.EdgeScrollX : monitor_get_all_widths();
-	dy = m->virtual_scr.EdgeScrollY ? m->virtual_scr.EdgeScrollY : monitor_get_all_heights();
+	dx = m->virtual_scr.EdgeScrollX ?
+		m->virtual_scr.EdgeScrollX : monitor_get_all_widths();
+	dy = m->virtual_scr.EdgeScrollY ?
+		m->virtual_scr.EdgeScrollY : monitor_get_all_heights();
 
 	if (!GrabEm(cursor, GRAB_NORMAL))
 	{
@@ -2981,8 +2983,10 @@ Bool __move_loop(
 				xl = xl2;
 				yt = yt2;
 			}
-			if (xl != xl_orig || yt != yt_orig || vx != m->virtual_scr.Vx ||
-			    vy != m->virtual_scr.Vy || was_snapped)
+			if (
+				xl != xl_orig || yt != yt_orig ||
+				vx != m->virtual_scr.Vx ||
+				vy != m->virtual_scr.Vy || was_snapped)
 			{
 				/* only snap if the window actually moved! */
 				if (!is_alt_mode_enabled)
@@ -4022,8 +4026,10 @@ static Bool __resize_window(F_CMD_ARGS)
 	Bool was_alt_key_not_pressed = False;
 	Bool is_alt_mode_enabled = False;
 
-	dx = mon->virtual_scr.EdgeScrollX ? mon->virtual_scr.EdgeScrollX : monitor_get_all_widths();
-	dy = mon->virtual_scr.EdgeScrollY ? mon->virtual_scr.EdgeScrollY : monitor_get_all_heights();
+	dx = mon->virtual_scr.EdgeScrollX ?
+		mon->virtual_scr.EdgeScrollX : monitor_get_all_widths();
+	dy = mon->virtual_scr.EdgeScrollY ?
+		mon->virtual_scr.EdgeScrollY : monitor_get_all_heights();
 
 	bad_window = False;
 	ResizeWindow = FW_W_FRAME(fw);

--- a/modules/FvwmIconMan/FvwmIconMan.h
+++ b/modules/FvwmIconMan/FvwmIconMan.h
@@ -65,7 +65,6 @@ typedef struct Resolution {
 		NO_SHOW_PAGE = 0x20,
 		NO_SHOW_SCREEN = 0x40,
 	} type;
-		
 } Resolution;
 
 typedef enum {


### PR DESCRIPTION
- Pressing Alt during "Move" enables immediate paging.
- Remove trailing whitespace.
- __move_loop: Rename variables.
- Break long lines.
- Fix "&AMP;" in man page.
- Remove reference to FvwmTheme from man page.
- Remove MWM reference from manpage; reword first paragraphs.
- Remove section "MWM COMPATIBILITY" from man page.
