### PR TITLE
ta/dv logfile

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -4,6 +4,7 @@
 [*-c* _config-command_]
 [*-d* _displayname_]
 [*-f* _config-file_]
+[*-o* _logfile_]
 [*-s* [_screen_num_]]
 [*-v*]
 [other options]
@@ -80,6 +81,11 @@ down, but guarantees that fvwm's internal error messages are correct.
 Causes fvwm to read _config-file_ instead of _~/.fvwm/config_ as its
 initialization file. _$FVWM_USERDIR_ can also be used to change location
 of default user directory _~/.fvwm_.
+
+*-o* _logfile_::
+
+Write log messages to _logfile_.  If _logfile_ is '-', log to the
+console.  (Does not turn on logging, see the *-v* option.)
 
 *-h* | *--help*::
 
@@ -241,7 +247,7 @@ save a few bits of memory.
 Enables stack ring debugging. This option is only intended for internal
 debugging and should only be used by developers.
 
-*-v*::
+*-v* | *--verbose*::
 
 Enables debug logging. Writes in append mode to fvwm log file, which is
 ~/.fvwm/fvwm3-output.log by default. See ENVIRONMENT section on how to

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -4,7 +4,6 @@
 _config-file_] [*-r*] [*-s* [_screen_num_]] [*-V*] [*-C* _visual-class_
 | *-I* _visual-id_] [*-l* _colors_ [*-L*] [*-A*] [*-S*] [*-P*]] [*-D*]
 [*-h*] [*-i* _client-id_] [*-F* _state-file_] [*--debug-stack-ring*]
-[*-blackout*]
 
 == DESCRIPTION
 
@@ -233,12 +232,6 @@ this option causes fvwm to never free the colors in its palette. By
 default, when fvwm does not need a color any more it frees this color so
 that a new color can be used. This option may speed up image loading and
 save a few bits of memory.
-
-*-blackout*::
-
-This option is provided for backward compatibility only. Blacking out
-the screen during startup is not necessary (and doesn't work) anymore.
-This option will be removed in the future.
 
 *--debug-stack-ring*::
 

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -1,9 +1,12 @@
 == SYNOPSIS
 
-*fvwm3* [*-c* _config-command_] [*-d* _displayname_] [*-f*
-_config-file_] [*-r*] [*-s* [_screen_num_]] [*-V*] [*-C* _visual-class_
-| *-I* _visual-id_] [*-l* _colors_ [*-L*] [*-A*] [*-S*] [*-P*]] [*-D*]
-[*-h*] [*-i* _client-id_] [*-F* _state-file_] [*--debug-stack-ring*]
+*fvwm3*
+[*-c* _config-command_]
+[*-d* _displayname_]
+[*-f* _config-file_]
+[*-s* [_screen_num_]]
+[*-v*]
+[other options]
 
 == DESCRIPTION
 

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -1140,7 +1140,7 @@ static signed int expand_vars_extended(
 		break;
 	case VAR_DEBUG_LOG_STATE:
 		is_numeric = True;
-		val = log_get_level();
+		val = lib_log_level;
 		break;
 	default:
 		/* unknown variable - try to find it in the environment */

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1931,13 +1931,6 @@ int main(int argc, char **argv)
 			usage(1);
 			exit(0);
 		}
-		else if (strcmp(argv[i], "-blackout") == 0)
-		{
-			/* obsolete option */
-			fvwm_debug(__func__,
-				   "The -blackout option is obsolete, it will be "
-				   "removed in 3.0.");
-		}
 		else if (strcmp(argv[i], "-r") == 0 ||
 			 strcmp(argv[i], "-replace") == 0 ||
 			 strcmp(argv[i], "--replace") == 0)

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1242,10 +1242,12 @@ static void usage(int is_verbose)
 		   " -I vis-id:    use visual <vis-id>\n"
 		   " -l colors:    try to use no more than <colors> colors\n"
 		   " -L:           strict color limit\n"
+                   " -o logfile:   output file or '-' for stderr\n"
 		   " -P:           visual palette\n"
 		   " -r:           replace running window manager\n"
 		   " -s [screen]:  manage a single screen\n"
 		   " -S:           static palette\n"
+		   " -v:           verbose log output\n"
 		   " -V:           print version information\n"
 		);
 	fprintf(stderr, "Try 'man %s' for more information.\n",
@@ -1802,6 +1804,7 @@ int main(int argc, char **argv)
 			   fvwm_userdir);
 	}
 
+	set_log_file(NULL);
 	for (i = 1; i < argc; i++)
 	{
 		if (strcmp(argv[i], "-debug_stack_ring") == 0 ||
@@ -2043,10 +2046,21 @@ int main(int argc, char **argv)
 			free(Fvwm_SupportInfo);
 			exit(0);
 		}
-		else if (strcmp(argv[i], "-v") == 0)
+		else if (
+			strcmp(argv[i], "-v") == 0 ||
+			strcmp(argv[i], "--verbose") == 0)
 		{
-			log_set_level(1);
-			log_open(fvwm_userdir);
+			lib_log_level = 1;
+		}
+		else if (strcmp(argv[i], "-o") == 0 ||
+			 strcmp(argv[i], "--output-file") == 0)
+		{
+			if (++i >= argc)
+			{
+				usage(0);
+				exit(1);
+			}
+			set_log_file(argv[i]);
 		}
 		else
 		{
@@ -2056,6 +2070,7 @@ int main(int argc, char **argv)
 			exit(1);
 		}
 	}
+	log_open(fvwm_userdir);
 
 	InstallSignals();
 

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -806,10 +806,10 @@ void FScreenTranslateCoordinates(
 int FScreenClipToScreen(fscreen_scr_arg *arg, fscreen_scr_t screen,
 			int *x, int *y, int w, int h)
 {
-	int sx;
-	int sy;
-	int sw;
-	int sh;
+	int sx = 0;
+	int sy = 0;
+	int sw = 0;
+	int sh = 0;
 	int lx = (x) ? *x : 0;
 	int ly = (y) ? *y : 0;
 	int x_grav = GRAV_POS;
@@ -852,10 +852,10 @@ int FScreenClipToScreen(fscreen_scr_arg *arg, fscreen_scr_t screen,
 void FScreenCenterOnScreen(fscreen_scr_arg *arg, fscreen_scr_t screen,
 			   int *x, int *y, int w, int h)
 {
-	int sx;
-	int sy;
-	int sw;
-	int sh;
+	int sx = 0;
+	int sy = 0;
+	int sw = 0;
+	int sh = 0;
 	int lx;
 	int ly;
 
@@ -895,10 +895,10 @@ void FScreenGetResistanceRect(
 Bool FScreenIsRectangleOnScreen(fscreen_scr_arg *arg, fscreen_scr_t screen,
 				rectangle *rec)
 {
-	int sx;
-	int sy;
-	int sw;
-	int sh;
+	int sx = 0;
+	int sy = 0;
+	int sw = 0;
+	int sh = 0;
 
 	FScreenGetScrRect(arg, screen, &sx, &sy, &sw, &sh);
 

--- a/libs/defaults.h
+++ b/libs/defaults.h
@@ -10,6 +10,9 @@
 #ifndef FVWMLIB_DEFAULTS_H
 #define FVWMLIB_DEFAULTS_H
 
+/*** logging ***/
+#define FVWM3_LOGFILE_DEFAULT "fvwm3-output.log"
+
 /*** event handling ***/
 #define CLOCK_SKEW_MS                  30000 /* ms */
 

--- a/libs/getpwuid.c
+++ b/libs/getpwuid.c
@@ -39,7 +39,7 @@ const char
 	return (home);
 }
 
-const char *
+char *
 expand_path(const char *path)
 {
 	char			*expanded, *name;

--- a/libs/getpwuid.h
+++ b/libs/getpwuid.h
@@ -20,6 +20,6 @@
 #endif
 
 const char	*find_home_dir(void);
-const char	*expand_path(const char *);
+char	*expand_path(const char *);
 
 #endif

--- a/libs/log.h
+++ b/libs/log.h
@@ -2,10 +2,10 @@
 #define FVWMLIB_LOG_H
 
 #define printflike(a, b) __attribute__ ((format (printf, a, b)))
-#define FVWM3_LOGFILE_DEFAULT "fvwm3-output.log"
 
-void	log_set_level(int);
-int	log_get_level(void);
+extern int	lib_log_level;
+
+void	set_log_file(char *name);
 void	log_open(const char *);
 void	log_toggle(const char *);
 void	log_close(void);


### PR DESCRIPTION
- Fix uninitialised varibles.
- Remove obsolete option "-blackout".
- Only important options in SYNOPSIS section.
- getpwuid.[ch]: Make expand_path non-const.
- libs/log.[ch]: Implement stderr logging.
