### PR TITLE
convert UPDATE_FVWM_SCREEN from macro to function

### DIFF
--- a/contrib/coccinelle/update_fvwm_screen.cocci
+++ b/contrib/coccinelle/update_fvwm_screen.cocci
@@ -1,0 +1,6 @@
+@@
+expression L;
+@@
+
+- UPDATE_FVWM_SCREEN(L);
++ update_fvwm_monitor(L);

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2533,7 +2533,7 @@ FvwmWindow *AddWindow(
 	{
 		rectangle attr_g;
 
-		UPDATE_FVWM_SCREEN(fw);
+		update_fvwm_monitor(fw);
 
 		if (IS_SHADED(fw))
 		{
@@ -2636,7 +2636,7 @@ FvwmWindow *AddWindow(
 	setup_key_and_button_grabs(fw);
 
 	/****** inform modules of new window ******/
-	UPDATE_FVWM_SCREEN(fw);
+	update_fvwm_monitor(fw);
 	BroadcastConfig(M_ADD_WINDOW,fw);
 	BroadcastWindowIconNames(fw, True, False);
 

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1813,7 +1813,7 @@ void monitor_update_ewmh(void)
 	BroadcastMonitorList(NULL);
 
 	for (t = Scr.FvwmRoot.next; t; t = t->next) {
-		UPDATE_FVWM_SCREEN(t);
+		update_fvwm_monitor(t);
 	}
 }
 

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -609,7 +609,7 @@ void update_absolute_geometry(FvwmWindow *fw)
 	 * outdated.
 	 */
 	if (IS_SHADED(fw))
-		UPDATE_FVWM_SCREEN(fw);
+		update_fvwm_monitor(fw);
 	m = (fw && fw->m) ? fw->m : monitor_get_current();
 
 	/* store orig values in absolute coords */

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2054,7 +2054,7 @@ static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
 
 			/* then move to screen */
 			fvwmrect_move_into_rectangle(&r, &ms);
-			UPDATE_FVWM_SCREEN(fw);
+			update_fvwm_monitor(fw);
 		}
 
 		s.x = page.x - m->virtual_scr.Vx;
@@ -2167,25 +2167,25 @@ static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
 void CMD_Move(F_CMD_ARGS)
 {
 	__move_window(F_PASS_ARGS, False, MOVE_NORMAL);
-	UPDATE_FVWM_SCREEN(exc->w.fw);
+	update_fvwm_monitor(exc->w.fw);
 }
 
 void CMD_AnimatedMove(F_CMD_ARGS)
 {
 	__move_window(F_PASS_ARGS, True, MOVE_NORMAL);
-	UPDATE_FVWM_SCREEN(exc->w.fw);
+	update_fvwm_monitor(exc->w.fw);
 }
 
 void CMD_MoveToPage(F_CMD_ARGS)
 {
 	__move_window(F_PASS_ARGS, False, MOVE_PAGE);
-	UPDATE_FVWM_SCREEN(exc->w.fw);
+	update_fvwm_monitor(exc->w.fw);
 }
 
 void CMD_MoveToScreen(F_CMD_ARGS)
 {
 	__move_window(F_PASS_ARGS, False, MOVE_SCREEN);
-	UPDATE_FVWM_SCREEN(exc->w.fw);
+	update_fvwm_monitor(exc->w.fw);
 }
 
 static void update_pos(
@@ -2533,7 +2533,7 @@ Bool __move_loop(
 	struct monitor	*m = NULL;
 
 	if (fw->m == NULL)
-		UPDATE_FVWM_SCREEN(fw);
+		update_fvwm_monitor(fw);
 	m = fw->m;
 	v.x = m->virtual_scr.Vx;
 	v.y = m->virtual_scr.Vy;
@@ -2651,7 +2651,7 @@ Bool __move_loop(
 			int py;
 			int delay;
 
-			UPDATE_FVWM_SCREEN(fw);
+			update_fvwm_monitor(fw);
 
 			fev_get_last_event(&le);
 
@@ -4724,7 +4724,7 @@ void CMD_Resize(F_CMD_ARGS)
 	}
 
 	__resize_window(F_PASS_ARGS);
-	UPDATE_FVWM_SCREEN(fw);
+	update_fvwm_monitor(fw);
 
 	return;
 }
@@ -5398,7 +5398,7 @@ void CMD_ResizeMaximize(F_CMD_ARGS)
 		maximize_fvwm_window(fw, &max_g);
 	}
 	EWMH_SetWMState(fw, False);
-	UPDATE_FVWM_SCREEN(fw);
+	update_fvwm_monitor(fw);
 
 	return;
 }
@@ -5427,7 +5427,7 @@ void CMD_ResizeMoveMaximize(F_CMD_ARGS)
 		maximize_fvwm_window(fw, &max_g);
 	}
 	EWMH_SetWMState(fw, False);
-	UPDATE_FVWM_SCREEN(fw);
+	update_fvwm_monitor(fw);
 
 	return;
 }
@@ -5454,7 +5454,7 @@ int stick_across_pages(F_CMD_ARGS, int toggle)
 		{
 			action = "";
 			__move_window(F_PASS_ARGS, False, MOVE_PAGE);
-			UPDATE_FVWM_SCREEN(fw);
+			update_fvwm_monitor(fw);
 		}
 		SET_STICKY_ACROSS_PAGES(fw, 1);
 	}

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -487,24 +487,6 @@ typedef struct ScreenInfo
 	} last_added_item;
 } ScreenInfo;
 
-#define UPDATE_FVWM_SCREEN(fw)						   \
-	do {								   \
-		rectangle g;						   \
-		struct monitor *mnew;					   \
-									   \
-		get_unshaded_geometry((fw), &g);			   \
-		mnew = FindScreenOfXY((fw)->g.frame.x, (fw)->g.frame.y);   \
-		/* Avoid unnecessary updates. */			   \
-		if (mnew == (fw)->m)					   \
-			break;						   \
-		(fw)->m_prev = (fw)->m;					   \
-		(fw)->m = mnew;						   \
-		(fw)->Desk = mnew->virtual_scr.CurrentDesk;		   \
-		EWMH_SetCurrentDesktop((fw)->m);			   \
-		desk_add_fw((fw));					   \
-		BroadcastConfig(M_CONFIGURE_WINDOW, (fw));		   \
-	} while(0)
-
 /* A macro to to simplify he "ewmh desktop code" */
 #define IS_EWMH_DESKTOP(win) \
 	(Scr.EwmhDesktop && win == Scr.EwmhDesktop->wins.client)
@@ -519,6 +501,7 @@ typedef struct ScreenInfo
 void LoadDefaultButton(DecorFace *bf, int i);
 void ResetAllButtons(FvwmDecor *decor);
 void DestroyAllButtons(FvwmDecor *decor);
+void update_fvwm_monitor(FvwmWindow *);
 
 void simplify_style_list(void);
 

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -43,6 +43,7 @@
 #include "focus.h"
 #include "stack.h"
 #include "icons.h"
+#include "virtual.h"
 
 /* ---------------------------- local definitions -------------------------- */
 
@@ -658,6 +659,26 @@ void apply_decor_change(FvwmWindow *fw)
 	apply_window_updates(fw, &flags, &style, get_focus_window());
 
 	return;
+}
+
+/* Update which monitor a window is on. */
+void update_fvwm_monitor(FvwmWindow *fw)
+{
+	rectangle g;
+	struct monitor *mnew;
+
+	get_unshaded_geometry((fw), &g);
+	mnew = FindScreenOfXY((fw)->g.frame.x, (fw)->g.frame.y);
+
+	/* Avoid unnecessary updates. */
+	if (mnew == (fw)->m)
+		return;
+	(fw)->m_prev = (fw)->m;
+	(fw)->m = mnew;
+	(fw)->Desk = mnew->virtual_scr.CurrentDesk;
+	EWMH_SetCurrentDesktop((fw)->m);
+	desk_add_fw((fw));
+	BroadcastConfig(M_CONFIGURE_WINDOW, (fw));
 }
 
 /* Check and apply new style to each window if the style has changed. */

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2403,7 +2403,7 @@ update:
 	raisePanFrames();
 
 	for (t = Scr.FvwmRoot.next; t; t = t->next)
-		UPDATE_FVWM_SCREEN(t);
+		update_fvwm_monitor(t);
 
 	BroadcastMonitorList(NULL);
 }


### PR DESCRIPTION
Updating the information for which monitor a window is on originally
started out as a macro.  However, this has now grown sufficiently large
that it should be a function in its own right.

Therefore, rename UPDATE_FVWM_SCREEN -> update_fvwm_monitor().

The coccinelle script which introduces this change is also part of this
commit.
