### PR TITLE
DisplayPosition: fix segfault

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -1153,6 +1153,8 @@ static void display_string(Bool Init, char *str)
 	int offset;
 	FlocaleWinString fstr;
 
+	memset(&fstr, 0, sizeof(fstr));
+
 	if (Scr.SizeWindow.cset >= 0)
 	{
 		fstr.colorset = &Colorset[Scr.SizeWindow.cset];


### PR DESCRIPTION
Zero-out fstr so that the default values are initialised, regardless of
any user configuration.
