### PR TITLE
Fix ExitFunction

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -550,7 +550,7 @@ void Done(int restart, char *command)
 
 		char *action;
 
-		xasprintf(&action, "Function ", exit_func_name);
+		xasprintf(&action, "Function %s", exit_func_name);
 
 		ecc.type = restart ? EXCT_TORESTART : EXCT_QUIT;
 		ecc.w.wcontext = C_ROOT;


### PR DESCRIPTION
A typo in fvwm3.c (line 553) prevents ExitFunction from executing.

* **What does this PR do?**
A missing `%s` in the xasprintf call at line 553 causes ExitFunction to not execute. Adding `%s` allows ExitFunction to execute as expected.