### PR TITLE
avoid sprintf(%n)

### DIFF
--- a/libs/ColorUtils.c
+++ b/libs/ColorUtils.c
@@ -422,15 +422,15 @@ int pixel_to_color_string(
 
 	if (!use_hash)
 	{
-		sprintf(
-			output, "rgb:%04x/%04x/%04x%n", (int)color.red,
-			(int)color.green, (int)color.blue, &n);
+		n = sprintf(
+			output, "rgb:%04x/%04x/%04x", (int)color.red,
+			(int)color.green, (int)color.blue);
 	}
 	else
 	{
-		sprintf(
-			output, "#%02x%02x%02x%n", (int)(color.red/256),
-			(int)(color.green/256), (int)(color.blue/256), &n);
+		n = sprintf(
+			output, "#%02x%02x%02x", (int)(color.red/256),
+			(int)(color.green/256), (int)(color.blue/256));
 	}
 
 	return n;

--- a/libs/Module.c
+++ b/libs/Module.c
@@ -497,7 +497,7 @@ char *module_expand_action(
 				return NULL;
 			}
 			/* print the number into the string */
-			sprintf(dest, "%d%n", val, &offset);
+			offset = sprintf(dest, "%d", val);
 			dest += offset;
 		}
 		else if (is_string)
@@ -512,7 +512,7 @@ char *module_expand_action(
 			/* print the colour name into the string */
 			if (string)
 			{
-				sprintf(dest, "%s%n", string, &offset);
+				offset = sprintf(dest, "%s", string);
 				dest += offset;
 			}
 		}


### PR DESCRIPTION
Hello,

On OpenBSD the compiler warns that:

```
warning: '%n' format specifier support is deactivated and will call abort(3)
```

The `%n` conversion specifier for the printf* family of functions is widely discouraged for security reasons and the OpenBSD libc in particular will abort(3) if such specifier is found.  (scanf* %n is a different story)
