### PR TITLE
Fix selectable flag for the Resize window operation menu item

### DIFF
--- a/fvwm/menuitem.c
+++ b/fvwm/menuitem.c
@@ -461,6 +461,7 @@ void menuitem_paint(
 	}
 	else
 	{
+		MI_IS_SELECTABLE(mi) = True;
 		gcs = ST_MENU_INACTIVE_GCS(ms);
 		off_gcs = ST_MENU_INACTIVE_GCS(ms);
 	}


### PR DESCRIPTION
* **What does this PR do?**
This is an attempt to fix the following bug:
* Open an xterm (or any other window), activate the window operations menu, note that Resize is selectable as expected.
* Next, open a non-resizable window, such as the Identify window. Open its window operations menu. Note Resize is greyed out and not selectable. Close the Identify window.
* Next, open the window operations menu on the xterm again. Resize will not be greyed out but will not be selectable.

This happens because in `menuitem_paint` when a function is not allowed, the selectable flag is cleared. However it is never restored. Since the Resize menu item is being reused, it disables selecting Resize on all other windows.

The fix is quick and dirty, but works for me. I'd like some feedback as to whether this is the best way. Please have a look, thanks!
