### PR TITLE
ewmh: add time.h

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/times.h>
+#include <time.h>
 #include "libs/fvwm_x11.h"
 #include "libs/fvwmlib.h"
 #include "fvwm.h"


### PR DESCRIPTION
Needed when certain code paths (such as with --disable-png) are hit, and
the set of #includes changes.

Fixes #669
