### PR TITLE
Windowshade: explicitly set input focus

### DIFF
--- a/fvwm/windowshade.c
+++ b/fvwm/windowshade.c
@@ -219,7 +219,7 @@ void CMD_WindowShade(F_CMD_ARGS)
 	FlushAllMessageQueues();
 	XFlush(dpy);
 	EWMH_SetWMState(fw, False);
-
+	SetFocusWindow(fw, True, FOCUS_SET_FORCE);
 	return;
 }
 


### PR DESCRIPTION
When shading/unshading a window which might still be focused, still tell
the window this to avoid only redrawing the window borders without
having set the focus first.

Fixes #671
