### PR TITLE
Do not calculate size for missing characters.

### DIFF
--- a/libs/Fft.c
+++ b/libs/Fft.c
@@ -336,8 +336,15 @@ static void MatchFont(Display *dpy,
 
 			if (result == FcResultMatch) {
 				XftFont *fallback_font = XftFontOpenPattern(dpy, font_pattern);
-				if (fallback_font) sp.font = fallback_font;
-				else FcPatternDestroy(font_pattern);
+				/*
+				 * Hack to not use a fallback font for emoji's (codelen == 4).
+				 * FIXME: Temporary fix to avoid crashes until a proper
+				 * fix to display emoji's with a fallback font is found.
+				 */
+				if (fallback_font && codelen != 4)
+					sp.font = fallback_font;
+				else
+					FcPatternDestroy(font_pattern);
 			}
 		}
 		XGlyphInfo info;


### PR DESCRIPTION
This is my understanding of the situation: When the code in [`MatchFont`](https://github.com/fvwmorg/fvwm3/blob/4d646ca61c80545f9b0467dae68da8dbe3395f72/libs/Fft.c#L282) decides that the chosen font does not have the character in question, it constructs a fallback font from the properties of the original. Then, it reports the dimensions of the character  and also renders it using this new fallback font. Mostly this works fine. I checked this by debugging through the code character by character.

However, the only exception I found is for characters with codelen = 4. There might be other cases but I could not reproduce this in my tests with other types of chars. In this case calling `XftCharExists` on the char with the fallback font will return true and `XftTextExtents32` will return some reasonable looking values, but the character actually does not render using the fallback font when `render_char` is called next. This is the case which throws BadLength.

For `FvwmIdent`, in fact during the [`MakeList`](https://github.com/fvwmorg/fvwm3/blob/4d646ca61c80545f9b0467dae68da8dbe3395f72/modules/FvwmIdent/FvwmIdent.c#L1102) call when no rendering is done, `XftTextExtents32` is called for these problematic characters using the fallback font. This is enough to cause a BadLength error during the Xlib calls [here](https://github.com/fvwmorg/fvwm3/blob/4d646ca61c80545f9b0467dae68da8dbe3395f72/modules/FvwmIdent/FvwmIdent.c#L1251).

In my test fix I skip over these characters if a fallback is active. This avoids the Xlib BadLength error which caused the crash. Of course this test is too simplistic, but maybe we can find a better way to detect and skip such non-rendering characters. Please have a look, thanks!

```
Fixes #622, fixes #680.
```