### PR TITLE
Fix for lock recusion in handle_all_expose()

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -267,6 +267,12 @@ static int _pred_weed_accumulate_expose(
 	return 1;
 }
 
+static int _pred_weed_is_expose(
+	Display *display, XEvent *event, XPointer arg)
+{
+	return (event->type == Expose);
+}
+
 static int _pred_weed_handle_expose(
 	Display *display, XEvent *event, XPointer arg)
 {
@@ -4546,7 +4552,8 @@ void handle_all_expose(void)
 
 	saved_event = fev_save_event();
 	FPending(dpy);
-	FWeedIfEvents(dpy, _pred_weed_handle_expose, NULL);
+	FWeedAndHandleIfEvents(dpy, _pred_weed_is_expose,
+			       _pred_weed_handle_expose, NULL);
 	fev_restore_event(saved_event);
 
 	return;

--- a/libs/FEvent.c
+++ b/libs/FEvent.c
@@ -534,6 +534,28 @@ int FWeedIfEvents(
 	return weed_args.count;
 }
 
+int FWeedAndHandleIfEvents(
+	Display *display,
+	int (*weed_predicate) (Display *display, XEvent *event, XPointer arg),
+	int (*handler) (Display *display, XEvent *event, XPointer arg),
+	XPointer arg)
+{
+	_fev_weed_args weed_args;
+	XEvent e;
+
+	assert(fev_is_invalid_event_type_set);
+	memset(&weed_args, 0, sizeof(weed_args));
+	weed_args.weed_predicate = weed_predicate;
+	weed_args.arg = arg;
+	if (FCheckPeekIfEvent(display, &e, _fev_pred_weed_if,
+			      (XPointer)&weed_args)) {
+		handler(display, &e, arg);
+	}
+	_fev_pred_weed_if_finish(&weed_args);
+
+	return weed_args.count;
+}
+
 int FWeedIfWindowEvents(
 	Display *display, Window window,
 	int (*weed_predicate) (

--- a/libs/FEvent.h
+++ b/libs/FEvent.h
@@ -114,6 +114,14 @@ int FWeedIfEvents(
 		Display *display, XEvent *current_event, XPointer arg),
 	XPointer arg);
 
+/* Same as FWeedIfEvents but with a second callback out of XLockDisplay()
+ * to handle events in a lock-safe manner */
+int FWeedAndHandleIfEvents(
+	Display *display,
+	int (*weed_predicate) (Display *display, XEvent *event, XPointer arg),
+	int (*handler) (Display *display, XEvent *event, XPointer arg),
+	XPointer arg);
+
 /* Same as FWeedIfEvents but weeds only events for the given window.  The
  * weed_predicate is only called for events with a matching window.  */
 int FWeedIfWindowEvents(


### PR DESCRIPTION
XCheckIfEvent() holds the X display lock and the predicate
function it calls is not allowed to call any Xlib function that
would re-enter the lock.
libX11 1.8.1 enables X display locks unconditionnaly (it was only
enabled by XInitThreads() when called explicitely before) and
thus exposes the issue.

So don't process events in the FCheckPeekIfEvent() predicate, but
instead use a separate handler that is called for the returned event
out of the lock.

* **What does this PR do?**

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
