### PR TITLE
menuitem: set selectable when not a separator

### DIFF
--- a/fvwm/menuitem.c
+++ b/fvwm/menuitem.c
@@ -461,7 +461,8 @@ void menuitem_paint(
 	}
 	else
 	{
-		MI_IS_SELECTABLE(mi) = True;
+		if (!MI_IS_SEPARATOR(mi))
+			MI_IS_SELECTABLE(mi) = True;
 		gcs = ST_MENU_INACTIVE_GCS(ms);
 		off_gcs = ST_MENU_INACTIVE_GCS(ms);
 	}


### PR DESCRIPTION
When setting whether a painted menu item is selectable or not, ensure
this does not happen for separators, as they can gain focus without this
check, but doing so is not helpful.

Fixes #675
