### PR TITLE
update_fvwm_monitor: cosmetic change

### DIFF
--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -667,18 +667,18 @@ Bool update_fvwm_monitor(FvwmWindow *fw)
 	rectangle g;
 	struct monitor *mnew;
 
-	get_unshaded_geometry((fw), &g);
+	get_unshaded_geometry(fw, &g);
 	mnew = FindScreenOfXY(g.x, g.y);
 
 	/* Avoid unnecessary updates. */
-	if (mnew == (fw)->m)
+	if (mnew == fw->m)
 		return False;
-	(fw)->m_prev = (fw)->m;
-	(fw)->m = mnew;
-	(fw)->Desk = mnew->virtual_scr.CurrentDesk;
-	EWMH_SetCurrentDesktop((fw)->m);
-	desk_add_fw((fw));
-	BroadcastConfig(M_CONFIGURE_WINDOW, (fw));
+	fw->m_prev = fw->m;
+	fw->m = mnew;
+	fw->Desk = mnew->virtual_scr.CurrentDesk;
+	EWMH_SetCurrentDesktop(fw->m);
+	desk_add_fw(fw);
+	BroadcastConfig(M_CONFIGURE_WINDOW, fw);
 
 	return True;
 }


### PR DESCRIPTION
update_fvwm_monitor() used to be a macro, and as such, when that was
converted to update_fvwm_monitor(), some macro-specific styles remained.

This change cleans those up, there aren't any functional changes.
