### PR TITLE
GotoDesk: avoid over-eager matching

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1404,6 +1404,11 @@ static void move_viewport_delta(
 	{
 		TAILQ_FOREACH(mloop, &monitor_q, entry)
 		{
+			if (is_tracking_shared) {
+			    if ((!m->virtual_scr.is_swapping ||
+			        !mloop->virtual_scr.is_swapping) && mloop != m)
+					continue;
+			}
 			BroadcastPacket(
 				M_NEW_PAGE, 8,
 				(long)mloop->virtual_scr.Vx,

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1713,19 +1713,27 @@ void goto_desk(int desk, struct monitor *m)
 			    has_run_globally)
 				break;
 
+			if (is_tracking_shared && m == m2) {
+			    BroadcastPacket(M_NEW_DESK, 2,
+				(long)m2->virtual_scr.CurrentDesk,
+				(long)m2->si->rr_output);
+
+				goto done;
+			}
+
 			/* If we're swapping a desktop between monitors for
 			 * shared mode, only do this when the is_swapping flag
 			 * is true, otherwise events would be raised for a
 			 * new_desk for monitors/desks which have not changed.
 			 */
 			if (is_tracking_shared) {
-				if (!m->virtual_scr.is_swapping ||
-				    !m2->virtual_scr.is_swapping) {
+			    if ((!m->virtual_scr.is_swapping ||
+			        !m2->virtual_scr.is_swapping) && m2 != m)
 					continue;
-				}
-				BroadcastPacket(M_NEW_DESK, 2,
-				    (long)m2->virtual_scr.CurrentDesk,
-				    (long)m2->si->rr_output);
+
+			    BroadcastPacket(M_NEW_DESK, 2,
+				(long)m2->virtual_scr.CurrentDesk,
+				(long)m2->si->rr_output);
 
 				goto done;
 			}

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1662,6 +1662,8 @@ done:
 void goto_desk(int desk, struct monitor *m)
 {
 	struct monitor	*m2 = NULL;
+	bool has_run_globally = false;
+
 	/* RBW - the unmapping operations are now removed to their own
 	 * functions so they can also be used by the new GoToDeskAndPage
 	 * command. */
@@ -1706,23 +1708,45 @@ void goto_desk(int desk, struct monitor *m)
 		}
 
 		TAILQ_FOREACH(m2, &monitor_q, entry) {
+			/* In global mode, only do this once. */
+			if (monitor_mode == MONITOR_TRACKING_G &&
+			    has_run_globally)
+				break;
+
 			/* If we're swapping a desktop between monitors for
 			 * shared mode, only do this when the is_swapping flag
 			 * is true, otherwise events would be raised for a
 			 * new_desk for monitors/desks which have not changed.
 			 */
-			if (m != m2 && !m2->virtual_scr.is_swapping)
-				continue;
+			if (is_tracking_shared) {
+				if (!m->virtual_scr.is_swapping ||
+				    !m2->virtual_scr.is_swapping) {
+					continue;
+				}
+				BroadcastPacket(M_NEW_DESK, 2,
+				    (long)m2->virtual_scr.CurrentDesk,
+				    (long)m2->si->rr_output);
+
+				goto done;
+			}
 			if (m != m2) {
 				m2->Desktops = m->Desktops;
 				if (!is_tracking_shared) {
 					m2->virtual_scr.CurrentDesk =
 						m->virtual_scr.CurrentDesk;
 				}
-			}
 
-			BroadcastPacket(M_NEW_DESK, 2, (long)m2->virtual_scr.CurrentDesk,
+				BroadcastPacket(M_NEW_DESK, 2,
+					(long)m2->virtual_scr.CurrentDesk,
 					(long)m2->si->rr_output);
+
+				if (monitor_mode == MONITOR_TRACKING_G &&
+				    !has_run_globally) {
+					has_run_globally = true;
+					goto done;
+				}
+			}
+done:
 
 			/* FIXME: domivogt (22-Apr-2000): Fake a 'restack' for sticky
 			 * window upon desk change.  This is a workaround for a
@@ -2594,6 +2618,13 @@ void CMD_GotoDeskAndPage(F_CMD_ARGS)
 		goto_desk(m->virtual_scr.CurrentDesk, m);
 		focus_grab_buttons_all();
 
+		/* If we're sharing desks between monitors, don't send further
+		 * NEW_DESK packets, as we've already handled this in the call
+		 * to goto_desk above.
+		 */
+		if (is_tracking_shared)
+			goto done;
+
 		BroadcastPacket(M_NEW_DESK, 2, (long)m->virtual_scr.CurrentDesk,
 			(long)m->si->rr_output);
 		/* FIXME: domivogt (22-Apr-2000): Fake a 'restack' for sticky
@@ -2612,6 +2643,7 @@ void CMD_GotoDeskAndPage(F_CMD_ARGS)
 		BroadcastPacket(M_NEW_DESK, 2, (long)m->virtual_scr.CurrentDesk,
 				(long)m->si->rr_output);
 	}
+done:
 	BroadcastMonitorList(NULL);
 	EWMH_SetCurrentDesktop(m);
 


### PR DESCRIPTION
When looping round GotoDesk and associated commands (GotoDeskAndPage,
etc.), ensure the matching for which desk and monitor to apply the
request to, doesn't loop on the same value, essentially causing multiple
requests happen.

In the case of DesktopConfiguration shared/global, this would happen per
monitor when it shouldn't.

Fixes #655
