### PR TITLE
Add AnyScreen to conditional in IconManClick

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -133,7 +133,7 @@ AddToFunc   SetBG
 # This function is run from FvwmIconMan when the button is clicked.
 DestroyFunc IconManClick
 AddToFunc   IconManClick
-+ I ThisWindow (Raised, !Shaded, !Iconic, CurrentPage) Iconify
++ I ThisWindow (Raised, !Shaded, !Iconic, CurrentPage, AnyScreen) Iconify
 + I TestRc (Match) Break
 + I ThisWindow WindowShade off
 + I ThisWindow Iconify off


### PR DESCRIPTION
  Adds the AnyScreen conditional to IconManClick so windows
  on the current page but a secondary monitor are correctly
  raised/iconfied by using IconMan in the RightPanel.

Fixing an small annoyance I when using the default-config.