### PR TITLE
expand: add monitor.prev variable

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -1596,7 +1596,7 @@ $[pointer.screen]::
 +
 This is deprecated; use $[monitor.current] instead.
 
-$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width], $[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.current], $[monitor.output], $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
+$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width], $[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.current], $[monitor.prev] $[monitor.output], $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
 	Returns information about the selected monitor. These can be nested, for
 	example: $[monitor.$[monitor.primary].width]
 +
@@ -1608,6 +1608,9 @@ returns the monitor's height (in pixels)
 +
 "current" is the same as the deprecated $[screen.pointer] variable; the
 monitor which has the mouse pointer.
++
+"prev" returns the previously focused monitor, or the empty string if there
+isn't one.
 +
 "count" returns the number of active monitors.
 +

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2579,9 +2579,11 @@ void HandleFocusIn(const evh_args_t *ea)
 			EWMH_SetActiveWindow(focus_w);
 
 			struct monitor *pfm;
-			pfm = monitor_resolve_name( prev_focused_monitor);
+			pfm = monitor_resolve_name(prev_focused_monitor);
 
 			if (fw != NULL && fw->m != pfm) {
+				pfm->is_prev = true;
+				fw->m->is_prev = false;
 				BroadcastName(MX_MONITOR_FOCUS, -1, -1, -1,
 				    fw->m->si->name /* Name of the monitor. */
 			        );

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -524,6 +524,15 @@ static signed int expand_vars_extended(
 			goto GOT_STRING;
 		}
 
+		if (strcmp(rest, "prev") == 0) {
+			struct monitor *m2 = monitor_get_prev();
+
+			should_quote = False;
+			string = (m2 != NULL) ? m2->si->name : "";
+
+			goto GOT_STRING;
+		}
+
 		/* We could be left with "<NAME>.?" */
 		char		*m_name = NULL;
 		struct monitor  *mon2;

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -164,6 +164,22 @@ monitor_get_global(void)
 }
 
 struct monitor *
+monitor_get_prev(void)
+{
+	struct monitor	*m, *mret = NULL;
+
+	TAILQ_FOREACH(m, &monitor_q, entry) {
+		if (m->is_prev) {
+			mret = m;
+			break;
+		}
+	}
+
+	/* Can be NULL -- is checked in expand.c */
+	return (mret);
+}
+
+struct monitor *
 monitor_get_current(void)
 {
 	int		 JunkX = 0, JunkY = 0, x, y;

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -82,6 +82,7 @@ struct monitor {
 	int			 flags;
 	int			 emit;
 	int			 dx, dy;
+	bool			 is_prev;
 
 	/* info for some desktops; the first entries should be generic info
          * correct for any desktop not in the list
@@ -147,6 +148,7 @@ struct monitor	*monitor_by_xy(int, int);
 struct monitor  *monitor_by_output(int);
 struct monitor  *monitor_by_primary(void);
 struct monitor  *monitor_get_current(void);
+struct monitor  *monitor_get_prev(void);
 struct monitor  *monitor_get_global(void);
 void		 monitor_init_contents(struct monitor *);
 void		 monitor_dump_state(struct monitor *);


### PR DESCRIPTION
Add a new monitor variable -- $[monitor.prev] which prints the previously focused monitor.

This is tracked via focus based on windows -- so if no window on a particular monitor has ever been focused, even if the pointer has moved to its root window, there will be no such value associated with $[monitor.prev]'s expansion.

If $[monitor.prev] does not contain a monitor, the empty string is printed in its place.