### PR TITLE
doc: don't build FvwmConsole.1 if FvwmPrompt enabled

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,5 @@
 docdir = @FVWM_DOCDIR@
-MODULE_ADOC = \
+MODULE_ADOC_SRCS = \
 	fvwm3.adoc \
 	fvwm3all.adoc \
 	fvwm3commands.adoc \
@@ -7,6 +7,14 @@ MODULE_ADOC = \
 	fvwm3styles.adoc \
 	$(wildcard Fvwm*.adoc) \
 	$(wildcard fvwm-*.adoc)
+
+# If building FvwmPrompt, don't generate the manpage for FvwmConsole as that
+# won't ever be installed.
+if FVWM_BUILD_GOLANG
+MODULE_ADOC = $(filter-out FvwmConsole.adoc, $(MODULE_ADOC_SRCS))
+else
+MODULE_ADOC = $(MODULE_ADOC_SRCS)
+endif
 
 EXTRA_DIST = $(MODULE_ADOC)
 


### PR DESCRIPTION
When generating the documentation, don't build FvwmConsole's manpage, as
FvwmConsole is disabled in lieu of using FvwmPrompt.

Fixes #597
