### PR TITLE
FvwmEvent: handle previous_monitor and no longer passthrough ID 

### DIFF
--- a/doc/FvwmEvent.adoc
+++ b/doc/FvwmEvent.adoc
@@ -170,17 +170,7 @@ needed.
 The monitor_* events do not operate in a window context (as there isn't
 one), but react to when a monitor is plugged in (enabled), unplugged
 (disabled), focused (focus) or changed (resized/rotated, etc., which
-will only be true if the monitor is already active). In all cases, the
-monitor name is is passed through to the command, hence the following
-example prints out the changed monitor's name, and width/height values:
-+
-....
-	DestroyFunc MonitorExample
-	AddToFunc   MonitorExample
-	+ I Echo "Monitor $0 changed ($[monitor.$0.width] x $[monitor.$0.height])
-
-	*FvwmEvent: monitor_changed MonitorExample
-....
+will only be true if the monitor is already active).
 +
 The echo event is generated whenever Fvwm receives an Echo command.
 +

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -167,8 +167,11 @@ struct monitor *
 monitor_get_prev(void)
 {
 	struct monitor	*m, *mret = NULL;
+	struct monitor  *this = monitor_get_current();
 
 	TAILQ_FOREACH(m, &monitor_q, entry) {
+		if (m == this)
+			continue;
 		if (m->is_prev) {
 			mret = m;
 			break;
@@ -537,6 +540,7 @@ void FScreenInit(Display *dpy)
 		m->Desktops->next = NULL;
 		m->Desktops->desk = 0;
 		m->flags |= (MONITOR_NEW|MONITOR_ENABLED);
+		m->is_prev = false;
 		monitor_scan_edges(m);
 	}
 
@@ -572,6 +576,7 @@ monitor_dump_state(struct monitor *m)
 			"\tDisabled:\t%s\n"
 			"\tIs Primary:\t%s\n"
 			"\tIs Current:\t%s\n"
+			"\tIs Previous:\t%s\n"
 			"\tOutput:\t%d\n"
 			"\tCoords:\t{x: %d, y: %d, w: %d, h: %d}\n"
 			"\tVirtScr: {\n"
@@ -586,6 +591,7 @@ monitor_dump_state(struct monitor *m)
 			(m2->flags & MONITOR_DISABLED) ? "true" : "false",
 			(m2->flags & MONITOR_PRIMARY) ? "yes" : "no",
 			(mcur && m2 == mcur) ? "yes" : "no",
+			m2->is_prev ? "yes" : "no",
 			(int)m2->si->rr_output,
 			m2->si->x, m2->si->y, m2->si->w, m2->si->h,
 			m2->virtual_scr.VxMax, m2->virtual_scr.VyMax,

--- a/modules/FvwmEvent/FvwmEvent.c
+++ b/modules/FvwmEvent/FvwmEvent.c
@@ -95,7 +95,6 @@ static Bool audio_compat = False;
 static char *audio_play_dir = NULL;
 
 #define ARG_NO_WINID 1024  /* just a large number */
-#define ARG_EXPECTS_CHAR 1025
 
 #define EVENT_ENTRY(name,action_arg) { name, action_arg, {NULL} }
 static event_entry message_event_table[] =
@@ -139,11 +138,11 @@ static event_entry extended_message_event_table[] =
 	EVENT_ENTRY( "enter_window", 0 ),
 	EVENT_ENTRY( "leave_window", 0 ),
 	EVENT_ENTRY( "property_change", 0),
-	EVENT_ENTRY( "monitor_enabled", 0 | ARG_EXPECTS_CHAR),
-	EVENT_ENTRY( "monitor_disabled", 0 | ARG_EXPECTS_CHAR),
-	EVENT_ENTRY( "monitor_changed", 0 | ARG_EXPECTS_CHAR),
-	EVENT_ENTRY( "monitor_focus", 0 | ARG_EXPECTS_CHAR),
-	EVENT_ENTRY( "echo", 0 | ARG_EXPECTS_CHAR),
+	EVENT_ENTRY( "monitor_enabled", 0 | ARG_NO_WINID),
+	EVENT_ENTRY( "monitor_disabled", 0 | ARG_NO_WINID),
+	EVENT_ENTRY( "monitor_changed", 0 | ARG_NO_WINID),
+	EVENT_ENTRY( "monitor_focus", 0 | ARG_NO_WINID),
+	EVENT_ENTRY( "echo", 0),
 	EVENT_ENTRY( "reply", 0), /* FvwmEvent will never receive MX_REPLY */
 	EVENT_ENTRY(NULL,0)
 };
@@ -468,11 +467,6 @@ void execute_event(event_entry *event_table, short event, unsigned long *body)
 					sprintf(buf, "%s %s 0x%lx", cmd_line,
 						action,	body[action_arg]);
 				}
-			}
-			/* monitor_* events. */
-			else if (action_arg != -1 && (action_arg & ARG_EXPECTS_CHAR)) {
-				sprintf(buf, "%s %s %s", cmd_line, action,
-						(char *)(&body[3]));
 			}
 			else
 			{


### PR DESCRIPTION
Currently, FvwmEvent tries to passthrough the monitor in use, but this will conflict with most internal Fvwm commands.

Don't do this.