### PR TITLE
MapRequest: don't fake map/unmap events

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -3221,8 +3221,23 @@ void HandleMapRequestKeepRaised(
 				 * remember exactly why this is necessary, but
 				 * probably something w/ (de)iconify state
 				 * confusion. */
-				fake_map_unmap_notify(fw, MapNotify);
-				fake_map_unmap_notify(fw, UnmapNotify);
+				if (Restarting &&
+				    win_opts->initial_state == IconicState ) {
+					/* TA: 2022-09-21 -- putting this
+					 * inside a restart check and *only*
+					 * doing this for iconified windows
+					 * stops non-iconified windows on
+					 * recapture from being iconified.
+					 */
+					fvwm_debug(__func__,
+					    "Window 0x%x is new "
+					    "and is being recaptured and in an "
+					    "iconic state. Sending fake map/unmap",
+					    (int)FW_W(fw));
+					fake_map_unmap_notify(fw, MapNotify);
+					fake_map_unmap_notify(fw, UnmapNotify);
+				}
+
 			}
 			if (win_opts->flags.is_iconified_by_parent ||
 			    ((tmp = get_transientfor_fvwmwindow(fw)) &&


### PR DESCRIPTION
When recapturing windows on restart -- and presumably via restoration of
the window flags written out to the state file -- some clients would end
up in an iconified state, despite having never been in an iconified
state.

It seems to happen intermittently, and can be difficult to reproduce --
but putting fvwm3 on a restart loop can cause this.  It's unlikely to be
a race-condition, despite the symptoms manifesting that way.

Instead, don't fake map/unmap events, and let the client continue to do
whatever it would have done.
