### PR TITLE
Don't build doc/fvwm3_manpage_source.adoc

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,7 +3,6 @@ MODULE_ADOC_SRCS = \
 	fvwm3.adoc \
 	fvwm3all.adoc \
 	fvwm3commands.adoc \
-	fvwm3_manpage_source.adoc \
 	fvwm3menus.adoc \
 	fvwm3styles.adoc \
 	$(wildcard Fvwm*.adoc) \


### PR DESCRIPTION
This file is used as the source for doc/fvwm3.adoc and doc/fvwm3all.adoc, but isn't a standalone manpage. Don't build and install it.