### PR TITLE
Fix background resetting in default-config

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -76,12 +76,17 @@ DesktopConfiguration global
 # actions that are run after a restart.
 DestroyFunc StartFunction
 AddToFunc   StartFunction
-+ I Test (Init, f $[FVWM_USERDIR]/.BGdefault) \
++ I Test (Init) InitBackground
++ I Module FvwmButtons RightPanel
++ I Module FvwmEvent EventNewDesk
+
+# Function to set background when fvwm starts
+DestroyFunc InitBackground
+AddToFunc InitBackground
++ I Test (f $[FVWM_USERDIR]/.BGdefault) \
     Exec exec fvwm-root $[FVWM_USERDIR]/.BGdefault
 + I TestRc (NoMatch) Exec exec fvwm-root \
     $[FVWM_DATADIR]/default-config/images/background/bg1.png
-+ I Module FvwmButtons RightPanel
-+ I Module FvwmEvent EventNewDesk
 
 # Mouse Bindings Functions
 DestroyFunc RaiseMoveX


### PR DESCRIPTION
The default-config sets the background when starting by testing for `Init` and the existence of a file in `FVWM_USERDIR`. If this file doesn't exist it falls back to to using an image in the default-config. The logic was incorrect and the image would also revert on a `Restart`. This pushes the logic into another function so a restart wont change the background.