### PR TITLE
desk_add: fix window counting

### DIFF
--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -2436,6 +2436,8 @@ Bool setup_window_placement(
 		__explain_placement(fw, &reason);
 	}
 
+	desk_add_fw(fw);
+
 	return (rc == 0) ? False : True;
 }
 

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -49,6 +49,7 @@
 #include "icons.h"
 #include "stack.h"
 #include "functions.h"
+#include "builtins.h"
 
 /* ---------------------------- local definitions -------------------------- */
 
@@ -2985,6 +2986,9 @@ desk_add_fw(FvwmWindow *fw)
 			dfws = fxcalloc(1, sizeof *dfws);
 			dfws->fw = fw;
 			TAILQ_INSERT_TAIL(&df_loop->desk_fvwmwin_q, dfws, entry);
+
+			status_send();
+
 			return;
 		}
 	}
@@ -2997,6 +3001,8 @@ desk_add_fw(FvwmWindow *fw)
 
 	TAILQ_INSERT_TAIL(&df->desk_fvwmwin_q, dfws, entry);
 	TAILQ_INSERT_TAIL(&desktop_fvwm_q, df, entry);
+
+	status_send();
 }
 
 void
@@ -3010,6 +3016,7 @@ desk_del_fw(FvwmWindow *fw)
 			if (dfws->fw == fw) {
 				TAILQ_REMOVE(&df->desk_fvwmwin_q, dfws, entry);
 				free(dfws);
+				status_send();
 				break;
 			}
 		}

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -36,6 +36,7 @@
 #include "eventmask.h"
 #include "misc.h"
 #include "screen.h"
+#include "update.h"
 #include "virtual.h"
 #include "module_interface.h"
 #include "module_list.h"
@@ -1825,6 +1826,8 @@ void do_move_window_to_desk(FvwmWindow *fw, int desk)
 	focus_grab_buttons_on_layer(fw->layer);
 	EWMH_SetWMDesktop(fw);
 
+	desk_add_fw(fw);
+
 	return;
 }
 
@@ -2964,7 +2967,7 @@ desk_add_fw(FvwmWindow *fw)
 	if (fw == NULL)
 		return;
 
-	desk = fw->m->virtual_scr.CurrentDesk;
+	desk = fw->Desk;
 
 	if (TAILQ_EMPTY(&desktop_fvwm_q))
 		TAILQ_INIT(&desktop_fvwm_q);


### PR DESCRIPTION
When counting windows on desks, use the window's desk assignment, rather
than the screen's current desk.

This should fix window counting with SkipMapping.
