### PR TITLE
two clock_t and time_t casts for portability

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -285,9 +285,9 @@ static void EWMH_DLOG(char *msg, ...)
 		time_taken = time_val - prev_time;
 		prev_time = time_val;
 		sprintf(
-			buffer, "%.2d:%.2d:%.2d %6ld",
+			buffer, "%.2d:%.2d:%.2d %6lld",
 			t_ptr->tm_hour, t_ptr->tm_min, t_ptr->tm_sec,
-			time_taken);
+			(long long)time_taken);
 
 		fvwm_debug(__func__, "EWMH DEBUG: ");
 		va_start(args,msg);

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -669,7 +669,7 @@ static char *GetTime (int *NbArg,long *TabArg)
 
   str = fxcalloc(20, sizeof(char));
   t = time(NULL);
-  sprintf(str,"%ld",(long)t-x11base->BeginTime);
+  sprintf(str,"%lld",(long long)t-x11base->BeginTime);
   return str;
 }
 


### PR DESCRIPTION
cast one clock_t to long long for portability (on OpenBSD it is actually a `long long`) and fixes the casting of one time_t.  OpenBSD has 64bit time_t, but hopefully it's not the only OS.