### PR TITLE
changing sprintf -> snprintf & co

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1375,6 +1375,10 @@ AH_VERBATIM([_ZEND_EXPLICIT_DEFINITIONS],
 #define SUPPRESS_UNUSED_VAR_WARNING(x) \
 do { void *p; p = (void *)&x; (void)p; } while (0);
 
+#ifndef HAVE_STRLCAT
+#   include "libs/strlcat.h"
+#endif
+
 #ifndef HAVE_STRLCPY
 #   include "libs/strlcpy.h"
 #endif

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -391,7 +391,7 @@ static char *interpolate_titleformat_name(
 					break;
 				}
 
-				strcat(stringbuf, fw->name.name);
+				strlcat(stringbuf, fw->name.name, sizeof(stringbuf));
 				break;
 			case 'c':
 				if (strlen(stringbuf) +
@@ -404,7 +404,7 @@ static char *interpolate_titleformat_name(
 
 					break;
 				}
-				strcat(stringbuf, fw->class.res_class);
+				strlcat(stringbuf, fw->class.res_class, sizeof(stringbuf));
 				break;
 			case 'i':
 				/* format contains icon name */
@@ -427,7 +427,7 @@ static char *interpolate_titleformat_name(
 					break;
 				}
 
-				strcat(stringbuf, fw->icon_name.name);
+				strlcat(stringbuf, fw->icon_name.name, sizeof(stringbuf));
 				break;
 			case 'r':
 				if (strlen(stringbuf) +
@@ -440,7 +440,7 @@ static char *interpolate_titleformat_name(
 
 					break;
 				}
-				strcat(stringbuf, fw->class.res_name);
+				strlcat(stringbuf, fw->class.res_name, sizeof(stringbuf));
 				break;
 			case 't':
 				setup_name_count(fw, is_icon);
@@ -450,15 +450,15 @@ static char *interpolate_titleformat_name(
 				if (count > (MAX_WINDOW_NAME_NUMBER - 1))
 					count = MAX_WINDOW_NAME_NUMBER - 1;
 
-				sprintf(win_name_len, "%hu", ++count);
-				strcat(stringbuf, win_name_len);
+				snprintf(win_name_len, sizeof(win_name_len), "%hu", ++count);
+				strlcat(stringbuf, win_name_len, sizeof(stringbuf));
 				break;
 			case 'I':
-				sprintf(w_id, "0x%x", (int)FW_W(fw));
-				strcat(stringbuf, w_id);
+				snprintf(w_id, sizeof(w_id), "0x%x", (int)FW_W(fw));
+				strlcat(stringbuf, w_id, sizeof(stringbuf));
 				break;
 			case '%':
-				strcat(stringbuf, "%");
+				strlcat(stringbuf, "%", sizeof(stringbuf));
 				break;
 			default:
 				break;
@@ -2588,7 +2588,7 @@ FvwmWindow *AddWindow(
 			     EWMH_STATE_HAS_HINT) ? 100 : 0;
 			v = (HAS_EWMH_INIT_MAXVERT_STATE(fw) ==
 			     EWMH_STATE_HAS_HINT) ? 100 : 0;
-			sprintf(cmd,"Maximize on %i %i", h, v);
+			snprintf(cmd, sizeof(cmd), "Maximize on %i %i", h, v);
 			execute_function_override_window(
 				NULL, NULL, cmd, NULL, 0, fw);
 		}

--- a/fvwm/borders.c
+++ b/fvwm/borders.c
@@ -4994,7 +4994,6 @@ void CMD_BorderStyle(F_CMD_ARGS)
 	{
 		if (StrEquals(parm, "active") || StrEquals(parm, "inactive"))
 		{
-			int len;
 			char *end, *tmp;
 			DecorFace tmpdf, *df;
 
@@ -5046,11 +5045,7 @@ void CMD_BorderStyle(F_CMD_ARGS)
 					   parm);
 				return;
 			}
-			len = end - action + 1;
-			/* TA:  FIXME xasprintf */
-			tmp = fxmalloc(len);
-			strncpy(tmp, action, len - 1);
-			tmp[len - 1] = 0;
+			tmp = fxstrdup(action);
 			ReadDecorFace(tmp, df,-1,True);
 			free(tmp);
 			action = end + 1;

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -218,7 +218,7 @@ static void status_init_pipe(void)
 	if ((tmpdir = getenv("TMPDIR")) == NULL)
 		tmpdir = "/tmp";
 
-	asprintf(&pipename, "%s/%s", tmpdir, PIPENAME);
+	xasprintf(&pipename, "%s/%s", tmpdir, PIPENAME);
 
 	unlink(pipename);
 	if ((mkfifo(pipename, 0666) == -1)) {
@@ -2958,19 +2958,11 @@ void CMD_HilightColor(F_CMD_ARGS)
 	GetNextToken(action, &back);
 	if (fore && back)
 	{
-		/* TA:  FIXME:  xasprintf() */
-		action = fxmalloc(strlen(fore) + strlen(back) + 29);
-		sprintf(action, "* HilightFore %s, HilightBack %s", fore, back);
+		xasprintf(&action, "* HilightFore %s, HilightBack %s", fore, back);
 		CMD_Style(F_PASS_ARGS);
 	}
-	if (fore)
-	{
-		free(fore);
-	}
-	if (back)
-	{
-		free(back);
-	}
+	free(fore);
+	free(back);
 
 	return;
 }
@@ -2991,9 +2983,7 @@ void CMD_HilightColorset(F_CMD_ARGS)
 
 	if (action)
 	{
-		/* TA:  FIXME!  xasprintf() */
-		newaction = fxmalloc(strlen(action) + 32);
-		sprintf(newaction, "* HilightColorset %s", action);
+		xasprintf(&newaction, "* HilightColorset %s", action);
 		action = newaction;
 		CMD_Style(F_PASS_ARGS);
 		free(newaction);
@@ -3205,9 +3195,7 @@ void CMD_IconFont(F_CMD_ARGS)
 
 	if (action)
 	{
-		/* TA:  FIXME!  xasprintf() */
-		newaction = fxmalloc(strlen(action) + 16);
-		sprintf(newaction, "* IconFont %s", action);
+		xasprintf(&newaction, "* IconFont %s", action);
 		action = newaction;
 		CMD_Style(F_PASS_ARGS);
 		free(newaction);
@@ -3231,9 +3219,7 @@ void CMD_WindowFont(F_CMD_ARGS)
 
 	if (action)
 	{
-		/* TA;  FIXME!  xasprintf() */
-		newaction = fxmalloc(strlen(action) + 16);
-		sprintf(newaction, "* Font %s", action);
+		xasprintf(&newaction, "* Font %s", action);
 		action = newaction;
 		CMD_Style(F_PASS_ARGS);
 		free(newaction);
@@ -3502,8 +3488,7 @@ void CMD_SetEnv(F_CMD_ARGS)
 	{
 		szValue = fxstrdup("");
 	}
-	szPutenv = fxmalloc(strlen(szVar) + strlen(szValue) + 2);
-	sprintf(szPutenv,"%s=%s", szVar, szValue);
+	xasprintf(&szPutenv, "%s=%s", szVar, szValue);
 	flib_putenv(szVar, szPutenv);
 	free(szVar);
 	free(szPutenv);

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -284,8 +284,7 @@ static void EWMH_DLOG(char *msg, ...)
 		time_val = (unsigned int)times(&not_used_tms);
 		time_taken = time_val - prev_time;
 		prev_time = time_val;
-		sprintf(
-			buffer, "%.2d:%.2d:%.2d %6lld",
+		snprintf(buffer, sizeof(buffer), "%.2d:%.2d:%.2d %6lld",
 			t_ptr->tm_hour, t_ptr->tm_min, t_ptr->tm_sec,
 			(long long)time_taken);
 
@@ -2059,8 +2058,8 @@ void EWMH_fullscreen(FvwmWindow *fw)
 		&scr_g.width, &scr_g.height);
 	get_window_borders(fw, &b);
 	get_page_offset_check_visible(&page_x, &page_y, fw);
-	sprintf(
-		cmd, "ResizeMoveMaximize %dp %dp +%dp +%dp ewmhiwa",
+	snprintf(cmd, sizeof(cmd),
+		"ResizeMoveMaximize %dp %dp +%dp +%dp ewmhiwa",
 		scr_g.width, scr_g.height,
 		scr_g.x - b.top_left.width + page_x,
 		scr_g.y - b.top_left.height + page_y);

--- a/fvwm/ewmh_events.c
+++ b/fvwm/ewmh_events.c
@@ -92,7 +92,7 @@ int ewmh_DesktopGeometry(
 
 		return -1;
 	}
-	sprintf(action, "DesktopSize %ld %ld", width, height);
+	snprintf(action, sizeof(action), "DesktopSize %ld %ld", width, height);
 	execute_function_override_window(NULL, NULL, action, NULL, 0, NULL);
 
 	return -1;
@@ -449,7 +449,7 @@ int ewmh_MoveResize(
 
 	if (!move)
 	{
-		sprintf(cmd, "WarpToWindow %i %i",x_warp,y_warp);
+		snprintf(cmd, sizeof(cmd), "WarpToWindow %i %i",x_warp,y_warp);
 		execute_function_override_window(NULL, NULL, cmd, NULL, 0, fw);
 	}
 
@@ -547,7 +547,7 @@ int ewmh_WMState(
 
 		if (maximize & EWMH_MAXIMIZE_REMOVE)
 		{
-			sprintf(cmd,"Maximize off");
+			strlcpy(cmd, "Maximize off", sizeof(cmd));
 		}
 		else
 		{
@@ -557,7 +557,7 @@ int ewmh_WMState(
 			{
 				return 0;
 			}
-			sprintf(cmd,"Maximize on %i %i", max_horiz, max_vert);
+			snprintf(cmd, sizeof(cmd), "Maximize on %i %i", max_horiz, max_vert);
 		}
 		execute_function_override_window(NULL, NULL, cmd, NULL, 0, fw);
 	}
@@ -714,12 +714,12 @@ int ewmh_WMStateHidden(
 			{
 				return 0;
 			}
-			sprintf(cmd, "Iconify on");
+			strlcpy(cmd, "Iconify on", sizeof(cmd));
 		}
 		else
 		{
 			/* deiconify */
-			sprintf(cmd, "Iconify off");
+			strlcpy(cmd, "Iconify off", sizeof(cmd));
 		}
 		execute_function_override_window(NULL, NULL, cmd, NULL, 0, fw);
 	}

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -492,9 +492,7 @@ static signed int expand_vars_extended(
 		if (string == NULL)
 		{
 			const char *ddn = _("Desk");
-			/* TA:  FIXME!  xasprintf() */
-			allocated_string = fxmalloc(19 + strlen(ddn));
-			sprintf(allocated_string, "%s %i", ddn, cs);
+			xasprintf(&allocated_string, "%s %i", ddn, cs);
 			string = allocated_string;
 		}
 		goto GOT_STRING;

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -501,7 +501,6 @@ char *get_display_name(char *disp_name, int screen_num)
 	char *msg;
 	char *new_dn;
 	char *cp;
-	char string_screen_num[32];
 
 	CopyString(&msg, disp_name);
 	cp = strchr(msg, ':');
@@ -514,12 +513,7 @@ char *get_display_name(char *disp_name, int screen_num)
 			*cp = '\0';
 		}
 	}
-	sprintf(string_screen_num, ".%d", screen_num);
-	/* TA:  FIXME!  Use asprintF() */
-	new_dn = fxmalloc(strlen(msg) + strlen(string_screen_num) + 1);
-	*new_dn = '\0';
-	strcat(new_dn, msg);
-	strcat(new_dn, string_screen_num);
+	xasprintf(&new_dn, "%s.%d", msg, screen_num);
 	free(msg);
 
 	return new_dn;
@@ -1236,13 +1230,13 @@ static void setVersionInfo(void)
 	char version_str[256];
 	char license_str[512];
 	char support_str[512] = "";
-	int support_len;
+	size_t support_len;
 
 	/* Set version information string */
-	sprintf(version_str, "fvwm3 %s (%s)", VERSION, VERSIONINFO);
+	snprintf(version_str, sizeof(version_str), "fvwm3 %s (%s)", VERSION, VERSIONINFO);
 	Fvwm_VersionInfo = fxstrdup(version_str);
 
-	sprintf(license_str,
+	snprintf(license_str, sizeof(license_str),
 		"fvwm3 comes with NO WARRANTY, to the extent permitted by law. "
 		"You may\nredistribute copies of fvwm under "
 		"the terms of the GNU General Public License.\n"
@@ -1251,40 +1245,40 @@ static void setVersionInfo(void)
 	Fvwm_LicenseInfo = fxstrdup(license_str);
 
 #ifdef HAVE_READLINE
-	strcat(support_str, " ReadLine,");
+	strlcat(support_str, " ReadLine,", sizeof(support_str));
 #endif
 #ifdef XPM
-	strcat(support_str, " XPM,");
+	strlcat(support_str, " XPM,", sizeof(support_str));
 #endif
 #if PngSupport
-	strcat(support_str, " PNG,");
+	strlcat(support_str, " PNG,", sizeof(support_str));
 #endif
 #ifdef HAVE_RSVG
-	strcat(support_str, " SVG,");
+	strlcat(support_str, " SVG,", sizeof(support_str));
 #endif
 	if (FHaveShapeExtension)
-		strcat(support_str, " Shape,");
+		strlcat(support_str, " Shape,", sizeof(support_str));
 #ifdef HAVE_XSHM
-	strcat(support_str, " XShm,");
+	strlcat(support_str, " XShm,", sizeof(support_str));
 #endif
 #ifdef SESSION
-	strcat(support_str, " SM,");
+	strlcat(support_str, " SM,", sizeof(support_str));
 #endif
 #ifdef HAVE_BIDI
-	strcat(support_str, " Bidi text,");
+	strlcat(support_str, " Bidi text,", sizeof(support_str));
 #endif
-	strcat(support_str, " XRandR,");
+	strlcat(support_str, " XRandR,", sizeof(support_str));
 #ifdef HAVE_XRENDER
-	strcat(support_str, " XRender,");
+	strlcat(support_str, " XRender,", sizeof(support_str));
 #endif
 #ifdef HAVE_XCURSOR
-	strcat(support_str, " XCursor,");
+	strlcat(support_str, " XCursor,", sizeof(support_str));
 #endif
 #ifdef HAVE_XFT
-	strcat(support_str, " XFT,");
+	strlcat(support_str, " XFT,", sizeof(support_str));
 #endif
 #ifdef HAVE_NLS
-	strcat(support_str, " NLS,");
+	strlcat(support_str, " NLS,", sizeof(support_str));
 #endif
 
 	support_len = strlen(support_str);

--- a/fvwm/icccm2.c
+++ b/fvwm/icccm2.c
@@ -54,7 +54,7 @@ SetupICCCM2(Bool replace_wm)
 	XClientMessageEvent ev;
 	char wm_sx[25];
 
-	sprintf(wm_sx, "WM_S%lu", Scr.screen);
+	snprintf(wm_sx, sizeof(wm_sx), "WM_S%lu", Scr.screen);
 	_XA_WM_SX =     XInternAtom(dpy, wm_sx, False);
 	_XA_MANAGER =   XInternAtom(dpy, "MANAGER", False);
 	_XA_ATOM_PAIR = XInternAtom(dpy, "ATOM_PAIR", False);

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -5627,8 +5627,7 @@ static void menu_tear_off(MenuRoot *mr_to_copy)
 	}
 	mr = clone_menu(mr_to_copy);
 	/* also dump the menu style */
-	buffer = fxmalloc(23);
-	sprintf(buffer,"%lu",(unsigned long)mr);
+	xasprintf(&buffer, "%lu", (unsigned long)mr);
 	action = buffer;
 	ms = menustyle_parse_style(F_PASS_ARGS);
 	if (!ms)

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -329,6 +329,7 @@ static MenuStyle *menustyle_parse_old_style(F_CMD_ARGS)
 	char *buffer, *rest;
 	char *fore, *back, *stipple, *font, *style, *animated;
 	MenuStyle *ms = NULL;
+	size_t len;
 
 	rest = GetNextToken(action,&fore);
 	rest = GetNextToken(rest,&back);
@@ -344,8 +345,9 @@ static MenuStyle *menustyle_parse_old_style(F_CMD_ARGS)
 	}
 	else
 	{
-		buffer = (char *)alloca(strlen(action) + 100);
-		sprintf(buffer,
+		len = strlen(action) + 100;
+		buffer = alloca(len);
+		snprintf(buffer, len,
 			"* \"%s\", Foreground \"%s\", Background \"%s\", "
 			"Greyed \"%s\", Font \"%s\", \"%s\"",
 			style, fore, back, stipple, font,
@@ -1905,9 +1907,7 @@ void CMD_CopyMenuStyle(F_CMD_ARGS)
 	if (!destms)
 	{
 		/* create destms menu style */
-		/* TA:  FIXME!  xasprintf() */
-		buffer = fxmalloc(strlen(destname) + 3);
-		sprintf(buffer,"\"%s\"",destname);
+		xasprintf(&buffer, "\"%s\"", destname);
 		action = buffer;
 		destms = menustyle_parse_style(F_PASS_ARGS);
 		free(buffer);

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -284,9 +284,7 @@ static void send_desktop_names(fmodule *module)
 	{
 		if (d->name != NULL)
 		{
-			/* TA:  FIXME!  xasprintf() */
-			name = fxmalloc(strlen(d->name) + 44);
-			sprintf(name,"DesktopName %d %s", d->desk, d->name);
+			xasprintf(&name, "DesktopName %d %s", d->desk, d->name);
 			SendName(module, M_CONFIG_INFO, 0, 0, 0, name);
 			free(name);
 		}
@@ -300,7 +298,7 @@ static void send_desktop_geometry(fmodule *module)
 	char msg[64];
 	struct monitor	*m = monitor_get_current();
 
-	sprintf(msg, "DesktopSize %d %d\n",
+	snprintf(msg, sizeof(msg), "DesktopSize %d %d\n",
 		m->virtual_scr.VxMax / monitor_get_all_widths() + 1,
 		m->virtual_scr.VyMax / monitor_get_all_heights() + 1);
 	SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
@@ -315,9 +313,7 @@ static void send_image_path(fmodule *module)
 
 	if (ImagePath && *ImagePath != 0)
 	{
-		/* TA:  FIXME!  xasprintf() */
-		msg = fxmalloc(strlen(ImagePath) + 12);
-		sprintf(msg, "ImagePath %s\n", ImagePath);
+		xasprintf(&msg, "ImagePath %s\n", ImagePath);
 		SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
 		free(msg);
 	}
@@ -331,7 +327,8 @@ static void send_color_limit(fmodule *module)
 	{
 		char msg[64];
 
-		sprintf(msg, "ColorLimit %d\n", Scr.ColorLimit);
+		snprintf(msg, sizeof(msg),
+			"ColorLimit %d\n", Scr.ColorLimit);
 		SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
 	}
 
@@ -359,7 +356,7 @@ static void send_click_time(fmodule *module)
 
 	/* Dominik Vogt (8-Nov-1998): Scr.ClickTime patch to set ClickTime to
 	 * 'not at all' during InitFunction and RestartFunction. */
-	sprintf(msg,"ClickTime %d\n", (Scr.ClickTime < 0) ?
+	snprintf(msg, sizeof(msg), "ClickTime %d\n", (Scr.ClickTime < 0) ?
 		-Scr.ClickTime : Scr.ClickTime);
 	SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
 
@@ -370,7 +367,7 @@ static void send_move_threshold(fmodule *module)
 {
 	char msg[64];
 
-	sprintf(msg, "MoveThreshold %d\n", Scr.MoveThreshold);
+	snprintf(msg, sizeof(msg), "MoveThreshold %d\n", Scr.MoveThreshold);
 	SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
 
 	return;
@@ -380,7 +377,7 @@ void send_ignore_modifiers(fmodule *module)
 {
 	char msg[64];
 
-	sprintf(msg, "IgnoreModifiers %d\n", GetUnusedModifiers());
+	snprintf(msg, sizeof(msg), "IgnoreModifiers %d\n", GetUnusedModifiers());
 	SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
 
 	return;

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -670,7 +670,7 @@ void broadcast_ignore_modifiers(void)
 {
 	char msg[32];
 
-	sprintf(msg, "IgnoreModifiers %d", GetUnusedModifiers());
+	snprintf(msg, sizeof(msg), "IgnoreModifiers %d", GetUnusedModifiers());
 	BroadcastConfigInfoString(msg);
 
 	return;

--- a/fvwm/module_list.c
+++ b/fvwm/module_list.c
@@ -321,10 +321,10 @@ static fmodule *do_execute_module(
 
 	MOD_NAME(module) = stripcpy(cptr);
 	free(cptr);
-	sprintf(arg2, "%d", app_to_fvwm[1]);
-	sprintf(arg3, "%d", fvwm_to_app[0]);
-	sprintf(arg5, "%lx", (unsigned long)win);
-	sprintf(arg6, "%lx", (unsigned long)exc->w.wcontext);
+	snprintf(arg2, sizeof(arg2), "%d", app_to_fvwm[1]);
+	snprintf(arg3, sizeof(arg3), "%d", fvwm_to_app[0]);
+	snprintf(arg5, sizeof(arg5), "%lx", (unsigned long)win);
+	snprintf(arg6, sizeof(arg6), "%lx", (unsigned long)exc->w.wcontext);
 	args[0] = arg1;
 	args[1] = arg2;
 	args[2] = arg3;
@@ -416,11 +416,12 @@ static fmodule *do_execute_module(
 			char visualid[32];
 			char colormap[32];
 
-			sprintf(
-				visualid, "FVWM_VISUALID=%lx",
+			snprintf(visualid, sizeof(visualid),
+				"FVWM_VISUALID=%lx",
 				XVisualIDFromVisual(Pvisual));
 			flib_putenv("FVWM_VISUALID", visualid);
-			sprintf(colormap, "FVWM_COLORMAP=%lx", Pcmap);
+			snprintf(colormap, sizeof(colormap),
+				"FVWM_COLORMAP=%lx", Pcmap);
 			flib_putenv("FVWM_COLORMAP", colormap);
 		}
 		else

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -1258,7 +1258,7 @@ static void DisplayPosition(
 	fscr.xypos.y = p.y;
 	FScreenTranslateCoordinates(NULL, FSCREEN_GLOBAL, &fscr,
 			FSCREEN_XYPOS, &p.x, &p.y);
-	(void)sprintf(str, GEOMETRY_WINDOW_POS_STRING, p.x, p.y);
+	(void)snprintf(str, sizeof(str), GEOMETRY_WINDOW_POS_STRING, p.x, p.y);
 	display_string(Init, str);
 
 	return;
@@ -1298,7 +1298,7 @@ static void DisplaySize(
 	d.width /= tmp_win->hints.width_inc;
 	d.height /= tmp_win->hints.height_inc;
 
-	(void)sprintf(str, GEOMETRY_WINDOW_SIZE_STRING, d.width, d.height);
+	(void)snprintf(str, sizeof(str), GEOMETRY_WINDOW_SIZE_STRING, d.width, d.height);
 	display_string(Init, str);
 
 	return;
@@ -3332,13 +3332,8 @@ void CMD_HideGeometryWindow(F_CMD_ARGS)
 void CMD_SnapAttraction(F_CMD_ARGS)
 {
 	char *cmd;
-	size_t len;
 
-	/* TA:  FIXME  xasprintf() */
-	len = strlen(action);
-	len += 99;
-	cmd = fxmalloc(len);
-	sprintf(cmd, "Style * SnapAttraction %s", action);
+	xasprintf(&cmd, "Style * SnapAttraction %s", action);
 	fvwm_debug(__func__,
 		   "The command SnapAttraction is obsolete. Please use the"
 		   " following command instead:\n\n%s", cmd);
@@ -3351,13 +3346,8 @@ void CMD_SnapAttraction(F_CMD_ARGS)
 void CMD_SnapGrid(F_CMD_ARGS)
 {
 	char *cmd;
-	size_t len;
 
-	/* TA:  FIXME xasprintf() */
-	len = strlen(action);
-	len += 99;
-	cmd = fxmalloc(len);
-	sprintf(cmd, "Style * SnapGrid %s", action);
+	xasprintf(&cmd, "Style * SnapGrid %s", action);
 	fvwm_debug(__func__,
 		   "The command SnapGrid is obsolete. Please use the following"
 		   " command instead:\n\n%s", cmd);

--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -116,22 +116,6 @@ int sm_fd = -1;
 
 /* ---------------------------- local functions ---------------------------- */
 
-static
-char *duplicate(const char *s)
-{
-	int l;
-	char *r;
-
-	/* TA:  FIXME!  Use xasprintf() */
-
-	if (!s) return NULL;
-	l = strlen(s);
-	r = fxmalloc (sizeof(char)*(l+1));
-	strncpy(r, s, l+1);
-
-	return r;
-}
-
 static char *get_version_string(void)
 {
 	return (VERSION);
@@ -815,7 +799,7 @@ set_sm_properties(FSmcConn sm_conn, char *filename, char hint)
 	prop4val.value = (FSmPointer) &priority;
 	prop4val.length = 1;
 
-	sprintf(screen_num, "%d", (int)Scr.screen);
+	snprintf(screen_num, sizeof(screen_num), "%d", (int)Scr.screen);
 
 	prop5.name = FSmCloneCommand;
 	prop5.type = FSmLISTofARRAY8;
@@ -906,9 +890,9 @@ set_sm_properties(FSmcConn sm_conn, char *filename, char hint)
 			   should be LISTofARRAY8 on posix systems, but xsm
 			   demands that it be ARRAY8.
 			*/
-			char *discardCommand = alloca(
-				(10 + strlen(filename)) * sizeof(char));
-			sprintf (discardCommand, "rm -f '%s'", filename);
+			size_t len = 10 + strlen(filename);
+			char *discardCommand = alloca(len);
+			snprintf (discardCommand, len, "rm -f '%s'", filename);
 			prop7.type = FSmARRAY8;
 			prop7.num_vals = 1;
 			prop7.vals = &prop7val;
@@ -1463,7 +1447,7 @@ LoadWindowStates(char *filename)
 				s2++;
 			}
 			sscanf(s2, "%[^\n]", s1);
-			matches[num_match - 1].client_id = duplicate(s1);
+			matches[num_match - 1].client_id = fxstrdup(s1);
 		}
 		else if (!strcmp(s1, "[WINDOW_ROLE]"))
 		{
@@ -1473,7 +1457,7 @@ LoadWindowStates(char *filename)
 				s2++;
 			}
 			sscanf(s2, "%[^\n]", s1);
-			matches[num_match - 1].window_role = duplicate(s1);
+			matches[num_match - 1].window_role = fxstrdup(s1);
 		}
 		else if (!strcmp(s1, "[RES_NAME]"))
 		{
@@ -1483,7 +1467,7 @@ LoadWindowStates(char *filename)
 				s2++;
 			}
 			sscanf(s2, "%[^\n]", s1);
-			matches[num_match - 1].res_name = duplicate(s1);
+			matches[num_match - 1].res_name = fxstrdup(s1);
 		}
 		else if (!strcmp(s1, "[RES_CLASS]"))
 		{
@@ -1493,7 +1477,7 @@ LoadWindowStates(char *filename)
 				s2++;
 			}
 			sscanf(s2, "%[^\n]", s1);
-			matches[num_match - 1].res_class = duplicate(s1);
+			matches[num_match - 1].res_class = fxstrdup(s1);
 		}
 		else if (!strcmp(s1, "[WM_NAME]"))
 		{
@@ -1503,7 +1487,7 @@ LoadWindowStates(char *filename)
 				s2++;
 			}
 			sscanf(s2, "%[^\n]", s1);
-			matches[num_match - 1].wm_name = duplicate(s1);
+			matches[num_match - 1].wm_name = fxstrdup(s1);
 		}
 		else if (!strcmp(s1, "[WM_COMMAND]"))
 		{
@@ -1519,7 +1503,7 @@ LoadWindowStates(char *filename)
 				sscanf (s+pos, "%s%n", s1, &pos1);
 				pos += pos1;
 				matches[num_match - 1].wm_command[i] =
-					duplicate (s1);
+					fxstrdup(s1);
 			}
 		}
 	}

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -2124,10 +2124,7 @@ static Bool style_parse_one_style_option(
 		if (strncasecmp(token, prefix, l) != 0)
 		{
 			/* add missing prefix */
-			/* TA:  xasprintf() */
-			token_l = fxmalloc(l + strlen(token) + 1);
-			strcpy(token_l, prefix);
-			strcat(token_l, token);
+			xasprintf(&token_l, "%s%s", prefix, token);
 			token = token_l;
 		}
 	}

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2251,18 +2251,18 @@ void CMD_EdgeResistance(F_CMD_ARGS)
 		char stylecmd2[99];
 
 		Scr.ScrollDelay = val[0];
-		sprintf(cmd, "EdgeResistance %d", val[0]);
-		sprintf(stylecmd, "Style * EdgeMoveDelay %d", val[0]);
+		snprintf(cmd, sizeof(cmd), "EdgeResistance %d", val[0]);
+		snprintf(stylecmd, sizeof(stylecmd), "Style * EdgeMoveDelay %d", val[0]);
 		if (n == 2)
 		{
-			sprintf(
-				stylecmd2, "Style * EdgeMoveResistance %d",
+			snprintf(stylecmd2, sizeof(stylecmd2),
+				"Style * EdgeMoveResistance %d",
 				val[1]);
 		}
 		else
 		{
-			sprintf(
-				stylecmd2, "Style * EdgeMoveResistance %d %d",
+			snprintf(stylecmd2, sizeof(stylecmd2),
+				"Style * EdgeMoveResistance %d %d",
 				val[1], val[2]);
 		}
 		fvwm_debug(__func__,
@@ -3086,17 +3086,14 @@ apply_desktops_monitor(struct monitor *m)
 			/* should send the info to the FvwmPager and set the EWMH
 			 * desktop names */
 			{
-				asprintf(&msg, "DesktopName %d %s",
+				xasprintf(&msg, "DesktopName %d %s",
 					dc->desk, dc->name);
 			}
 #if 0
 			else
 			{
-				/* TA:  FIXME!  xasprintf() */
-				msg = fxmalloc(strlen(default_desk_name)+44);
-				sprintf(
-						msg, "DesktopName %d %s %d", desk,
-						default_desk_name, desk);
+				xasprintf(&msg, "DesktopName %d %s %d", desk,
+					default_desk_name, desk);
 			}
 #endif
 			BroadcastConfigInfoString(msg);

--- a/fvwm/windowlist.c
+++ b/fvwm/windowlist.c
@@ -77,35 +77,25 @@ static char *get_desk_title(int desk, unsigned long flags, Bool is_top_title)
 	struct monitor	*m = monitor_get_current();
 
 	desk_name = GetDesktopName(m, desk);
-	if (desk_name != NULL)
-	{
-		tlabel = fxmalloc(strlen(desk_name)+50);
-	}
-	else
-	{
-		tlabel = fxmalloc(50);
-	}
-
-	/* TA:  FIXME! xasprintf() */
 
 	if (desk_name != NULL)
 	{
 		if (flags & NO_NUM_IN_DESK_TITLE)
 		{
-			sprintf(tlabel, "%s%s", desk_name,
+			xasprintf(&tlabel, "%s%s", desk_name,
 				(is_top_title && (flags & SHOW_GEOMETRY)) ?
 				_("\tGeometry") : "");
 		}
 		else
 		{
-			sprintf(tlabel,"%d: %s%s", desk, desk_name,
+			xasprintf(&tlabel,"%d: %s%s", desk, desk_name,
 				(is_top_title && (flags & SHOW_GEOMETRY)) ?
 				_("\tGeometry") : "");
 		}
 	}
 	else
 	{
-		sprintf(tlabel,_("Desk: %d%s"),desk,
+		xasprintf(&tlabel,_("Desk: %d%s"),desk,
 			(is_top_title && (flags & SHOW_GEOMETRY)) ?
 			_("\tGeometry") : "");
 	}
@@ -897,12 +887,12 @@ void CMD_WindowList(F_CMD_ARGS)
 				if (!IS_ICONIFIED(t) &&
 				    !(flags & NO_DESK_NUM))
 				{
-					sprintf(loc,"%d:", t->Desk);
-					strcat(tname,loc);
+					snprintf(loc, sizeof(loc), "%d:", t->Desk);
+					strlcat(tname, loc, sizeof(tname));
 				}
 				if (IS_ICONIFIED(t))
 				{
-					strcat(tname, "(");
+					strlcat(tname, "(", sizeof(tname));
 				}
 				strcat(t_hot,"\t");
 				strcat(t_hot,tname);
@@ -919,41 +909,41 @@ void CMD_WindowList(F_CMD_ARGS)
 				tname[0]=0;
 				if (IS_ICONIFIED(t))
 				{
-					strcpy(tname, "(");
+					strlcpy(tname, "(", sizeof(tname));
 				}
 				if (!(flags & NO_DESK_NUM))
 				{
-					sprintf(loc, "%d", t->Desk);
-					strcat(tname, loc);
+					snprintf(loc, sizeof(loc), "%d", t->Desk);
+					strlcat(tname, loc, sizeof(tname));
 				}
 				if (flags & SHOW_SCREEN)
 				{
-					sprintf(loc, "@%s", t->m->si->name);
-					strcat(tname, loc);
+					snprintf(loc, sizeof(loc), "@%s", t->m->si->name);
+					strlcat(tname, loc, sizeof(tname));
 				}
 				if (flags & SHOW_PAGE_X)
 				{
-					sprintf(loc, "+%d",
+					snprintf(loc, sizeof(loc), "+%d",
 						(mon->virtual_scr.Vx + t->g.frame.x +
 						 t->g.frame.width / 2) /
 						monitor_get_all_widths());
-					strcat(tname, loc);
+					strlcat(tname, loc, sizeof(tname));
 				}
 				if (flags & SHOW_PAGE_Y)
 				{
-					sprintf(loc, "+%d",
+					snprintf(loc, sizeof(loc), "+%d",
 						(mon->virtual_scr.Vy + t->g.frame.y +
 						 t->g.frame.height/2) /
 						monitor_get_all_heights());
-					strcat(tname, loc);
+					strlcat(tname, loc, sizeof(tname));
 				}
 				if (!(flags & NO_LAYER))
 				{
-					sprintf(loc, "(%d)",
+					snprintf(loc, sizeof(loc), "(%d)",
 						(get_layer(t)));
-					strcat(tname, loc);
+					strlcat(tname, loc, sizeof(tname));
 				}
-				strcat(tname, ":");
+				strlcat(tname, ":", sizeof(tname));
 				get_window_borders(t, &b);
 				dheight = t->g.frame.height -
 					b.total_size.height;
@@ -965,48 +955,47 @@ void CMD_WindowList(F_CMD_ARGS)
 				dheight = (dheight - t->hints.base_height)
 					  /t->orig_hints.height_inc;
 
-				sprintf(loc,"%d",dwidth);
-				strcat(tname, loc);
-				sprintf(loc,"x%d",dheight);
-				strcat(tname, loc);
+				snprintf(loc, sizeof(loc), "%d", dwidth);
+				strlcat(tname, loc, sizeof(tname));
+				snprintf(loc, sizeof(loc), "x%d", dheight);
+				strlcat(tname, loc, sizeof(tname));
 				if (t->g.frame.x >=0)
 				{
-					sprintf(loc,"+%d",t->g.frame.x);
+					snprintf(loc, sizeof(loc), "+%d", t->g.frame.x);
 				}
 				else
 				{
-					sprintf(loc,"%d",t->g.frame.x);
+					snprintf(loc, sizeof(loc) ,"%d", t->g.frame.x);
 				}
-				strcat(tname, loc);
+				strlcat(tname, loc, sizeof(tname));
 				if (t->g.frame.y >=0)
 				{
-					sprintf(loc,"+%d",t->g.frame.y);
+					snprintf(loc, sizeof(loc),"+%d",t->g.frame.y);
 				}
 				else
 				{
-					sprintf(loc,"%d",t->g.frame.y);
+					snprintf(loc, sizeof(loc),"%d",t->g.frame.y);
 				}
-				strcat(tname, loc);
+				strlcat(tname, loc, sizeof(tname));
 
 				if (IS_STICKY_ACROSS_PAGES(t) ||
 				    IS_STICKY_ACROSS_DESKS(t))
 				{
-					strcat(tname, " S");
+					strlcat(tname, " S", sizeof(tname));
 				}
 				if (IS_ICONIFIED(t))
 				{
-					strcat(tname, ")");
+					strlcat(tname, ")", sizeof(tname));
 				}
 				strcat(t_hot,"\t");
 				strcat(t_hot,tname);
 			}
 			ffunc = func ? func : "WindowListFunc";
-			tfunc = fxmalloc(strlen(ffunc) + 36);
+
 			/* support two ways for now: window context
 			 * (new) and window id param (old) */
 
-			/* TA:  FIXME!  xasprintf() */
-			sprintf(tfunc, "WindowId %lu %s %lu",
+			xasprintf(&tfunc, "WindowId %lu %s %lu",
 				FW_W(t), ffunc, FW_W(t));
 			AddToMenu(
 				mr, t_hot, tfunc, False, False, False);

--- a/fvwm/windowshade.c
+++ b/fvwm/windowshade.c
@@ -236,9 +236,7 @@ void CMD_WindowShadeAnimate(F_CMD_ARGS)
 		   "The WindowShadeAnimate command is obsolete. "
 		   "Please use 'Style * WindowShadeSteps %s' instead.",
 		   action);
-	/* TA:  FIXME!  xasprintf() */
-	buf = fxmalloc(strlen(action) + 32);
-	sprintf(buf, "* WindowShadeSteps %s", action);
+	xasprintf(&buf, "* WindowShadeSteps %s", action);
 	action = buf;
 	CMD_Style(F_PASS_ARGS);
 	free(buf);

--- a/libs/Colorset.c
+++ b/libs/Colorset.c
@@ -108,7 +108,7 @@ void AllocColorset(int n)
 static char csetbuf[270];
 char *DumpColorset(int n, colorset_t *cs)
 {
-	sprintf(csetbuf,
+	snprintf(csetbuf, sizeof(csetbuf),
 		"Colorset "
 		"%x %lx %lx %lx %lx %lx %lx %lx %lx %lx "
 		"%x %x %x %x %x %x %x %x %x %x %x",

--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -15,7 +15,7 @@ libfvwm3_a_SOURCES = \
 	XError.h XResource.h charmap.h defaults.h envvar.h fio.h flist.h fqueue.h \
 	fsm.h ftime.h fvwm_sys_stat.h fvwm_x11.h fvwmlib.h fvwmrect.h fvwmsignal.h \
 	gravity.c gravity.h getpwuid.h lang-strings.h log.h modifiers.h queue.h \
-	safemalloc.h setpgrp.h strlcpy.h timeout.h vpacket.h wcontext.h wild.h \
+	safemalloc.h setpgrp.h strlcat.h strlcpy.h timeout.h vpacket.h wcontext.h wild.h \
 	cJSON.h \
 	\
 	BidiJoin.c Flocale.c PictureUtils.c FScreen.c Graphics.c \
@@ -27,7 +27,7 @@ libfvwm3_a_SOURCES = \
 	fvwmrect.c FRenderInit.c safemalloc.c  FBidi.c \
 	wild.c Grab.c Event.c ClientMsg.c setpgrp.c FShape.c \
 	FGettext.c Rectangles.c timeout.c flist.c charmap.c wcontext.c \
-	modifiers.c fsm.c FTips.c fio.c fvwmlib3.c strlcpy.c getpwuid.c cJSON.c
+	modifiers.c fsm.c FTips.c fio.c fvwmlib3.c strlcat.c strlcpy.c getpwuid.c cJSON.c
 
 libfvwm3_a_LIBADD = @LIBOBJS@
 

--- a/libs/Module.c
+++ b/libs/Module.c
@@ -209,7 +209,7 @@ void SetMessageMask(int *fd, unsigned long mask)
 {
 	char set_mask_mesg[50];
 
-	sprintf(set_mask_mesg, "SET_MASK %lu", mask);
+	snprintf(set_mask_mesg, sizeof(set_mask_mesg), "SET_MASK %lu", mask);
 	SendText(fd, set_mask_mesg, 0);
 }
 
@@ -217,7 +217,8 @@ void SetSyncMask(int *fd, unsigned long mask)
 {
 	char set_syncmask_mesg[50];
 
-	sprintf(set_syncmask_mesg, "SET_SYNC_MASK %lu", mask);
+	snprintf(set_syncmask_mesg, sizeof(set_syncmask_mesg),
+		"SET_SYNC_MASK %lu", mask);
 	SendText(fd, set_syncmask_mesg, 0);
 }
 
@@ -225,7 +226,8 @@ void SetNoGrabMask(int *fd, unsigned long mask)
 {
 	char set_nograbmask_mesg[50];
 
-	sprintf(set_nograbmask_mesg, "SET_NOGRAB_MASK %lu", mask);
+	snprintf(set_nograbmask_mesg, sizeof(set_nograbmask_mesg),
+		"SET_NOGRAB_MASK %lu", mask);
 	SendText(fd, set_nograbmask_mesg, 0);
 }
 
@@ -239,9 +241,10 @@ static int first_pass = 1;
 
 void InitGetConfigLine(int *fd, char *match)
 {
-	char *buffer = (char *)alloca(strlen(match) + 32);
+	size_t len = strlen(match) + 32;
+	char *buffer = alloca(len);
 	first_pass = 0;              /* make sure get wont do this */
-	sprintf(buffer, "Send_ConfigInfo %s", match);
+	snprintf(buffer, len, "Send_ConfigInfo %s", match);
 	SendText(fd, buffer, 0);
 }
 

--- a/libs/PictureUtils.c
+++ b/libs/PictureUtils.c
@@ -1246,9 +1246,7 @@ static void finish_ct_init(
 			ctt++;
 		}
 		/* TA:  FIXME!  Spelling!!! */
-		/* TA:  FIXME!  Use xasprintf() */
-		env = fxmalloc(PICTURE_TABLETYPE_LENGHT + 1);
-		sprintf(env, "%i", ctt);
+		xasprintf(&env, "%i", ctt);
 		flib_putenv("FVWM_COLORTABLE_TYPE", env);
 		free(env);
 		if (Pdepth <= 8)
@@ -2152,9 +2150,7 @@ void PictureReduceColorName(char **my_color)
 	 * string */
 	free(*my_color);                    /* free old color */
 	/* area for new color */
-	/* TA:  FIXME!  xasprintf() */
-	*my_color = fxmalloc(8);
-	sprintf(*my_color,"#%x%x%x",
+	xasprintf(my_color,"#%x%x%x",
 		Pct[index].color.red >> 8,
 		Pct[index].color.green >> 8,
 		Pct[index].color.blue >> 8); /* put it there */

--- a/libs/XError.c
+++ b/libs/XError.c
@@ -115,7 +115,8 @@ static char *error_name(unsigned char code)
 {
 	if (code == 0 || code > (sizeof(error_names) / sizeof(char *)))
 	{
-		sprintf(unknown, "Unknown: %d", (int)code);
+		snprintf(unknown, sizeof(unknown),
+			"Unknown: %d", (int)code);
 		return unknown;
 	}
 	return error_names[code - 1];
@@ -251,11 +252,11 @@ static char *request_name(unsigned char code)
 	{
 		if (code == FRenderGetMajorOpCode())
 		{
-			sprintf(unknown, "XRender");
+			snprintf(unknown, sizeof(unknown), "XRender");
 		}
 		else
 		{
-			sprintf(unknown, "Unknown: %d", (int)code);
+			snprintf(unknown, sizeof(unknown), "Unknown: %d", (int)code);
 		}
 		return unknown;
 	}

--- a/libs/cJSON.c
+++ b/libs/cJSON.c
@@ -124,7 +124,8 @@ CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
 CJSON_PUBLIC(const char*) cJSON_Version(void)
 {
     static char version[15];
-    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+    snprintf(version, sizeof(version),
+        "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
 
     return version;
 }
@@ -560,22 +561,22 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     /* This checks for NaN and Infinity */
     if (isnan(d) || isinf(d))
     {
-        length = sprintf((char*)number_buffer, "null");
+        length = strlcat((char*)number_buffer, "null", sizeof(number_buffer));
     }
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.15g", d);
 
         /* Check whether the original double can be recovered */
         if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
         {
             /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.17g", d);
         }
     }
 
-    /* sprintf failed or buffer overrun occurred */
+    /* snprintf failed or buffer overrun occurred */
     if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
     {
         return false;

--- a/libs/cJSON.h
+++ b/libs/cJSON.h
@@ -85,6 +85,8 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 
 #include <stddef.h>
 
+#include "libs/strlcat.h"
+
 /* cJSON Types: */
 #define cJSON_Invalid (0)
 #define cJSON_False  (1 << 0)

--- a/libs/fsm.c
+++ b/libs/fsm.c
@@ -162,9 +162,7 @@ unique_filename(char *path, char *prefix, int *pFd)
 {
 	char *tempFile;
 
-	/* TA:  FIXME!  xasprintf() */
-	tempFile = fxmalloc(strlen(path) + strlen(prefix) + 8);
-	sprintf(tempFile, "%s/%sXXXXXX", path, prefix);
+	xasprintf(&tempFile, "%s/%sXXXXXX", path, prefix);
 	*pFd =  fvwm_mkstemp(tempFile);
 	if (*pFd == -1)
 	{
@@ -272,7 +270,7 @@ Status SetAuthentication(
 
 	umask (original_umask);
 
-	sprintf (command, "iceauth source %s", addAuthFile);
+	snprintf (command, sizeof(command), "iceauth source %s", addAuthFile);
 	{
 		int n;
 
@@ -331,7 +329,7 @@ void FreeAuthenticationData(int count, FIceAuthDataEntry *authDataEntries)
 
 	free ((char *) authDataEntries);
 
-	sprintf (command, "iceauth source %s", remAuthFile);
+	snprintf (command, sizeof(command), "iceauth source %s", remAuthFile);
 	{
 		int n;
 
@@ -1078,9 +1076,7 @@ int fsm_init(char *module)
 	}
 
 	networkIds = FIceComposeNetworkIdList(numTransports, slistenObjs);
-	/* TA:  FIXME!  xasprintf() */
-	p = fxmalloc(16 + strlen(networkIds) + 1);
-	sprintf(p, "SESSION_MANAGER=%s", networkIds);
+	xasprintf(&p, "SESSION_MANAGER=%s", networkIds);
 	putenv(p);
 
 #ifdef FVWM_DEBUG_FSM

--- a/libs/strlcat.c
+++ b/libs/strlcat.c
@@ -1,0 +1,61 @@
+/*	$OpenBSD: strlcat.c,v 1.19 2019/01/25 00:19:25 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/string/strlcat.c */
+
+#ifndef HAVE_STRLCAT
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Appends src to string dst of size dsize (unlike strncat, dsize is the
+ * full size of dst, not space left).  At most dsize-1 characters
+ * will be copied.  Always NUL terminates (unless dsize <= strlen(dst)).
+ * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
+ * If retval >= dsize, truncation occurred.
+ */
+size_t
+strlcat(char *dst, const char *src, size_t dsize)
+{
+	const char *odst = dst;
+	const char *osrc = src;
+	size_t n = dsize;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end. */
+	while (n-- != 0 && *dst != '\0')
+		dst++;
+	dlen = dst - odst;
+	n = dsize - dlen;
+
+	if (n-- == 0)
+		return(dlen + strlen(src));
+	while (*src != '\0') {
+		if (n != 0) {
+			*dst++ = *src;
+			n--;
+		}
+		src++;
+	}
+	*dst = '\0';
+
+	return(dlen + (src - osrc));	/* count does not include NUL */
+}
+
+#endif /* !HAVE_STRLCAT */

--- a/libs/strlcat.h
+++ b/libs/strlcat.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/string/strlcat.c */
+
+#ifndef LIBC_STRLCAT_H
+#define LIBC_STRLCAT_H
+
+#include <stdlib.h>
+
+size_t	strlcat(char *, const char *, size_t);
+
+#endif /* LIBC_STRLCAT_H */

--- a/modules/FvwmAnimate/FvwmAnimate.c
+++ b/modules/FvwmAnimate/FvwmAnimate.c
@@ -122,18 +122,18 @@ static struct
    CMD10 - module->name, CatString3("*",module->name,0)
    CMD11 - module->name,module->name */
 #define CMD1X(TEXT) \
-  sprintf(cmd,TEXT,module->name);\
+  snprintf(cmd,sizeof(cmd),TEXT,module->name);\
   SendText(Channel,cmd,0);
 #define CMD10(TEXT) \
   do { \
 	  char *x; \
 	  xasprintf(&x, "*%s", module->name); \
-	  sprintf(cmd,TEXT,module->name, x);\
+	  snprintf(cmd,sizeof(cmd),TEXT,module->name, x);\
 	  SendText(Channel,cmd,0); \
 	  free(x); \
   } while (0);
 #define CMD11(TEXT) \
-  sprintf(cmd,TEXT,module->name,module->name);\
+  snprintf(cmd,sizeof(cmd),TEXT,module->name,module->name);\
   SendText(Channel,cmd,0);
 
 static void Loop(void);
@@ -822,7 +822,7 @@ int main(int argc, char **argv) {
   Scr.root = DefaultRootWindow(dpy);
   Scr.screen = DefaultScreen(dpy);
 
-  sprintf(cmd,"read .%s Quiet",module->name); /* read quiet modules config */
+  snprintf(cmd,sizeof(cmd),"read .%s Quiet",module->name); /* read quiet modules config */
   SendText(Channel,cmd,0);
   ParseOptions();                       /* get cmds fvwm has parsed */
 
@@ -1413,10 +1413,10 @@ static void SaveConfig(void) {
      read.c, right now, this logic only works well if fvwm is started
      from the users home directory.
   */
-  sprintf(filename,"%s/.%s",getenv("FVWM_USERDIR"),module->name);
+  snprintf(filename, sizeof(filename), "%s/.%s",getenv("FVWM_USERDIR"),module->name);
   config_file = fopen(filename,"w");
   if (config_file == NULL) {
-    sprintf(msg,
+    snprintf(msg, sizeof(msg),
 	    "%s: Open config file <%s> for write failed. \
 Save not done! Error\n",
 	    module->name, filename);
@@ -1474,7 +1474,7 @@ static void DefineForm(void) {
   } /* end all buttons */
   /* Macro for a command with one var */
 #define CMD1V(TEXT,VAR) \
-  sprintf(cmd,TEXT,module->name,VAR);\
+  snprintf(cmd,sizeof(cmd),TEXT,module->name,VAR);\
   SendText(Channel,cmd,0);
 
   /* There is a cleaner way (using the array) for this...dje */

--- a/modules/FvwmAuto/FvwmAuto.c
+++ b/modules/FvwmAuto/FvwmAuto.c
@@ -105,7 +105,6 @@ main(int argc, char **argv)
 	char *enter_fn="Silent Raise";        /* default */
 	char *leave_fn=NULL;
 	char *buf;
-	int len;
 	unsigned long m_mask;
 	unsigned long mx_mask;
 	unsigned long last_win = 0;   /* last window handled */
@@ -337,22 +336,6 @@ main(int argc, char **argv)
 	fd_width = fd[1] + 1;
 	FD_ZERO(&in_fdset);
 
-	/* create the command buffer */
-	len = 0;
-	if (enter_fn != 0)
-	{
-		len = strlen(enter_fn);
-	}
-	if (leave_fn != NULL)
-	{
-		len = max(len, strlen(leave_fn));
-	}
-	if (do_pass_id)
-	{
-		len += 32;
-	}
-	buf = fxmalloc(len);
-
 	while (!isTerminated)
 	{
 		char raise_window_now;
@@ -370,7 +353,7 @@ main(int argc, char **argv)
 		{
 			char tmp[32];
 
-			sprintf(tmp, "%d usecs", (delay) ?
+			snprintf(tmp, sizeof(tmp), "%d usecs", (delay) ?
 				(int)delay->tv_usec : -1);
 			myfprintf((stderr, "select: delay = %s\n",
 				   (have_new_window) ? tmp : "infinite" ));
@@ -509,14 +492,16 @@ main(int argc, char **argv)
 				/* if focus_win isn't the root */
 				if (do_pass_id)
 				{
-					sprintf(buf, "%s 0x%x\n", leave_fn,
+					xasprintf(&buf, "%s 0x%x\n", leave_fn,
 						(int)last_win);
 				}
 				else
 				{
-					sprintf(buf, "%s\n", leave_fn);
+					xasprintf(&buf, "%s\n", leave_fn);
 				}
 				SendInfo(fd, buf, last_win);
+				free(buf);
+
 				if (use_enter_mode)
 				{
 					raised_win = 0;
@@ -528,14 +513,16 @@ main(int argc, char **argv)
 				/* if focus_win isn't the root */
 				if (do_pass_id)
 				{
-					sprintf(buf, "%s 0x%x\n", enter_fn,
+					xasprintf(&buf, "%s 0x%x\n", enter_fn,
 						(int)focus_win);
 				}
 				else
 				{
-					sprintf(buf, "%s\n", enter_fn);
+					xasprintf(&buf, "%s\n", enter_fn);
 				}
 				SendInfo(fd, buf, focus_win);
+				free(buf);
+
 				raised_win = focus_win;
 			}
 			else if (focus_win && enter_fn == NULL)

--- a/modules/FvwmButtons/FvwmButtons.c
+++ b/modules/FvwmButtons/FvwmButtons.c
@@ -292,8 +292,7 @@ static void DeadPipeCleanup(void)
 					{
 						char cmd[256];
 
-						sprintf(
-						  cmd,
+						snprintf(cmd, sizeof(cmd),
 						  "PropertyChange %u %u %lu",
 						  MX_PROPERTY_CHANGE_SWALLOW,
 						  0, swin);
@@ -2070,7 +2069,7 @@ static void HandlePanelPress(button_info *b)
   b->newflags.panel_mapped = !is_mapped;
 
   /* make sure the window maps on the current desk */
-  sprintf(cmd, "Silent WindowId 0x%08x (!Sticky) MoveToDesk 0",
+  snprintf(cmd, sizeof(cmd), "Silent WindowId 0x%08x (!Sticky) MoveToDesk 0",
 	  (int)b->PanelWin);
   SendInfo(fd, cmd, b->PanelWin);
   SlideWindow(Dpy, b->PanelWin,
@@ -2517,7 +2516,7 @@ static void send_bg_change_to_module(button_info *b, XEvent *Event)
 	else
 	{
 		char cmd[256];
-		sprintf(cmd, "PropertyChange %u %u %lu",
+		snprintf(cmd, sizeof(cmd), "PropertyChange %u %u %lu",
 			MX_PROPERTY_CHANGE_BACKGROUND, 0, SwallowedWindow(b));
 		SendText(fd, cmd, 0);
 	}
@@ -2805,7 +2804,7 @@ void process_message(unsigned long type, unsigned long *body)
 				swin = SwallowedWindow(b);
 				if ((buttonSwallowCount(b) == 3) && swin)
 				{
-					sprintf(cmd,
+					snprintf(cmd, sizeof(cmd),
 						"PropertyChange %u %u %lu %lu",
 						MX_PROPERTY_CHANGE_SWALLOW, 1,
 						swin, s);
@@ -3313,7 +3312,7 @@ void swallow(unsigned long *body)
 					/* if we swallow a module we send an avertisment */
 					char cmd[256];
 
-					sprintf(cmd,
+					snprintf(cmd, sizeof(cmd),
 						"PropertyChange %u %u %lu %lu",
 						MX_PROPERTY_CHANGE_SWALLOW, 1,
 						SwallowedWindow(b),
@@ -3374,7 +3373,6 @@ void exec_swallow(char *action, button_info *b)
 {
 	static char *my_sm_env = NULL;
 	static char *orig_sm_env = NULL;
-	static int len = 0;
 	static Bool sm_initialized = False;
 	static Bool session_manager = False;
 	char *cmd;
@@ -3405,14 +3403,10 @@ void exec_swallow(char *action, button_info *b)
 	if (my_sm_env == NULL)
 	{
 		my_sm_env = getenv("SESSION_MANAGER");
-		len = 45 + strlen(my_sm_env) + strlen(orig_sm_env);
 	}
 
 	/* TA:  FIXME!  xasprintf() */
-	cmd = fxmalloc(len + strlen(action));
-	sprintf(
-		cmd,
-		"FSMExecFuncWithSessionManagment \"%s\" \"%s\" \"%s\"",
+	xasprintf(&cmd, "FSMExecFuncWithSessionManagment \"%s\" \"%s\" \"%s\"",
 		my_sm_env, action, orig_sm_env);
 	SendText(fd, cmd, 0);
 	free(cmd);

--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -2108,8 +2108,7 @@ void ParseConfiguration(button_info *ub)
 		NULL
 	};
 
-	items[0] = fxmalloc(strlen(MyName) + 2);
-	sprintf(items[0], "*%s", MyName);
+	xasprintf(&items[0], "*%s", MyName);
 
 	/* send config lines with MyName */
 	InitGetConfigLine(fd, items[0]);

--- a/modules/FvwmEvent/FvwmEvent.c
+++ b/modules/FvwmEvent/FvwmEvent.c
@@ -432,11 +432,11 @@ void execute_event(event_entry *event_table, short event, unsigned long *body)
 			if (!audio_play_dir || audio_play_dir[0] == '\0' ||
 			    action[0] == '/')
 			{
-				sprintf(buf,"%s %s", cmd_line, action);
+				snprintf(buf,len,"%s %s", cmd_line, action);
 			}
 			else
 			{
-				sprintf(buf,"%s %s/%s &", cmd_line,
+				snprintf(buf,len,"%s %s/%s &", cmd_line,
 					audio_play_dir, action);
 			}
 			if (!system(buf))
@@ -459,18 +459,18 @@ void execute_event(event_entry *event_table, short event, unsigned long *body)
 				if (action_arg & ARG_NO_WINID)
 				{
 					action_arg &= ~ARG_NO_WINID;
-					sprintf(buf, "%s %s %ld", cmd_line,
+					snprintf(buf, len, "%s %s %ld", cmd_line,
 						action,	body[action_arg]);
 				}
 				else
 				{
-					sprintf(buf, "%s %s 0x%lx", cmd_line,
+					snprintf(buf, len, "%s %s 0x%lx", cmd_line,
 						action,	body[action_arg]);
 				}
 			}
 			else
 			{
-				sprintf(buf,"%s %s", cmd_line, action);
+				snprintf(buf, len,"%s %s", cmd_line, action);
 			}
 			/* let fvwm execute the function */
 			SendText(fd, buf, fw);

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -1009,7 +1009,7 @@ static void ReadFormData(void)
   int leading_len;
   char *line_buf;			/* ptr to curr config line */
   char cmd_buffer[200];
-  sprintf(cmd_buffer,"read %s Quiet",CF.file_to_read);
+  snprintf(cmd_buffer, sizeof(cmd_buffer), "read %s Quiet",CF.file_to_read);
   SendText(Channel,cmd_buffer,0);	/* read data */
   leading_len = strlen(CF.leading);
   InitGetConfigLine(Channel, CF.leading); /* ask for certain lines */
@@ -2734,7 +2734,7 @@ int main (int argc, char **argv)
   ReadDefaults();			/* get config from fvwm */
 
   if (strcasecmp(module->name,"FvwmForm") != 0) { /* if not already read */
-    sprintf(cmd,"read %s Quiet",module->name); /* read quiet modules config */
+    snprintf(cmd,sizeof(cmd),"read %s Quiet",module->name); /* read quiet modules config */
     SendText(Channel,cmd,0);
   }
 

--- a/modules/FvwmIconMan/xmanager.c
+++ b/modules/FvwmIconMan/xmanager.c
@@ -846,7 +846,8 @@ void set_win_iconified(WinData *win, int iconified)
 			}
 			if (iconified)
 			{
-				sprintf(string, "%s %d %d %d %d %d %d %d %d",
+				snprintf(string, sizeof(string),
+					"%s %d %d %d %d %d %d %d %d",
 					win->manager->AnimCommand,
 					(int)win->x, (int)win->y,
 					(int)win->width, (int)win->height,
@@ -854,7 +855,8 @@ void set_win_iconified(WinData *win, int iconified)
 			}
 			else
 			{
-				sprintf(string, "%s %d %d %d %d %d %d %d %d",
+				snprintf(string, sizeof(string),
+					"%s %d %d %d %d %d %d %d %d",
 					win->manager->AnimCommand,
 					abs_x, abs_y, w, h,
 					(int)win->x, (int)win->y,

--- a/modules/FvwmIdent/FvwmIdent.c
+++ b/modules/FvwmIdent/FvwmIdent.c
@@ -654,7 +654,7 @@ int ProcessXEvent(int x, int y)
 		case ReparentNotify:
 			if (minimal_layer >= 0)
 			{
-				sprintf(buf, "Layer 0 %d", my_layer);
+				snprintf(buf, sizeof(buf), "Layer 0 %d", my_layer);
 				SendText(fd, buf, main_win);
 			}
 			SendText(fd, "Raise", main_win);
@@ -1122,14 +1122,14 @@ void MakeList(void)
 		height -= target.title_h;
 	}
 
-	sprintf(desktop, "%ld",  target.desktop);
-	sprintf(layer,   "%ld",  target.layer);
-	sprintf(id,      "0x%x", (unsigned int)target.id);
-	sprintf(swidth,  "%d",   width);
-	sprintf(sheight, "%d",   height);
-	sprintf(borderw, "%ld",  target.border_w);
-	sprintf(xstr,    "%ld",  target.frame_x);
-	sprintf(ystr,    "%ld",  target.frame_y);
+	snprintf(desktop, sizeof(desktop), "%ld",  target.desktop);
+	snprintf(layer, sizeof(layer),     "%ld",  target.layer);
+	snprintf(id, sizeof(id),           "0x%x", (unsigned int)target.id);
+	snprintf(swidth, sizeof(swidth),   "%d",   width);
+	snprintf(sheight, sizeof(sheight), "%d",   height);
+	snprintf(borderw, sizeof(borderw), "%ld",  target.border_w);
+	snprintf(xstr, sizeof(xstr),       "%ld",  target.frame_x);
+	snprintf(ystr, sizeof(ystr),       "%ld",  target.frame_y);
 
 	AddToList("Name:",          target.name);
 	AddToList("Icon Name:",     target.icon_name);
@@ -1218,32 +1218,32 @@ void MakeList(void)
 	width = (width - target.base_w)/target.width_inc;
 	height = (height - target.base_h)/target.height_inc;
 
-	sprintf(loc,"%dx%d",width,height);
-	strcpy(geometry, loc);
+	snprintf(loc,sizeof(loc),"%dx%d",width,height);
+	strlcpy(geometry, loc, sizeof(geometry));
 
 	if ((target.gravity == EastGravity) ||
 	    (target.gravity == NorthEastGravity)||
 	    (target.gravity == SouthEastGravity))
 	{
-		sprintf(loc,"-%d",x2);
+		snprintf(loc,sizeof(loc),"-%d",x2);
 	}
 	else
 	{
-		sprintf(loc,"+%d",x1);
+		snprintf(loc,sizeof(loc),"+%d",x1);
 	}
-	strcat(geometry, loc);
+	strlcat(geometry, loc, sizeof(geometry));
 
 	if((target.gravity == SouthGravity)||
 	   (target.gravity == SouthEastGravity)||
 	   (target.gravity == SouthWestGravity))
 	{
-		sprintf(loc,"-%d",y2);
+		snprintf(loc,sizeof(loc),"-%d",y2);
 	}
 	else
 	{
-		sprintf(loc,"+%d",y1);
+		snprintf(loc,sizeof(loc),"+%d",y1);
 	}
-	strcat(geometry, loc);
+	strlcat(geometry, loc, sizeof(geometry));
 	AddToList("Geometry:", geometry);
 
 	{
@@ -1318,15 +1318,15 @@ void MakeList(void)
 			{
 				if (supplied_return & PAspect)
 				{ /* if window has a aspect ratio */
-					sprintf(
-						mymin_aspect, "%d/%d",
+					snprintf(mymin_aspect, sizeof(mymin_aspect),
+						"%d/%d",
 						size_hints->min_aspect.x,
 						size_hints->min_aspect.y);
 					AddToList(
 						"Minimum aspect ratio:",
 						mymin_aspect);
-					sprintf(
-						max_aspect, "%d/%d",
+					snprintf(max_aspect, sizeof(max_aspect),
+						"%d/%d",
 						size_hints->max_aspect.x,
 						size_hints->max_aspect.y);
 					AddToList(

--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -310,7 +310,7 @@ handle_packet(unsigned long type, unsigned long *body, unsigned long len)
 
 	fm = fvwm_msg_new();
 
-	sprintf(xwid, "0x%lx", body[0]);
+	snprintf(xwid, sizeof(xwid), "0x%lx", body[0]);
 
 	if (debug)
 		fprintf(stderr, "%s: matched: <<%s>>\n", __func__, type_name);

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -354,7 +354,7 @@ int main(int argc, char **argv)
   Desks = fxcalloc(1, ndesks*sizeof(DeskInfo));
   for(i=0;i<ndesks;i++)
     {
-      sprintf(line,"Desk %d",i+desk1);
+      snprintf(line,sizeof(line),"Desk %d",i+desk1);
       CopyString(&Desks[i].label,line);
       Desks[i].colorset = -1;
       Desks[i].highcolorset = -1;
@@ -1011,7 +1011,7 @@ void list_new_desk(unsigned long *body)
     }
     else
     {
-      sprintf(line, "Desk %d", desk1);
+      snprintf(line, sizeof(line), "Desk %d", desk1);
       CopyString(&Desks[0].label, line);
     }
     XStoreName(dpy, Scr.Pager_w, Desks[0].label);
@@ -1117,7 +1117,7 @@ void list_new_desk(unsigned long *body)
     }
     else
     {
-      sprintf(line, "Desk %d", m->virtual_scr.CurrentDesk);
+      snprintf(line, sizeof(line), "Desk %d", m->virtual_scr.CurrentDesk);
       name = &(line[0]);
     }
     XStoreName(dpy, Scr.Pager_w, name);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -160,8 +160,8 @@ static void do_scroll(int sx, int sy, Bool do_send_message,
 	    ( psx != 0 || psy != 0 ))
 	{
 		if (monitor_to_track != NULL)
-			sprintf(screen, "screen %s", monitor_to_track);
-		sprintf(command, "Scroll %s %dp %dp", screen, psx, psy);
+			snprintf(screen, sizeof(screen), "screen %s", monitor_to_track);
+		snprintf(command, sizeof(command), "Scroll %s %dp %dp", screen, psx, psy);
 		SendText(fd, command, 0);
 		messages_sent++;
 		SendText(fd, "Send_Reply ScrollDone", 0);
@@ -1162,7 +1162,7 @@ void DispatchEvent(XEvent *Event)
       if (do_move_page)
       {
 	char command[64];
-	sprintf(command,"Scroll %d %d", dx, dy);
+	snprintf(command, sizeof(command),"Scroll %d %d", dx, dy);
 	SendText(fd, command, 0);
       }
     }
@@ -1661,7 +1661,7 @@ void MovePage(Bool is_new_desk)
       sptr = Desks[mon->virtual_scr.CurrentDesk -desk1].label;
     else
     {
-      sprintf(str, "GotoDesk %s %d", mon->name, mon->virtual_scr.CurrentDesk);
+      snprintf(str, sizeof(str), "GotoDesk %s %d", mon->name, mon->virtual_scr.CurrentDesk);
       sptr = &str[0];
     }
 
@@ -1816,7 +1816,7 @@ void DrawGrid(int desk, int erase, Window ew, XRectangle *r)
 	w = FlocaleTextWidth(Ffont,ptr,strlen(ptr));
 	if( w > desk_w)
 	{
-		sprintf(str,"%d",d);
+		snprintf(str,sizeof(str),"%d",d);
 		ptr = str;
 		w = FlocaleTextWidth(Ffont,ptr,strlen(ptr));
 	}
@@ -1932,8 +1932,9 @@ void SwitchToDesk(int Desk)
 	char command[256];
 	struct fpmonitor *m = fpmonitor_this();
 
-	sprintf(command, "GotoDesk %s 0 %d", monitor_to_track ? m->name : "",
-			Desk + desk1);
+	snprintf(command, sizeof(command),
+		"GotoDesk %s 0 %d", monitor_to_track ? m->name : "",
+		Desk + desk1);
 	SendText(fd,command,0);
 }
 
@@ -1957,7 +1958,7 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
       vy = Event->xbutton.y * mon->virtual_scr.VHeight / (desk_h * mon->virtual_scr.MyDisplayHeight);
     mon->virtual_scr.Vx = vx * mon->virtual_scr.MyDisplayWidth;
     mon->virtual_scr.Vy = vy * mon->virtual_scr.MyDisplayHeight;
-    sprintf(command, "GotoDeskAndPage %s %d %d %d",
+    snprintf(command, sizeof(command), "GotoDeskAndPage %s %d %d %d",
 		monitor_to_track ? mon->name : "", Desk + desk1, vx, vy);
     SendText(fd, command, 0);
 
@@ -1985,7 +1986,7 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
       x = mon->virtual_scr.VxMax / mon->virtual_scr.MyDisplayWidth;
     if (y * mon->virtual_scr.MyDisplayHeight > mon->virtual_scr.VyMax)
       y = mon->virtual_scr.VyMax / mon->virtual_scr.MyDisplayHeight;
-    sprintf(command, "GotoPage %s %d %d", monitor_to_track ? mon->name : "", x, y);
+    snprintf(command, sizeof(command), "GotoPage %s %d %d", monitor_to_track ? mon->name : "", x, y);
     SendText(fd, command, 0);
   }
   Wait = 1;
@@ -1996,7 +1997,7 @@ void IconSwitchPage(XEvent *Event)
   char command[34];
   struct fpmonitor *mon = fpmonitor_this();
 
-  sprintf(command,"GotoPage %s %d %d",
+  snprintf(command,sizeof(command),"GotoPage %s %d %d",
 	  monitor_to_track ? mon->name : "",
 	  Event->xbutton.x * mon->virtual_scr.VWidth /
 		  (icon.width * mon->virtual_scr.MyDisplayWidth),
@@ -2639,7 +2640,7 @@ void MoveWindow(XEvent *Event)
 					ChangeDeskForWindow(t,mon->virtual_scr.CurrentDesk);
 			}
 			else if (NewDesk + desk1 != mon->virtual_scr.CurrentDesk) {
-				sprintf(command, "Silent MoveToDesk 0 %d",
+				snprintf(command, sizeof(command), "Silent MoveToDesk 0 %d",
 					NewDesk + desk1);
 				SendText(fd, command, t->w);
 				t->desk = NewDesk + desk1;
@@ -2659,7 +2660,7 @@ void MoveWindow(XEvent *Event)
 				/* XXX: Note the use of ewmhiwa to disable
 				 * clipping the coordinates to the wrong area!
 				 */
-				sprintf(buf, "Silent Move +%dp +%dp ewmhiwa",
+				snprintf(buf, sizeof(buf), "Silent Move +%dp +%dp ewmhiwa",
 					rec.x, rec.y);
 				SendText(fd, buf, t->w);
 				XSync(dpy,0);
@@ -2670,7 +2671,7 @@ void MoveWindow(XEvent *Event)
 		}
 
 		if (do_switch_desk_later) {
-			sprintf(command, "Silent MoveToDesk 0 %d", NewDesk +
+			snprintf(command, sizeof(command), "Silent MoveToDesk 0 %d", NewDesk +
 				desk1);
 			SendText(fd, command, t->w);
 			t->desk = NewDesk + desk1;
@@ -3034,7 +3035,7 @@ void IconMoveWindow(XEvent *Event, PagerWindow *t)
 
 		if (moved) {
 			char buf[64];
-			sprintf(buf, "Silent Move +%dp +%dp ewmhiwa",
+			snprintf(buf, sizeof(buf), "Silent Move +%dp +%dp ewmhiwa",
 				rec.x, rec.y);
 			SendText(fd, buf, t->w);
 			XSync(dpy, 0);

--- a/modules/FvwmRearrange/FvwmRearrange.c
+++ b/modules/FvwmRearrange/FvwmRearrange.c
@@ -258,7 +258,7 @@ void move_resize_raise_window(
 		const char *function = do_maximize?
 			"ResizeMoveMaximize":
 			"ResizeMove";
-		sprintf(msg, "%s %dp %dp %up %upi %s", function, w, h, x, y,
+		snprintf(msg, sizeof(msg), "%s %dp %dp %up %upi %s", function, w, h, x, y,
 			ewmhiwa);
 		SendText(fd, msg, wi->frame);
 	}
@@ -268,10 +268,10 @@ void move_resize_raise_window(
 			"ResizeMoveMaximize":
 			do_animate ? "AnimatedMove" : "Move";
 		if (do_maximize)
-			sprintf(msg, "%s keep keep %up %up %s", function, x, y,
+			snprintf(msg, sizeof(msg), "%s keep keep %up %up %s", function, x, y,
 				ewmhiwa);
 		else
-			sprintf(msg, "%s %up %up %s", function, x, y, ewmhiwa);
+			snprintf(msg, sizeof(msg), "%s %up %up %s", function, x, y, ewmhiwa);
 		SendText(fd, msg, wi->frame);
 	}
 

--- a/modules/FvwmScript/FvwmScript.c
+++ b/modules/FvwmScript/FvwmScript.c
@@ -189,7 +189,7 @@ void ReadConfig (char *ScriptName)
      it ends up trying the command line file name undecorated, which
      could be a full path, or it could be relative to the current directory.
      Not very pretty, dje 12/26/99 */
-  sprintf(s,"%s%s%s",ScriptPath,(!*ScriptPath ? "" : "/"),ScriptName);
+  snprintf(s,sizeof(s),"%s%s%s",ScriptPath,(!*ScriptPath ? "" : "/"),ScriptName);
   yyin = fopen(s,"r");
   if (yyin == NULL) {                   /* file not found yet, */
     TryToFind(ScriptName);                   /* look in some other places */
@@ -223,10 +223,10 @@ static void TryToFind(char *filename) {
     yyin = fopen(filename,"r");
     return;
   }
-  sprintf(path,"%s/%s",getenv("FVWM_USERDIR"),filename);
+  snprintf(path,sizeof(path),"%s/%s",getenv("FVWM_USERDIR"),filename);
   yyin = fopen( path, "r" );
   if ( yyin == NULL ) {
-    sprintf(path,"%s/%s",FVWM_DATADIR, filename );
+    snprintf(path,sizeof(path),"%s/%s",FVWM_DATADIR, filename );
     yyin = fopen( path, "r" );
   }
   return;
@@ -339,10 +339,11 @@ void Xinit(int IsFather)
 
   if (IsFather)
   {
-    name = fxcalloc(sizeof(char), strlen("FvwmScript") + 5);
+    size_t len = strlen("FvwmScript") + 5;
+    name = fxcalloc(sizeof(char), len);
     do
     {
-      sprintf(name,"%c%xFvwmScript",161,i);
+      snprintf(name, len,"%c%xFvwmScript",161,i);
       i++;
       myatom = XInternAtom(dpy, name, False);
     }
@@ -1279,7 +1280,7 @@ void MainLoop (void)
 			  if (tabxobj[i]->TypeWidget == SwallowExec &&
 			      tabxobj[i]->win != None)
 			  {
-				  sprintf(cmd,"PropertyChange %u %u %lu %lu",
+				  snprintf(cmd,sizeof(cmd),"PropertyChange %u %u %lu %lu",
 					  MX_PROPERTY_CHANGE_SWALLOW, 1,
 					  tabxobj[i]->win, s);
 				  SendText(fd,cmd,0);

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -155,14 +155,12 @@ static char *CalcArg (long *TabArg,int *Ix)
   if (TabArg[*Ix]>100000)       /* Number coding case */
   {
     i = (int)TabArg[*Ix] - 200000;
-    TmpStr = fxcalloc(1, sizeof(char) * 10);
-    sprintf(TmpStr,"%d",i);
+    xasprintf(&TmpStr,"%d",i);
   }
   else if (TabArg[*Ix] < -200000)/* Comparison fuction ID case */
   {
    i = TabArg[*Ix]+250000;
-   TmpStr = fxcalloc(1, sizeof(char) * 10);
-   sprintf(TmpStr,"%d",i);
+   xasprintf(&TmpStr,"%d",i);
   }
   else if (TabArg[*Ix] < -100000)       /* Function ID case */
   {
@@ -189,8 +187,7 @@ static char *FuncGetValue(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 10);
-  sprintf(tmp,"%d",tabxobj[TabIdObj[Id]]->value);
+  xasprintf(&tmp,"%d",tabxobj[TabIdObj[Id]]->value);
   return tmp;
 }
 
@@ -204,8 +201,7 @@ static char *FuncGetMinValue(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 10);
-  sprintf(tmp,"%d",tabxobj[TabIdObj[Id]]->value2);
+  xasprintf(&tmp,"%d",tabxobj[TabIdObj[Id]]->value2);
   return tmp;
 }
 
@@ -219,8 +215,7 @@ static char *FuncGetMaxValue(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 10);
-  sprintf(tmp,"%d",tabxobj[TabIdObj[Id]]->value3);
+  xasprintf(&tmp,"%d",tabxobj[TabIdObj[Id]]->value3);
   return tmp;
 }
 
@@ -235,10 +230,9 @@ static char *FuncGetFore(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 7);
   color.pixel = tabxobj[TabIdObj[Id]]->TabColor[fore];
   XQueryColor(dpy, Pcmap, &color);
-  sprintf(tmp, "%02x%02x%02x",
+  xasprintf(&tmp, "%02x%02x%02x",
 	  color.red >> 8, color.green >> 8, color.blue >> 8);
   return tmp;
 }
@@ -254,10 +248,9 @@ static char *FuncGetBack(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 7);
   color.pixel = tabxobj[TabIdObj[Id]]->TabColor[back];
   XQueryColor(dpy, Pcmap, &color);
-  sprintf(tmp, "%02x%02x%02x",
+  xasprintf(&tmp, "%02x%02x%02x",
 	  color.red >> 8, color.green >> 8, color.blue >> 8);
   return tmp;
 }
@@ -273,10 +266,9 @@ static char *FuncGetHili(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 7);
   color.pixel = tabxobj[TabIdObj[Id]]->TabColor[hili];
   XQueryColor(dpy, Pcmap, &color);
-  sprintf(tmp, "%02x%02x%02x",
+  xasprintf(&tmp, "%02x%02x%02x",
 	  color.red >> 8, color.green >> 8, color.blue >> 8);
   return tmp;
 }
@@ -292,10 +284,9 @@ static char *FuncGetShad(int *NbArg, long *TabArg)
   tmp = CalcArg(TabArg,NbArg);
   Id = atoi(tmp);
   free(tmp);
-  tmp = fxcalloc(1, sizeof(char) * 7);
   color.pixel = tabxobj[TabIdObj[Id]]->TabColor[shad];
   XQueryColor(dpy, Pcmap, &color);
-  sprintf(tmp, "%02x%02x%02x",
+  xasprintf(&tmp, "%02x%02x%02x",
 	  color.red >> 8, color.green >> 8, color.blue >> 8);
   return tmp;
 }
@@ -430,9 +421,7 @@ static char *FuncNumToHex(int *NbArg, long *TabArg)
   nbchar = atoi(str);
   free(str);
 
-  str = fxcalloc(1, nbchar + 10);
-  sprintf(str,"%X",value);
-  j = strlen(str);
+  j = xasprintf(&str,"%X",value);
   if (j < nbchar)
   {
     memmove(&str[nbchar-j],str,j);
@@ -456,8 +445,7 @@ static char *FuncHexToNum(int *NbArg, long *TabArg)
   k = (int)strtol(str,NULL,16);
   free(str);
 
-  str2 = fxcalloc(1, 20);
-  sprintf(str2,"%d",k);
+  xasprintf(&str2,"%d",k);
   return str2;
 }
 
@@ -475,8 +463,7 @@ static char *FuncAdd(int *NbArg, long *TabArg)
   str = CalcArg(TabArg,NbArg);
   val2 = atoi(str);
   free(str);
-  str = fxcalloc(1, 20);
-  sprintf(str,"%d",val1+val2);
+  xasprintf(&str,"%d",val1+val2);
   return str;
 }
 
@@ -494,8 +481,7 @@ static char *FuncMult(int *NbArg, long *TabArg)
   str = CalcArg(TabArg,NbArg);
   val2 = atoi(str);
   free(str);
-  str = fxcalloc(1, 20);
-  sprintf(str,"%d",val1*val2);
+  xasprintf(&str,"%d",val1*val2);
   return str;
 }
 
@@ -513,8 +499,7 @@ static char *FuncDiv(int *NbArg, long *TabArg)
   str = CalcArg(TabArg,NbArg);
   val2 = atoi(str);
   free(str);
-  str = fxcalloc(1, 20);
-  sprintf(str,"%d",val1/val2);
+  xasprintf(&str,"%d",val1/val2);
   return str;
 }
 
@@ -536,9 +521,8 @@ static char *RemainderOfDiv(int *NbArg, long *TabArg)
   str = CalcArg(TabArg,NbArg);
   val2 = atoi(str);
   free(str);
-  str = fxcalloc(1, 20);
   res = div(val1,val2);
-  sprintf(str,"%d",res.rem);
+  xasprintf(&str,"%d",res.rem);
   return str;
 #endif
 }
@@ -618,14 +602,12 @@ static char *LaunchScript (int *NbArg,long *TabArg)
   }
 
   /* Building the command */
-  execstr = fxcalloc(strlen(module->name) + strlen(arg) + strlen(x11base->TabScriptId[x11base->NbChild + 2]) + 5,
-                    sizeof(char));
   scriptname = fxcalloc(sizeof(char), 100);
   sscanf(arg,"%s",scriptname);
   scriptarg = fxcalloc(sizeof(char), strlen(arg));
   scriptarg = (char*)strncpy(scriptarg, &arg[strlen(scriptname)],
 			     strlen(arg) - strlen(scriptname));
-  sprintf(execstr,"%s %s %s %s",module->name,scriptname,
+  xasprintf(&execstr,"%s %s %s %s",module->name,scriptname,
 	  x11base->TabScriptId[x11base->NbChild + 2],scriptarg);
   free(scriptname);
   free(scriptarg);
@@ -654,11 +636,7 @@ static char *LaunchScript (int *NbArg,long *TabArg)
 /* GetScriptFather */
 static char *GetScriptFather (int *NbArg,long *TabArg)
 {
-  char *str;
-
-  str = fxcalloc(10, sizeof(char));
-  sprintf(str,"0");
-  return str;
+  return fxstrdup("0");
 }
 
 /* GetTime */
@@ -667,9 +645,8 @@ static char *GetTime (int *NbArg,long *TabArg)
   char *str;
   time_t t;
 
-  str = fxcalloc(20, sizeof(char));
   t = time(NULL);
-  sprintf(str,"%lld",(long long)t-x11base->BeginTime);
+  xasprintf(&str,"%lld",(long long)t-x11base->BeginTime);
   return str;
 }
 
@@ -715,8 +692,7 @@ static char *ReceivFromScript (int *NbArg,long *TabArg)
   send = (int)atoi(arg);
   free(arg);
 
-  msg = fxcalloc(256, sizeof(char));
-  sprintf(msg,"No message");
+  msg = fxstrdup("No message");
 
   /* Get atoms */
   AReceiv = XInternAtom(dpy,x11base->TabScriptId[1],True);
@@ -778,8 +754,7 @@ static char *FuncGetPid(int *NbArg,long *TabArg)
   pid_t pid;
 
   pid = getpid();
-  str = fxcalloc(1, 20);
-  sprintf(str,"%d",pid);
+  xasprintf(&str,"%d",pid);
   return str;
 }
 
@@ -813,9 +788,7 @@ static char *FuncSendMsgAndGet(int *NbArg,long *TabArg)
   free(tmp);
 
   setFvwmUserDir();
-  in_fifo =
-    fxcalloc(strlen(com_name) + strlen(FvwmUserDir) + 14, sizeof(char));
-  sprintf(in_fifo,"%s/.tmp-com-in-%s",FvwmUserDir,com_name);
+  xasprintf(&in_fifo,"%s/.tmp-com-in-%s",FvwmUserDir,com_name);
 
   /* unlock the receiver, wait IN_FIFO_TIMEOUT * IN_FIFO_NBR_OF_TRY so that *
    * the receiver has the time to go in its communication loop at startup   *
@@ -871,16 +844,12 @@ static char *FuncSendMsgAndGet(int *NbArg,long *TabArg)
   {
     free(cmd);
     free(com_name);
-    str=fxcalloc(2, sizeof(char));
-    sprintf(str,(err) ? "0" : "1");
-    return str;
+    return fxstrdup(err ? "0" : "1");
   }
 
   /* get the answer from the receiver.                              *
    * we wait OUT_FIFO_TIMEOUT * OUT_FIFO_NBR_OF_TRY for this answer */
-  out_fifo =
-    fxcalloc(strlen(com_name) + strlen(FvwmUserDir) + 15, sizeof(char));
-  sprintf(out_fifo,"%s/.tmp-com-out-%s",FvwmUserDir,com_name);
+  xasprintf(&out_fifo,"%s/.tmp-com-out-%s",FvwmUserDir,com_name);
   i = 0;
   while(1)
   {
@@ -929,9 +898,7 @@ static char *FuncSendMsgAndGet(int *NbArg,long *TabArg)
   {
     if (buf)
       free(buf);
-    str=fxcalloc(2, sizeof(char));
-    sprintf(str,"0");
-    return str;
+    return fxstrdup("0");
   }
   l = strlen(buf);
   str=fxcalloc(l + 1, sizeof(char));
@@ -1573,8 +1540,7 @@ static void IfThen (int NbArg,long *TabArg)
     if (TabArg[j] > 100000)     /* Number coding case */
     {
       i = (int)TabArg[j] - 200000;
-      arg[CurrArg] = fxcalloc(1, sizeof(char) * 10);
-      sprintf(arg[CurrArg],"%d",i);
+      xasprintf(&arg[CurrArg],"%d",i);
       CurrArg++;
     }
     else if (TabArg[j] < -200000)/* Comparison function ID case */
@@ -1622,8 +1588,7 @@ static void Loop (int NbArg,long *TabArg)
     {
       int x;
       x = (int)TabArg[i] - 200000;
-      arg[CurrArg] = fxcalloc(1, sizeof(char) * 10);
-      sprintf(arg[CurrArg],"%d",x);
+      xasprintf(&arg[CurrArg],"%d",x);
     }
     else if (TabArg[i] < -100000)       /* Function ID case */
     {
@@ -1715,8 +1680,8 @@ static void WriteToFile (int NbArg,long *TabArg)
     arg[1][i+1] = '\0';
   }
 
-  sprintf(StrEnd,"#end\n");
-  sprintf(StrBegin,"#%s,",ScriptName);
+  strlcpy(StrEnd,"#end\n",sizeof(StrEnd));
+  snprintf(StrBegin,sizeof(StrBegin),"#%s,",ScriptName);
 
   buf=fxcalloc(1, maxsize);
 
@@ -1724,10 +1689,8 @@ static void WriteToFile (int NbArg,long *TabArg)
   {
     file = fxstrdup(arg[0]);
     home = getenv("HOME");
-    arg[0] = fxrealloc(arg[0],
-                      sizeof(char) * (strlen(arg[0]) + 4 + strlen(home)),
-                      sizeof(arg[0]));
-    sprintf(arg[0],"%s/%s",home,file);
+    free(arg[0]);
+    xasprintf(&arg[0],"%s/%s",home,file);
     free(file);
   }
   f = fopen(arg[0],"a+");
@@ -1740,14 +1703,16 @@ static void WriteToFile (int NbArg,long *TabArg)
   }
   if (CurrPos==size)
   {
-    sprintf(buf + strlen(buf),"\n%s%d\n%s%s\n",StrBegin,getpid(),arg[1],StrEnd);
+    size_t l = strlen(buf);
+    if (l < maxsize)
+      snprintf(buf + l, maxsize - l, "\n%s%d\n%s%s\n",StrBegin,getpid(),arg[1],StrEnd);
   }
   else
   {
     sscanf(&buf[CurrPos+strlen(StrBegin)],"%d",&OldPID);
     if (OldPID == getpid())
     {
-      sprintf(str,"%d\n",OldPID);
+      snprintf(str,sizeof(str),"%d\n",OldPID);
       while(((strncmp(StrEnd,&buf[CurrPos],strlen(StrEnd))) != 0) &&
 	    (CurrPos<size))
       {
@@ -1765,7 +1730,7 @@ static void WriteToFile (int NbArg,long *TabArg)
       {
 	CurrPos2++;
       }
-      sprintf(str,"%d\n%s",getpid(),arg[1]);
+      snprintf(str,sizeof(str),"%d\n%s",getpid(),arg[1]);
       memmove(&buf[CurrPos+strlen(str)], &buf[CurrPos2], strlen(buf)-CurrPos2);
       buf[strlen(buf)-((CurrPos2-CurrPos)-strlen(str))] = '\0';
       memmove(&buf[CurrPos],str,strlen(str));
@@ -1812,8 +1777,7 @@ static void SendToScript (int NbArg,long *TabArg)
   }
 
   /* Compute Receiver */
-  R=fxcalloc(strlen(x11base->TabScriptId[dest]) + 1, sizeof(char));
-  sprintf(R,"%s",x11base->TabScriptId[dest]);
+  R=fxstrdup(x11base->TabScriptId[dest]);
   myatom=XInternAtom(dpy,R,True);
 
   if ((BuffSend.NbMsg<40)&&(XGetSelectionOwner(dpy,myatom)!=None))

--- a/modules/FvwmScript/Widgets/HScrollBar.c
+++ b/modules/FvwmScript/Widgets/HScrollBar.c
@@ -51,7 +51,7 @@ void DrawThumbH(struct XObj *xobj, XEvent *evp)
   XDrawSegments(dpy, xobj->win, xobj->gc, &segm, 1);
   XSetForeground(dpy, xobj->gc, xobj->TabColor[fore]);
 
-  sprintf(str, "%d", xobj->value);
+  snprintf(str, sizeof(str), "%d", xobj->value);
   x = x + 15 - (FlocaleTextWidth(xobj->Ffont, str, strlen(str)) / 2);
   y = y - xobj->Ffont->descent - 4;
   MyDrawString(dpy, xobj, xobj->win, x, y, str, fore, hili, back,
@@ -122,9 +122,9 @@ void InitHScrollBar(struct XObj *xobj)
   if (!((xobj->value >= xobj->value2) && (xobj->value <= xobj->value3)))
     xobj->value = xobj->value2;
   xobj->height = xobj->Ffont->height * 2 + 30;
-  sprintf(str, "%d", xobj->value2);
+  snprintf(str, sizeof(str), "%d", xobj->value2);
   i = FlocaleTextWidth(xobj->Ffont, str, strlen(str));
-  sprintf(str, "%d", xobj->value3);
+  snprintf(str, sizeof(str), "%d", xobj->value3);
   i = FlocaleTextWidth(xobj->Ffont, str, strlen(str)) + i + 20;
   if (xobj->width<i)
     xobj->width = i;
@@ -156,12 +156,12 @@ void DrawHScrollBar(struct XObj *xobj, XEvent *evp)
   DrawThumbH(xobj, evp);
   DrawReliefRect(x, y, w, h, xobj, shad, hili);
   /* Write values */
-  sprintf(str, "%d", xobj->value2);
+  snprintf(str, sizeof(str), "%d", xobj->value2);
   x = 4;
   y = y + xobj->Ffont->ascent + h;
   MyDrawString(dpy, xobj, xobj->win, x, y, str, fore, hili, back,
 	       !xobj->flags[1], NULL, evp);
-  sprintf(str, "%d", xobj->value3);
+  snprintf(str, sizeof(str), "%d", xobj->value3);
   x = w - FlocaleTextWidth(xobj->Ffont, str, strlen(str)) - 4;
   MyDrawString(dpy, xobj, xobj->win, x, y, str, fore, hili, back,
 	       !xobj->flags[1], NULL, evp);

--- a/modules/FvwmScript/Widgets/PushButton.c
+++ b/modules/FvwmScript/Widgets/PushButton.c
@@ -369,8 +369,7 @@ void EvtKeyPushButton(struct XObj *xobj, XKeyEvent *EvtKey)
 	carks2 = XKeysymToString(ks);
 	if (carks2 != NULL)
 	{
-		carks = (char*)calloc(sizeof(char), 30);
-		sprintf(carks, "%s", carks2);
+		carks = fxstrdup(carks2);
 		if (strcmp(carks, "Return") == 0)
 		{
 			xobj->value = 1;

--- a/modules/FvwmScript/Widgets/Swallow.c
+++ b/modules/FvwmScript/Widgets/Swallow.c
@@ -77,7 +77,6 @@ void InitSwallow(struct XObj *xobj)
 	XSetWindowAttributes Attr;
 	static char *my_sm_env = NULL;
 	static char *orig_sm_env = NULL;
-	static int len = 0;
 	static Bool sm_initialized = False;
 	static Bool session_manager = False;
 	char *cmd;
@@ -134,12 +133,9 @@ void InitSwallow(struct XObj *xobj)
 	if (my_sm_env == NULL)
 	{
 		my_sm_env = getenv("SESSION_MANAGER");
-		len = 45 + strlen(my_sm_env) + strlen(orig_sm_env);
 	}
 
-	cmd = fxmalloc(len + strlen(xobj->swallow));
-	sprintf(
-		cmd,
+	xasprintf(&cmd,
 		"FSMExecFuncWithSessionManagment \"%s\" \"%s\" \"%s\"",
 		my_sm_env, xobj->swallow, orig_sm_env);
 	SendText(fd, cmd, 0);
@@ -172,14 +168,12 @@ void CheckForHangon(struct XObj *xobj,unsigned long *body)
 {
 	char *cbody;
 
-	cbody=(char*)calloc(strlen((char *)&body[3]) + 1,sizeof(char));
-	sprintf(cbody,"%s",(char *)&body[3]);
+	cbody=fxstrdup((char *)&body[3]);
 	if(strcmp(cbody,xobj->title)==0)
 	{
 		xobj->win = (Window)body[0];
 		free(xobj->title);
-		xobj->title=(char*)calloc(sizeof(char),20);
-		sprintf(xobj->title,"No window");
+		xobj->title=fxstrdup("No window");
 		XUnmapWindow(dpy,xobj->win);
 		XSetWindowBorderWidth(dpy,xobj->win,0);
 	}
@@ -196,8 +190,8 @@ void swallow(struct XObj *xobj,unsigned long *body)
 			dpy,xobj->win,*xobj->ParentWin,xobj->x,xobj->y);
 		XResizeWindow(dpy,xobj->win,xobj->width,xobj->height);
 		XMapWindow(dpy,xobj->win);
-		sprintf(
-			cmd,"PropertyChange %u %u %lu %lu",
+		snprintf(cmd, sizeof(cmd),
+			"PropertyChange %u %u %lu %lu",
 			MX_PROPERTY_CHANGE_SWALLOW, 1, xobj->win,
 			(x11base->swallower_win)?
 			x11base->swallower_win:x11base->win);

--- a/modules/FvwmScript/Widgets/TextField.c
+++ b/modules/FvwmScript/Widgets/TextField.c
@@ -607,8 +607,7 @@ void EvtKeyTextField(struct XObj *xobj,XKeyEvent *EvtKey)
 
 	if (carks2!=NULL)
 	{
-		carks=(char*)calloc(sizeof(char),30);
-		sprintf(carks,"%s",carks2);
+		carks=fxstrdup(carks2);
 		if (strcmp(carks,"Right")==0)
 		{
 			/* if we are at the end, don't go further */

--- a/modules/FvwmScript/Widgets/VScrollBar.c
+++ b/modules/FvwmScript/Widgets/VScrollBar.c
@@ -51,7 +51,7 @@ void DrawThumbV(struct XObj *xobj, XEvent *evp)
 	XDrawSegments(dpy, xobj->win, xobj->gc, &segm, 1);
 	XSetForeground(dpy, xobj->gc, xobj->TabColor[fore]);
 
-	sprintf(str, "%d", xobj->value);
+	snprintf(str, sizeof(str), "%d", xobj->value);
 	x = x-FlocaleTextWidth(xobj->Ffont, str, strlen(str))-6;
 	y = y + 13 + xobj->Ffont->ascent/2;
 	MyDrawString(dpy, xobj, xobj->win, x, y, str, fore, hili, back,
@@ -68,7 +68,7 @@ void HideThumbV(struct XObj *xobj)
 		(xobj->height - 36) * (xobj->value - xobj->value3) /
 		(xobj->value2 - xobj->value3);
 	XClearArea(dpy, xobj->win, x, y, 20, 32, False);
-	sprintf(str, "%d", xobj->value);
+	snprintf(str, sizeof(str), "%d", xobj->value);
 	XClearArea(
 		dpy, xobj->win, 0, 0,xobj->width/2 - 14,xobj->height, False);
 }
@@ -129,9 +129,9 @@ void InitVScrollBar(struct XObj *xobj)
 	i = (xobj->Ffont->height)*2+30;
 	if (xobj->height < i)
 		xobj->height = i;
-	sprintf(str, "%d", xobj->value2);
+	snprintf(str, sizeof(str), "%d", xobj->value2);
 	i = FlocaleTextWidth(xobj->Ffont, str, strlen(str));
-	sprintf(str, "%d", xobj->value3);
+	snprintf(str, sizeof(str), "%d", xobj->value3);
 	j = FlocaleTextWidth(xobj->Ffont, str, strlen(str));
 	if (i<j)
 		i = j*2+30;
@@ -168,10 +168,10 @@ void DrawVScrollBar(struct XObj *xobj, XEvent *evp)
 	/* Write values */
 	x = x + 26;
 	y = xobj->Ffont->ascent + 2;
-	sprintf(str, "%d", xobj->value3);
+	snprintf(str, sizeof(str), "%d", xobj->value3);
 	MyDrawString(dpy, xobj, xobj->win, x, y, str, fore, hili, back,
 		     !xobj->flags[1], NULL, evp);
-	sprintf(str, "%d", xobj->value2);
+	snprintf(str, sizeof(str), "%d", xobj->value2);
 	y = h - xobj->Ffont->descent - 2;
 	MyDrawString(dpy, xobj, xobj->win, x, y, str, fore, hili, back,
 		     !xobj->flags[1], NULL, evp);


### PR DESCRIPTION
First of all, sorry for the long, boring diff!

While fixing the time_t casting i noticed a few `sprintf` calls and so I started to convert them to `snprintf` to avoid mangling the stack on overflow.  Well... it took a bit longer than what I expected!  There are still some strcat/strcpy/sprintf around, I changed only the "easy" ones, the majority of the diff is mechanical.

I'm quite confident of the changes and I've played a bit with Xephyr and it didn't explode, but it definitely needs more testing as I'm not sure how to trigger all those code paths.
