### PR TITLE
FvwmScript.c: fix wrong size of TabCom array

### DIFF
--- a/modules/FvwmScript/FvwmScript.c
+++ b/modules/FvwmScript/FvwmScript.c
@@ -78,7 +78,7 @@ Window ref;
 FlocaleWinString *FwinString;
 
 extern int yyparse(void);
-extern void (*TabCom[25]) (int NbArg,long *TabArg);
+extern void (*TabCom[]) (int NbArg,long *TabArg);
 
 Display *dpy;
 int screen;


### PR DESCRIPTION
Fix an error: TabCom has an explicit length in the declaration, it does not match the actual length.

FvwmScript.c:81:15: warning: type of TabCom does not match original declaration
81 | extern void (*TabCom[25]) (int NbArg,long *TabArg);
| ^
Instructions.c:37:8: note: array types have different bounds
37 | void (*TabCom[29]) (int NbArg,long *TabArg);
| ^
Instructions.c:37:8: note: TabCom was previously declared here