### PR TITLE
deprecate color commands

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -5158,8 +5158,7 @@ _StaysPut_, _Sticky_ / _Slippery_, _StickyAcrossPages_ /
 _!StickyAcrossPages_, _StickyAcrossDesks_ / _!StickyAcrossDesks_,
 _!StickyStippledTitle_ / _StickyStippledTitle_,
 _!StickyStippledIconTitle_ / _StickyStippledIconTitle_, _StartIconic_
-/ _StartNormal_, _Color_, _ForeColor_, _BackColor_, _Colorset_,
-_HilightFore_, _HilightBack_, _HilightColorset_, _BorderColorset_,
+/ _StartNormal_,  _Colorset_, _HilightColorset_, _BorderColorset_,
 _HilightBorderColorset_, _IconTitleColorset_,
 _HilightIconTitleColorset_, _IconBackgroundColorset_,
 _IconTitleRelief_, _IconBackgroundRelief_, _IconBackgroundPadding_,
@@ -5441,23 +5440,12 @@ _StickyAcrossPages_ or _StickyAcrossDesks_ style. _!StippledTitle_
 reverts back to normal titles. _StippledTitleOff_ is equivalent to
 _!StippledTitle_ but is deprecated.
 +
-_Color_ takes two arguments. The first is the window-label text
-color and the second is the window decorations normal background
-color. The two colors are separated with a slash. If the use of a
-slash causes problems then the separate _ForeColor_ and _BackColor_
-options can be used.
-+
 *Colorset* takes the colorset number as its sole argument and
 overrides the colors set by _Color_. Instead, the corresponding
 colors from the given colorset are used. Note that all other
 features of a colorset are not used. Use the *Colorset* decoration
 style in the *TitleStyle* and _ButtonStyle_ command for that. To
 stop using the colorset, the colorset number is omitted.
-+
-The _HilightFore_, _HilightBack_ and _HilightColorset_ style options
-work exactly like _ForeColor_, _BackColor_ and _Colorset_ but are
-used only if the window has the focus. These styles replace the old
-commands *HilightColor* and _HilightColorset_.
 +
 _BorderColorset_ takes eight positive integers as its arguments and will
 apply the given colorsets to the eight individual components of the window
@@ -6868,8 +6856,7 @@ AddToDecor FlatDecor
 + BorderStyle -- HiddenHandles NoInset
 
 Style FlatStyle \
-	UseDecor FlatDecor, HandleWidth 4, ForeColor white, \
-	BackColor grey40, HilightFore black, HilightBack grey70
+	UseDecor FlatDecor, HandleWidth 4, Colorset 0, HilightColorset 1
 
 Style xterm UseStyle FlatStyle
 ....

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -627,10 +627,6 @@ typedef struct window_style
 	signed char icon_title_relief;
 	char *icon_font;
 	char *window_font;
-	char *fore_color_name;
-	char *back_color_name;
-	char *fore_color_name_hi;
-	char *back_color_name_hi;
 	int colorset;
 	int colorset_hi;
 	int border_colorset[BP_SIZE];

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -18,10 +18,6 @@
 	((sf)->do_start_shaded)
 #define SHAS_BORDER_WIDTH(sf) \
 	((sf)->has_border_width)
-#define SHAS_COLOR_BACK(sf) \
-	((sf)->has_color_back)
-#define SHAS_COLOR_FORE(sf) \
-	((sf)->has_color_fore)
 #define SHAS_HANDLE_WIDTH(sf) \
 	((sf)->has_handle_width)
 #define SHAS_ICON(sf) \
@@ -426,22 +422,6 @@
 	((s).decor_name)
 #define SSET_DECOR_NAME(s,x) \
 	((s).decor_name = (x))
-#define SGET_FORE_COLOR_NAME(s) \
-	((s).fore_color_name)
-#define SSET_FORE_COLOR_NAME(s,x) \
-	((s).fore_color_name = (x))
-#define SGET_BACK_COLOR_NAME(s) \
-	((s).back_color_name)
-#define SSET_BACK_COLOR_NAME(s,x) \
-	((s).back_color_name = (x))
-#define SGET_FORE_COLOR_NAME_HI(s) \
-	((s).fore_color_name_hi)
-#define SSET_FORE_COLOR_NAME_HI(s,x) \
-	((s).fore_color_name_hi = (x))
-#define SGET_BACK_COLOR_NAME_HI(s) \
-	((s).back_color_name_hi)
-#define SSET_BACK_COLOR_NAME_HI(s,x) \
-	((s).back_color_name_hi = (x))
 #define SGET_ICON_FONT(s) \
 	((s).icon_font)
 #define SSET_ICON_FONT(s,x) \


### PR DESCRIPTION
Colorsets have been around long enough that the logic is such that the
older colour commands are never considered.  Thefore, remove the
following commands:

Color
ForeColor
BackColor
HilightFore
HilightBack

This is just in context of fvwm itself.  There will be existing modules
which use the terms `backcolor` and `forecolor`, but that's not
referring to this change.

Fixes #735
