### PR TITLE
Ensure a default colorset is always configured.

### DIFF
--- a/fvwm/ConfigFvwmDefaults
+++ b/fvwm/ConfigFvwmDefaults
@@ -56,6 +56,11 @@ Style * EWMHPlacementUseDynamicWorkingArea, EWMHMaximizeUseDynamicWorkingArea
 Style fvwm_menu NoPPosition, NeverFocus, NoLenience, \
 	WindowListSkip, CirculateSkip
 
+# Default colorsets to ensure they are set.
+Colorset 0 fg black, bg grey
+Colorset 1 fg black, bg grey25
+Style * Colorset 1, BorderColorset 1, HilightColorset 0, HilightBorderColorset 0
+
 # Alt-Tab:
 Key Tab A M WindowList Root c c NoDeskSort
 


### PR DESCRIPTION
Set a default colorset for active and inactive windows to ensure it is always configured if a user doesn't configure it themselves.

With removing the old color methods, no default colorset is being set (test using a blank config `fvwm3 -c /dev/null`). This ensures that a default colorset both both active and inactive windows is always configured.