### PR TITLE
Update Move shuffle logic to jump to next monitor

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -4009,14 +4009,18 @@ To move a window in a given direction until it hits another window, icon,
 or screen boundary use:
 +
 
-> *Move* shuffle [Warp] [snap _type_] [layers _min_ _max_] _direction_(s)
+> *Move* shuffle [Warp] [ewmhiwa] [snap _type_] [layers _min_ _max_] _direction_(s)
 
 +
 The _direction_ can be _North_/_N_/_Up_/_U_, _East_/_E_/_Right_/_R_,
 _South_/_S_/_Down_/_D_, or _West_/_W_/_Left_/_L_. The window will move
-in the given direction until it hits another window, the *EwmhBaseStruts*,
-or the screen boundary. If multiple _direction_(s) are given, the window
-will move the directions in the order of the sequence stated.
+in the given direction until it hits another window or the
+*EwmhBaseStruts*/screen boundary. When a window is at the
+*EwmhBaseStruts*/screen boundary, it will move to the next monitor
+in the given direction, if it exists. Windows will honor the EWMH
+working area and stop at the *EwmhBaseStruts* unless the literal
+option _ewmhiwa_ is given. If multiple _direction_(s) are given,
+the window will move the directions in the order of the sequence stated.
 +
 The literal option _Warp_ will warp the mouse pointer to the window.
 If the literal option _snap_ followed by a snap _type_ of _windows_,


### PR DESCRIPTION
When using Move shuffle to move a window until it hits the next window/icon/screen edge in a given direction, windows at the EwmhBaseStruts/screen edge will move to the edge of the monitor, instead of the first object they hit.

By default the edge of the current and next monitor is computed using EwmhBaseStruts, unless the new option 'ewmhiwa' is included, in which case the EwmhBaseStruts are completely ignored and the monitor edges are used instead.

Note it is now no longer possible to shuffle to both the EwmhBaseStruts and the monitor edge. It will use one or the other but not both. If there is a panel at the EwmhBaseStruts, then with `ewmhiwa` it will still stop at the panel since it hit a window, and then will go to the screen edge after that.