### PR TITLE
Don't set border colorsets by default.

### DIFF
--- a/fvwm/ConfigFvwmDefaults
+++ b/fvwm/ConfigFvwmDefaults
@@ -59,7 +59,7 @@ Style fvwm_menu NoPPosition, NeverFocus, NoLenience, \
 # Default colorsets to ensure they are set.
 Colorset 0 fg black, bg grey
 Colorset 1 fg black, bg grey25
-Style * Colorset 1, BorderColorset 1, HilightColorset 0, HilightBorderColorset 0
+Style * Colorset 1, HilightColorset 0
 
 # Alt-Tab:
 Key Tab A M WindowList Root c c NoDeskSort

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -5219,9 +5219,9 @@ void update_window_color_hi_style(FvwmWindow *fw, window_style *pstyle)
 
 		for (i = 0; i < BP_SIZE; i++) {
 			fw->border_cs_hi[i] = -1;
-			fw->border_hicolors[i].hilight = fw->colors.hilight;
-			fw->border_hicolors[i].shadow = fw->colors.shadow;
-			fw->border_hicolors[i].back = fw->colors.back;
+			fw->border_hicolors[i].hilight = fw->hicolors.hilight;
+			fw->border_hicolors[i].shadow = fw->hicolors.shadow;
+			fw->border_hicolors[i].back = fw->hicolors.back;
 		}
 	}
 }


### PR DESCRIPTION
  By default the BorderColorset and HilightBorderColorset should
  not be set, as they will default to using the Colorset and
  HilightColorset. In addition fix HilightColorset to correctly
  set the border colorsets using the HilightColorset and not
  the Colorset colors.