### PR TITLE
commands: remove DefaultColors & DefaultColorset

### DIFF
--- a/dev-docs/COMMANDS
+++ b/dev-docs/COMMANDS
@@ -30,8 +30,6 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   Current               - Operate on the currently focused window
   CursorMove            - Move the cursor pointer non interactively
   CursorStyle           - Define different cursor pointer shapes and colors
-  DefaultColors         - Set colors for the feedback window (will be obsolete)
-  DefaultColorset       - Set colors for the Move/Resize feedback window
   DefaultFont           - The default font to use (mainly for feedback window)
   DefaultIcon           - The default icon to use for iconified windows
   DefaultLayers         - Set StaysOnBottom, StaysPut, StaysOnTop layer numbers

--- a/dev-docs/PARSING.md
+++ b/dev-docs/PARSING.md
@@ -876,13 +876,6 @@ CURSORSTYLEXOPTION =/ "fg"
 CURSORSTYLEXOPTION =/ "bg"
 ```
 ```
-CMD_DEFAULTCOLORS = "DefaultColors" [(COLOUR_FG] / "-") [(COLOUR_BG - "/")]
-; XXX - We need to represent colour values here --- RGB.txt, etc.
-```
-```
-CMD_DEFAULTCOLORSET = "DefaultColorset" (COLORSET_NUM / "-1")
-```
-```
 CMD_DEFAULTFONT = "DefaultFont" [FONTNAME]
 ```
 ```

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -3301,27 +3301,6 @@ used with monochrome cursors. Otherwise they are silently ignored.
 CursorStyle ROOT nice_arrow.xpm yellow black
 ....
 
-*DefaultColors* [_foreground_] [_background_]::
-	*DefaultColors* sets the default foreground and background colors used
-	in miscellaneous windows created by fvwm, for example in the geometry
-	feedback windows during a move or resize operation. If you do not want
-	to change one color or the other, use - as its color name. To revert
-	to the built-in default colors omit both color names. Note that the
-	default colors are not used in menus, window titles or icon titles.
-
-*DefaultColorset* [_num_]::
-	*DefaultColorset* sets the colorset used by the windows controlled by
-	the *DefaultColors* command. To revert back to the *DefaultColors*
-	colors use
-+
-
-....
-DefaultColorset -1
-....
-
-+
-or any variant of the *DefaultColors* command.
-
 *DefaultFont* [_fontname_]::
 	*DefaultFont* sets the default font to font _fontname_. The default
 	font is used by fvwm whenever no other font has been specified. To

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -1400,7 +1400,7 @@ void ApplyDefaultFontAndColors(void)
 {
 	XGCValues gcv;
 	unsigned long gcm;
-	int cset = Scr.DefaultColorset;
+	int cset = 0;
 
 	/* make GC's */
 	gcm = GCFunction|GCLineWidth|GCForeground|GCBackground;
@@ -1411,16 +1411,9 @@ void ApplyDefaultFontAndColors(void)
 		gcv.font = Scr.DefaultFont->font->fid;
 	}
 	gcv.line_width = 0;
-	if (cset >= 0)
-	{
-		gcv.foreground = Colorset[cset].fg;
-		gcv.background = Colorset[cset].bg;
-	}
-	else
-	{
-		gcv.foreground = Scr.StdFore;
-		gcv.background = Scr.StdBack;
-	}
+	gcv.foreground = Colorset[cset].fg;
+	gcv.background = Colorset[cset].bg;
+
 	if (Scr.StdGC)
 	{
 		XChangeGC(dpy, Scr.StdGC, gcm, &gcv);
@@ -1431,14 +1424,8 @@ void ApplyDefaultFontAndColors(void)
 	}
 
 	gcm = GCFunction|GCLineWidth|GCForeground;
-	if (cset >= 0)
-	{
-		gcv.foreground = Colorset[cset].hilite;
-	}
-	else
-	{
-		gcv.foreground = Scr.StdHilite;
-	}
+	gcv.foreground = Colorset[cset].hilite;
+
 	if (Scr.StdReliefGC)
 	{
 		XChangeGC(dpy, Scr.StdReliefGC, gcm, &gcv);
@@ -1448,14 +1435,8 @@ void ApplyDefaultFontAndColors(void)
 		Scr.StdReliefGC = fvwmlib_XCreateGC(
 			dpy, Scr.NoFocusWin, gcm, &gcv);
 	}
-	if (cset >= 0)
-	{
-		gcv.foreground = Colorset[cset].shadow;
-	}
-	else
-	{
-		gcv.foreground = Scr.StdShadow;
-	}
+
+	gcv.foreground = Colorset[cset].shadow;
 	if (Scr.StdShadowGC)
 	{
 		XChangeGC(dpy, Scr.StdShadowGC, gcm, &gcv);
@@ -2209,11 +2190,8 @@ void reset_decor_changes(void)
 
 void update_fvwm_colorset(int cset)
 {
-	if (cset == Scr.DefaultColorset)
-	{
-		Scr.flags.do_need_window_update = 1;
-		Scr.flags.has_default_color_changed = 1;
-	}
+	Scr.flags.do_need_window_update = 1;
+
 	UpdateMenuColorset(cset);
 	update_style_colorset(cset);
 	update_decors_colorset(cset);
@@ -3051,66 +3029,6 @@ void CMD_DefaultIcon(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DefaultColorset(F_CMD_ARGS)
-{
-	int cset;
-
-	if (GetIntegerArguments(action, NULL, &cset, 1) != 1)
-	{
-		return;
-	}
-	Scr.DefaultColorset = cset;
-	if (Scr.DefaultColorset < 0)
-	{
-		Scr.DefaultColorset = -1;
-	}
-	alloc_colorset(Scr.DefaultColorset);
-	Scr.flags.do_need_window_update = 1;
-	Scr.flags.has_default_color_changed = 1;
-
-	return;
-}
-
-void CMD_DefaultColors(F_CMD_ARGS)
-{
-	char *fore = NULL;
-	char *back = NULL;
-
-	action = GetNextToken(action, &fore);
-	if (action)
-	{
-		action = GetNextToken(action, &back);
-	}
-	if (!back)
-	{
-		back = fxstrdup(DEFAULT_BACK_COLOR);
-	}
-	if (!fore)
-	{
-		fore = fxstrdup(DEFAULT_FORE_COLOR);
-	}
-	if (!StrEquals(fore, "-"))
-	{
-		PictureFreeColors(dpy, Pcmap, &Scr.StdFore, 1, 0, True);
-		Scr.StdFore = GetColor(fore);
-	}
-	if (!StrEquals(back, "-"))
-	{
-		PictureFreeColors(dpy, Pcmap, &Scr.StdBack, 3, 0, True);
-		Scr.StdBack = GetColor(back);
-		Scr.StdHilite = GetHilite(Scr.StdBack);
-		Scr.StdShadow = GetShadow(Scr.StdBack);
-	}
-	free(fore);
-	free(back);
-
-	Scr.DefaultColorset = -1;
-	Scr.flags.do_need_window_update = 1;
-	Scr.flags.has_default_color_changed = 1;
-
-	return;
-}
-
 void CMD_DefaultFont(F_CMD_ARGS)
 {
 	char *font;
@@ -3747,7 +3665,6 @@ void CMD_Emulate(F_CMD_ARGS)
 
 	Scr.flags.do_need_window_update = 1;
 	Scr.flags.has_default_font_changed = 1;
-	Scr.flags.has_default_color_changed = 1;
 
 	return;
 }

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -228,8 +228,6 @@ void CMD_CopyMenuStyle(F_CMD_ARGS);
 void CMD_Current(F_CMD_ARGS);
 void CMD_CursorMove(F_CMD_ARGS);
 void CMD_CursorStyle(F_CMD_ARGS);
-void CMD_DefaultColors(F_CMD_ARGS);
-void CMD_DefaultColorset(F_CMD_ARGS);
 void CMD_DefaultFont(F_CMD_ARGS);
 void CMD_DefaultIcon(F_CMD_ARGS);
 void CMD_DefaultLayers(F_CMD_ARGS);

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -152,13 +152,6 @@ const func_t func_table[] =
 	CMD_ENT("cursorstyle", CMD_CursorStyle, F_CURSOR_STYLE, 0, 0),
 	/* - Define different cursor pointer shapes and colors */
 
-	CMD_ENT("defaultcolors", CMD_DefaultColors, F_DFLT_COLORS, 0, 0),
-	/* - Set colors for the feedback window (will be obsolete) */
-
-	CMD_ENT("defaultcolorset", CMD_DefaultColorset, F_DFLT_COLORSET,
-		0, 0),
-	/* - Set colors for the Move/Resize feedback window */
-
 	CMD_ENT("defaultfont", CMD_DefaultFont, F_DFLT_FONT, 0, 0),
 	/* - The default font to use (mainly for feedback window) */
 

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1092,7 +1092,6 @@ static void InitVariables(void)
 	menus_init();
 	Scr.last_added_item.type = ADDED_NONE;
 	Scr.DefaultIcon = NULL;
-	Scr.DefaultColorset = -1;
 	Scr.StdGC = 0;
 	Scr.StdReliefGC = 0;
 	Scr.StdShadowGC = 0;
@@ -1320,7 +1319,6 @@ static void SetRCDefaults(void)
 		 * configuration which defines these and more.
 		 */
 		{ "DefaultFont", "", "" },
-		{ "DefaultColors black grey", "", "" },
 		{ DEFAULT_MENU_STYLE, "", "" },
 		{ "TitleStyle Centered -- Raised", "", "" },
 		{ "Style * Color lightgrey/dimgrey", "", "" },
@@ -2511,7 +2509,9 @@ int main(int argc, char **argv)
 			PictureBlackPixel(), PictureWhitePixel(), Pdepth);
 	}
 
-	attributes.background_pixel = Scr.StdBack;
+	int cs = 0;
+
+	attributes.background_pixel = Colorset[cs].bg;
 	attributes.colormap = Pcmap;
 	attributes.border_pixel = 0;
 	valuemask = CWBackPixel | CWColormap | CWBorderPixel;

--- a/fvwm/icons.c
+++ b/fvwm/icons.c
@@ -497,6 +497,8 @@ void GetIconPicture(FvwmWindow *fw, Bool no_icon_window)
  */
 static void set_icon_pixmap_background(FvwmWindow *fw)
 {
+	int cs = 0;
+
 	if (fw->iconPixmap != None &&
 	    (Pdefault || fw->iconDepth == 1 || fw->iconDepth == Pdepth ||
 	     IS_PIXMAP_OURS(fw)))
@@ -516,13 +518,13 @@ static void set_icon_pixmap_background(FvwmWindow *fw)
 			XSetWindowBackgroundPixmap(
 				dpy, FW_W_ICON_PIXMAP(fw), ParentRelative);
 		}
-		else if (Scr.DefaultColorset >= 0)
+		else
 		{
 			SetWindowBackground(
 				dpy, FW_W_ICON_PIXMAP(fw),
 				fw->icon_g.picture_w_g.width,
 				fw->icon_g.picture_w_g.height,
-				&Colorset[Scr.DefaultColorset], Pdepth,
+				&Colorset[cs], Pdepth,
 				Scr.StdGC, False);
 		}
 	}
@@ -543,6 +545,7 @@ void CreateIconWindow(FvwmWindow *fw, int def_x, int def_y)
 	Window old_icon_pixmap_w;
 	Window old_icon_w;
 	Bool is_old_icon_shaped = IS_ICON_SHAPED(fw);
+	int cs = 0;
 
 	old_icon_w = FW_W_ICON_TITLE(fw);
 	old_icon_pixmap_w = (IS_ICON_OURS(fw)) ? FW_W_ICON_PIXMAP(fw) : None;
@@ -598,7 +601,7 @@ void CreateIconWindow(FvwmWindow *fw, int def_x, int def_y)
 	valuemask = CWColormap | CWBorderPixel | CWBackPixel | CWCursor |
 		CWEventMask;
 	attributes.colormap = Pcmap;
-	attributes.background_pixel = Scr.StdBack;
+	attributes.background_pixel = Colorset[cs].bg;
 	attributes.cursor = Scr.FvwmCursors[CRS_DEFAULT];
 	attributes.border_pixel = 0;
 	attributes.event_mask = XEVMASK_ICONW;
@@ -632,14 +635,11 @@ void CreateIconWindow(FvwmWindow *fw, int def_x, int def_y)
 				fw->icon_g.title_w_g.height);
 		}
 	}
-	if (Scr.DefaultColorset >= 0)
-	{
-		SetWindowBackground(
-			dpy, FW_W_ICON_TITLE(fw), fw->icon_g.title_w_g.width,
-			fw->icon_g.title_w_g.height,
-			&Colorset[Scr.DefaultColorset], Pdepth, Scr.StdGC,
-			False);
-	}
+	SetWindowBackground(
+		dpy, FW_W_ICON_TITLE(fw), fw->icon_g.title_w_g.width,
+		fw->icon_g.title_w_g.height,
+		&Colorset[cs], Pdepth, Scr.StdGC,
+		False);
 
 	/*
 	 * create the icon picture window

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -1121,7 +1121,7 @@ static void position_geometry_window(const XEvent *eventp)
 void resize_geometry_window(void)
 {
 	size_rect s;
-	int cset = Scr.DefaultColorset;
+	int cset = 0;
 
 	if (Scr.SizeWindow.cset >= 0)
 		cset = Scr.SizeWindow.cset;
@@ -1143,12 +1143,6 @@ void resize_geometry_window(void)
 			dpy, Scr.SizeWindow.win, s.width, s.height,
 			&Colorset[cset], Pdepth, Scr.StdGC, False);
 	}
-	else
-	{
-		XSetWindowBackground(dpy, Scr.SizeWindow.win, Scr.StdBack);
-	}
-
-	return;
 }
 
 static void display_string(Bool Init, char *str)
@@ -1158,20 +1152,15 @@ static void display_string(Bool Init, char *str)
 	GC reliefGC;
 	GC shadowGC;
 	int offset;
+	int cs;
 	FlocaleWinString fstr;
 
 	memset(&fstr, 0, sizeof(fstr));
 
-	if (Scr.SizeWindow.cset >= 0)
-	{
-		fstr.colorset = &Colorset[Scr.SizeWindow.cset];
-		fstr.flags.has_colorset = True;
-	}
-	else if (Scr.DefaultColorset >= 0)
-	{
-		fstr.colorset = &Colorset[Scr.DefaultColorset];
-		fstr.flags.has_colorset = True;
-	}
+	cs = Scr.SizeWindow.cset > 0 ? Scr.SizeWindow.cset : 0;
+
+	fstr.colorset = &Colorset[cs];
+	fstr.flags.has_colorset = True;
 
 	if (Init)
 	{

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -362,7 +362,6 @@ typedef struct ScreenInfo
 	/* GC for transparency masks */
 	GC TransMaskGC;
 	/* don't change the order */
-	Pixel StdFore, StdBack, StdHilite, StdShadow;
 	GC StdGC;
 	GC StdReliefGC;
 	GC StdShadowGC;
@@ -427,9 +426,6 @@ typedef struct ScreenInfo
 	int ColormapFocus;
 	/* Limit on colors used in pixmaps */
 	int ColorLimit;
-	/* Default Colorset used by feedback window */
-	int DefaultColorset;
-
 	int use_backing_store;
 
 	/* some additional global options which will probably become window
@@ -468,7 +464,6 @@ typedef struct ScreenInfo
 		unsigned do_need_style_list_update : 1;
 		unsigned do_need_window_update : 1;
 		unsigned do_save_under : 1;
-		unsigned has_default_color_changed : 1;
 		unsigned has_default_font_changed : 1;
 		unsigned has_mouse_binding_changed : 1;
 		unsigned has_nr_buttons_changed : 1;

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -5140,16 +5140,12 @@ void update_style_colorset(int colorset)
 /* Update fore and back colours for a specific window */
 void update_window_color_style(FvwmWindow *fw, window_style *pstyle)
 {
-	int cs = Scr.DefaultColorset;
+	int cs = 0;
 
 	if (SUSE_COLORSET(&pstyle->flags))
 	{
 		cs = SGET_COLORSET(*pstyle);
 		fw->cs = cs;
-	}
-	else
-	{
-		fw->cs = -1;
 	}
 
 	fw->colors.fore = Colorset[cs].fg;
@@ -5184,18 +5180,13 @@ void update_window_color_style(FvwmWindow *fw, window_style *pstyle)
 
 void update_window_color_hi_style(FvwmWindow *fw, window_style *pstyle)
 {
-	int cs = Scr.DefaultColorset;
+	int cs = 0;
 
 	if (SUSE_COLORSET_HI(&pstyle->flags))
 	{
 		cs = SGET_COLORSET_HI(*pstyle);
 		fw->cs_hi = cs;
 	}
-	else
-	{
-		fw->cs_hi = -1;
-	}
-
 	fw->hicolors.fore = Colorset[cs].fg;
 	fw->hicolors.hilight = Colorset[cs].hilite;
 	fw->hicolors.shadow = Colorset[cs].shadow;

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -705,8 +705,7 @@ void flush_window_updates(void)
 	DeleteFocus(False);
 
 	/* Apply the new default font and colours first */
-	if (Scr.flags.has_default_color_changed ||
-	    Scr.flags.has_default_font_changed)
+	if (Scr.flags.has_default_font_changed)
 	{
 		ApplyDefaultFontAndColors();
 	}
@@ -766,7 +765,6 @@ void flush_window_updates(void)
 	reset_decor_changes();
 	Scr.flags.do_need_window_update = 0;
 	Scr.flags.has_default_font_changed = 0;
-	Scr.flags.has_default_color_changed = 0;
 	Scr.flags.has_mouse_binding_changed = 0;
 	Scr.flags.has_nr_buttons_changed = 0;
 


### PR DESCRIPTION
As with removing other colour commands, also remove DefaultColors and
DefaultColorset.  Now, Colorsets are the only way to reference specific
colours.  Since FvwmTheme was merged years ago, the older way of using
colours no longer makes sense.

Now, any default which has not been set will use Colorset 0, unless
otherwise defined.  Colorset 0 is set as a part of the default config
and is guaranteed to be set.

Fixes #748
