### PR TITLE
Add split manpages to default-config.

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -435,6 +435,11 @@ AddToMenu   MenuSendToPage
 DestroyMenu MenuFvwmManPages
 AddToMenu   MenuFvwmManPages "Help" Title
 + "fvwm3"         ViewManPage fvwm3
++ "fvwm3commands" ViewManPage fvwm3commands
++ "fvwm3styles"   ViewManPage fvwm3styles
++ "fvwm3menus"    ViewManPage fvwm3menus
++ "fvwm3all"      ViewManPage fvwm3all
++ "" Nop
 + "FvwmAnimate"   ViewManPage FvwmAnimate
 + "FvwmAuto"      ViewManPage FvwmAuto
 + "FvwmBacker"    ViewManPage FvwmBacker


### PR DESCRIPTION
  With the split of the fvwm manual pages, add all the manual
  pages to the Help menu in the default config.