### PR TITLE
FvwnIconMan use font as fallback for tips font.

### DIFF
--- a/modules/FvwmIconMan/x.c
+++ b/modules/FvwmIconMan/x.c
@@ -639,11 +639,14 @@ void X_init_manager (int man_id)
     ShutMeDown (1);
   }
 
-  if (man->tips_fontname == NULL)
-    man->tips_conf->Ffont = FlocaleLoadFont(theDisplay, NULL, MyName);
-  else
+  if (man->tips_fontname != NULL)
     man->tips_conf->Ffont = FlocaleLoadFont(
 	    theDisplay, man->tips_fontname, MyName);
+  else if (man->fontname != NULL)
+    man->tips_conf->Ffont = FlocaleLoadFont(
+	    theDisplay, man->fontname, MyName);
+  else
+    man->tips_conf->Ffont = FlocaleLoadFont(theDisplay, NULL, MyName);
 
   for ( i = 0; i < NUM_CONTEXTS; i++ ) {
     man->pixmap[i] = None;


### PR DESCRIPTION
If TipsFont is not set, use the Font setting instead of falling back to a default font.

Fixes #657 by insuring that TipsFont is set to the same font FvwmIconMan is using if it wasn't explicitly configured.