### PR TITLE
MenuStyle: Remove Depreciated options and non colorset 

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -2509,11 +2509,10 @@ using the *ChangeMenuStyle*. See also *DestroyMenuStyle*. When using
 monochrome color options are ignored.
 +
 _options_ is a comma separated list containing some of the keywords
-Fvwm / Mwm / Win, BorderWidth, Foreground, Background, Greyed,
-HilightBack / !HilightBack, HilightTitleBack, ActiveFore /
-!ActiveFore, MenuColorset, ActiveColorset, GreyedColorset,
+Fvwm / Mwm / Win, BorderWidth, HilightBack / !HilightBack, HilightTitleBack,
+ActiveFore / !ActiveFore, MenuColorset, ActiveColorset, GreyedColorset,
 TitleColorset, Hilight3DThick / Hilight3DThin / Hilight3DOff,
-Hilight3DThickness, Animation / !Animation, Font, TitleFont, MenuFace,
+Hilight3DThickness, Animation / !Animation, Font, TitleFont,
 PopupDelay, PopupOffset, TitleWarp / !TitleWarp, TitleUnderlines0 /
 TitleUnderlines1 / TitleUnderlines2, SeparatorsLong / SeparatorsShort,
 TrianglesSolid / TrianglesRelief, PopupImmediately / PopupDelayed,
@@ -2533,11 +2532,10 @@ prefixing ! to the option.
 +
 _Fvwm_, _Mwm_, _Win_ reset all options to the style with the same name
 in former versions of fvwm. The default for new menu styles is _Fvwm_
-style. These options override all others except _Foreground_,
-_Background_, _Greyed_, _HilightBack_, _ActiveFore_ and _PopupDelay_,
-so they should be used only as the first option specified for a menu
-style or to reset the style to defined behavior. The same effect can
-be created by setting all the other options one by one.
+style. These options override all others except _HilightBack_, _ActiveFore_
+and _PopupDelay_, so they should be used only as the first option specified
+for a menu style or to reset the style to defined behavior. The same effect
+can be created by setting all the other options one by one.
 +
 _Mwm_ and _Win_ style menus popup sub menus automatically. _Win_ menus
 indicate the current menu item by changing the background to dark.
@@ -2545,21 +2543,21 @@ _Fvwm_ sub menus overlap the parent menu, _Mwm_ and _Win_ style menus
 never overlap the parent menu.
 +
 _Fvwm_ style is equivalent to !HilightBack, Hilight3DThin,
-!ActiveFore, !Animation, Font, MenuFace, PopupOffset 0 67, TitleWarp,
+!ActiveFore, !Animation, Font, PopupOffset 0 67, TitleWarp,
 TitleUnderlines1, SeparatorsShort, TrianglesRelief, PopupDelayed,
 PopdownDelayed, PopupDelay 150, PopdownDelay 150, PopupAsSubmenu,
 HoldSubmenus, SubmenusRight, BorderWidth 2, !AutomaticHotkeys,
 UniqueHotkeyActivatesImmediate, PopupActiveArea 75.
 +
 _Mwm_ style is equivalent to !HilightBack, Hilight3DThick,
-!ActiveFore, !Animation, Font, MenuFace, PopupOffset -3 100,
+!ActiveFore, !Animation, Font, PopupOffset -3 100,
 !TitleWarp, TitleUnderlines2, SeparatorsLong, TrianglesRelief,
 PopupImmediately, PopdownDelayed, PopdownDelay 150, PopupAsSubmenu,
 HoldSubmenus, SubmenusRight, BorderWidth 2,
 UniqueHotkeyActivatesImmediate, !AutomaticHotkeys, PopupActiveArea 75.
 +
 _Win_ style is equivalent to HilightBack, Hilight3DOff, ActiveFore,
-!Animation, Font, MenuFace, PopupOffset -5 100, !TitleWarp,
+!Animation, Font, PopupOffset -5 100, !TitleWarp,
 TitleUnderlines1, SeparatorsShort, TrianglesSolid, PopupImmediately,
 PopdownDelayed, PopdownDelay 150, PopupAsSubmenu, RemoveSubmenus,
 SubmenusRight, BorderWidth 2, UniqueHotkeyActivatesImmediate,
@@ -2569,57 +2567,27 @@ _BorderWidth_ takes the thickness of the border around the menus in
 pixels. It may be zero to 50 pixels. The default is 2. Using an
 invalid value reverts the border width to the default.
 +
-_Foreground_ and _Background_ may have a color name as an argument.
-This color is used for menu text or the menu's background. You can
-omit the color name to reset these colors to the built-in default.
-+
-_Greyed_ may have a color name as an argument. This color is the one
-used to draw a menu-selection which is prohibited (or not recommended)
-by the Mwm hints which an application has specified. If the color is
-omitted the color of greyed menu entries is based on the background
-color of the menu.
-+
 _HilightBack_ and _!HilightBack_ switch hilighting the background of
-the selected menu item on and off. A specific background color may be
-used by providing the color name as an argument to _HilightBack_. If
-you use this option without an argument the color is based on the
-menu's background color. The _ActiveColorset_ option overrides the
-specified color. If the colorset has a non solid background it is used
-for the hilighting.
+the selected menu item on and off. The _ActiveColorset_ background
+color is used for the hilighting.
 +
 _HilightTitleBack_ switches hilighting the background of menu titles
-on. If a _TitleColorset_ was used, the background colour is taken from
-there. Otherwise the color is based on the menu's background color. If
-the colorset has a non solid background it is used for the hilighting.
+on. The _TitleColorset_ background color is used for the hilighting.
 +
 _ActiveFore_ and _!ActiveFore_ switch hilighting the foreground of the
-selected menu item on and off. A specific foreground color may be used
-by providing the color name as an argument to _ActiveFore_. Omitting
-the color turns hilighting on when an _ActiveColorset_ is used.
-_ActiveFore_ turns off hilighting the foreground completely. The
-_ActiveColorset_ option overrides the specified color.
+selected menu item on and off. The _ActiveColorset_ foreground color
+is used for the hilighting.
 +
-_MenuColorset_ controls if a colorset is used instead of the
-_Foreground_, _Background_ and _MenuFace_ menu styles. If the
-_MenuColorset_ keyword is followed by a number equal to zero or
-greater, this number is taken as the number of the colorset to use. If
-the number is omitted, the colorset is switched off and the regular
-menu styles are used again. The foreground and background colors of
-the menu items are replaced by the colors from the colorset. If the
-colorset has a pixmap defined, this pixmap is used as the background
-of the menu. Note that the _MenuFace_ menu style has been optimized
-for memory consumption and may use less memory than the background
-from a colorset. The shape mask from the colorset is used to shape the
+_MenuColorset_ controls the colorset used to color the menu. If the
+colorset has a pixmap or gradient defined, this is used as the background
+of the menu. The shape mask from the colorset is used to shape the
 menu. Please refer to the *Colorsets* section for details about
 colorsets.
 +
-_ActiveColorset_ works exactly like _MenuColorset_, but the foreground
-from the colorset replaces the color given with the _ActiveFore_ menu
-style and the colorset's background color replaces the color given
-with the _HilightBack_ command (to turn on background hilighting you
-have to use the _HilightBack_ menu style too). If specified, the
-hilight and shadow colors from the colorset are used too. The pixmap
-and shape mask from the colorset are not used. Hilighting the
+_ActiveColorset_ controls the color of the active menu item, provided
+the _HilightBack_ or _ActiveFore_ menu styles are used. If specified,
+the hilight and shadow colors from the colorset are used too. The
+pixmap and shape mask from the colorset are not used. Hilighting the
 background or foreground can be turned off individually with the
 _!ActiveFore_ or _!HilightBack_ menu styles.
 +
@@ -2648,53 +2616,6 @@ this name exists it is used for the text of all menu items. If it does
 not exist or if the name is left blank the built-in default is used.
 If a _TitleFont_ is given, it is used for all menu titles instead of
 the normal font.
-+
-_MenuFace_ enforces a fancy background upon the menus. You can use the
-same options for _MenuFace_ as for the *ButtonStyle*. See description
-of *ButtonStyle* command and the *Color Gradients* sections for more
-information. If you use _MenuFace_ without arguments the style is
-reverted back to normal.
-+
-Some examples of MenuFaces are:
-+
-....
-MenuFace DGradient 128 2 lightgrey 50 blue 50 white
-MenuFace TiledPixmap texture10.xpm
-MenuFace HGradient 128 2 Red 40 Maroon 60 White
-MenuFace Solid Maroon
-....
-+
-Note: The gradient styles H, V, B and D are optimized for high speed
-and low memory consumption in menus. This is not the case for all the
-other gradient styles. They may be slow and consume huge amounts of
-memory, so if you encounter performance problems with them you may be
-better off by not using them. To improve performance you can try one
-or all of the following:
-+
-Turn hilighting of the active menu item other than foreground color
-off:
-+
-....
-MenuStyle <style> Hilight3DOff, !HilightBack
-MenuStyle <style> ActiveFore <preferred color>
-....
-+
-Make sure sub menus do not overlap the parent menu. This can prevent
-menus being redrawn every time a sub menu pops up or down.
-+
-....
-MenuStyle <style> PopupOffset 1 100
-....
-+
-Run your X server with backing storage. If your X Server is started
-with the -bs option, turn it off. If not try the -wm and +bs options:
-+
-....
-startx -- -wm +bs
-....
-+
-You may have to adapt this example to your system (e.g. if you use
-xinit to start X).
 +
 _PopupDelay_ requires one numeric argument. This value is the delay in
 milliseconds before a sub menu is popped up when the pointer moves
@@ -2948,48 +2869,6 @@ the default. The opposite, _!ScrollOffPage_ disables this behaviour.
 _TrianglesUseFore_ draws sub menu triangles with the foreground color
 of the menu colorset (normally drawn with the hilight color).
 _!TrianglesUseFore_ disables this behaviour.
-+
-Examples:
-+
-....
-MenuStyle * Mwm
-MenuStyle * Foreground Black, Background gray40
-MenuStyle * Greyed gray70, ActiveFore White
-MenuStyle * !HilightBack, Hilight3DOff
-MenuStyle * Font lucidasanstypewriter-14
-MenuStyle * MenuFace DGradient 64 darkgray MidnightBlue
-
-MenuStyle red Mwm
-MenuStyle red Foreground Yellow
-MenuStyle red Background Maroon
-MenuStyle red Greyed Red, ActiveFore Red
-MenuStyle red !HilightBack, Hilight3DOff
-MenuStyle red Font lucidasanstypewriter-12
-MenuStyle red MenuFace DGradient 64 Red Black
-....
-+
-Note that all style options could be placed on a single line for each
-style name.
-
-*MenuStyle* _forecolor_ _backcolor_ _shadecolor_ _font_ _style_ [_anim_]::
-	This is the old syntax of the *MenuStyle* command. It is obsolete and
-	may be removed in the future. Please use the new syntax as described
-	above.
-+
-Sets the menu style. When using monochrome the colors are ignored. The
-_shadecolor_ is the one used to draw a menu-selection which is
-prohibited (or not recommended) by the Mwm hints which an application
-has specified. The style option is either _Fvwm_, _Mwm_ or _Win_,
-which changes the appearance and operation of the menus.
-+
-_Mwm_ and _Win_ style menus popup sub menus automatically. _Win_ menus
-indicate the current menu item by changing the background to black.
-_Fvwm_ sub menus overlap the parent menu, _Mwm_ and _Win_ style menus
-never overlap the parent menu.
-+
-When the _anim_ option is given, sub menus that do not fit on the
-screen cause the parent menu to be shifted to the left so the sub menu
-can be seen. See also *SetAnimation* command.
 // END 'menus'
 endif::[]
 
@@ -9373,19 +9252,47 @@ Examples:
 +
 
 ....
-MenuStyle * \
-MenuFace DGradient 128 2 lightgrey 50 blue 50 white
+Colorset 0 DGradient 128 2 lightgrey 50 blue 50 white
 
 # 20% gradient from red to blue,
 # 30% from blue to black,
 # 50% from black to grey
-MenuStyle * \
-MenuFace DGradient 100 3 Red 20 Blue 30 Black 50 Grey
+Colorset 0 DGradient 100 3 Red 20 Blue 30 Black 50 Grey
 
 # 50% from blue to green, then
 # 50% from yellow to red
 Colorset 0 HGradient 128 3 Blue 1000 Green 1 Yellow 1000 Red
 ....
+
+Note: Some gradient styles may be slow and consume huge amounts of
+memory, so if you encounter performance problems with them you may be
+better off by not using them. To improve performance you can try one
+or all of the following:
++
+Turn hilighting of the active menu item other than foreground color
+off:
++
+....
+MenuStyle <style> Hilight3DOff, !HilightBack
+....
++
+Make sure sub menus do not overlap the parent menu. This can prevent
+menus being redrawn every time a sub menu pops up or down.
++
+....
+MenuStyle <style> PopupOffset 1 100
+....
++
+Run your X server with backing storage. If your X Server is started
+with the -bs option, turn it off. If not try the -wm and +bs options:
++
+....
+startx -- -wm +bs
+....
++
+You may have to adapt this example to your system (e.g. if you use
+xinit to start X).
+
 // END 'commands'
 endif::[]
 

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -2531,14 +2531,6 @@ with a '/' in between. These options exclude each other. All paired
 options can be negated to have the effect of the counterpart option by
 prefixing ! to the option.
 +
-Some options are now negated by prefixing ! to the option. This is the
-preferred form for all such options. The other negative forms are now
-deprecated and will be removed in the future.
-+
-This is a list of MenuStyle deprecated negative options:
-ActiveForeOff, AnimationOff, AutomaticHotkeysOff, HilightBackOff,
-TitleWarpOff
-+
 _Fvwm_, _Mwm_, _Win_ reset all options to the style with the same name
 in former versions of fvwm. The default for new menu styles is _Fvwm_
 style. These options override all others except _Foreground_,

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2561,8 +2561,8 @@ void HandleFocusIn(const evh_args_t *ea)
 		}
 		/* Not very useful if no window that fvwm and its modules know
 		 * about has the focus. */
-		fc = GetColor(DEFAULT_FORE_COLOR);
-		bc = GetColor(DEFAULT_BACK_COLOR);
+		fc = Colorset[0].fg;
+		bc = Colorset[0].bg;
 	}
 	else if (fw != Scr.Hilite ||
 		 /* domivogt (16-May-2000): This check is necessary to force

--- a/fvwm/menuitem.h
+++ b/fvwm/menuitem.h
@@ -119,7 +119,6 @@ typedef struct MenuPaintItemParameters
 	int used_mini_icons;
 	struct MenuRoot *cb_mr;
 	/* number of item labels present in the item format */
-	Bool (*cb_reset_bg)(struct MenuRoot *mr, XEvent *pevent);
 	struct
 	{
 		unsigned is_first_item : 1;

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -55,96 +55,6 @@ static MenuStyle *default_menu_style;
 
 /* ---------------------------- local functions ---------------------------- */
 
-static void menustyle_free_face(MenuFace *mf)
-{
-	switch (mf->type)
-	{
-	case GradientMenu:
-		if (Pdepth <= 8 && mf->u.grad.npixels > 0 &&
-		    !mf->u.grad.do_dither)
-		{
-			Pixel *p;
-			int i;
-
-			p = fxmalloc(mf->u.grad.npixels * sizeof(Pixel));
-			for(i=0; i < mf->u.grad.npixels; i++)
-			{
-				p[i] = mf->u.grad.xcs[i].pixel;
-			}
-			PictureFreeColors(
-				dpy, Pcmap, p, mf->u.grad.npixels, 0, False);
-			free(p);
-		}
-		free(mf->u.grad.xcs);
-		mf->u.grad.xcs = NULL;
-		break;
-	case PixmapMenu:
-	case TiledPixmapMenu:
-		if (mf->u.p)
-		{
-			PDestroyFvwmPicture(dpy, mf->u.p);
-		}
-		mf->u.p = NULL;
-		break;
-	case SolidMenu:
-		fvwmlib_free_colors(dpy, &mf->u.back, 1, True);
-	default:
-		break;
-	}
-	mf->type = SimpleMenu;
-
-	return;
-}
-
-static void menustyle_copy_face(MenuFace *destmf, MenuFace *origmf)
-{
-	FvwmPictureAttributes fpa;
-	int i;
-
-	menustyle_free_face(destmf);
-	destmf->type = SimpleMenu;
-	switch (origmf->type)
-	{
-	case SolidMenu:
-		fvwmlib_copy_color(
-			dpy, &destmf->u.back, &origmf->u.back, False, True);
-		destmf->type = SolidMenu;
-		break;
-	case GradientMenu:
-		destmf->u.grad.xcs = fxmalloc(sizeof(XColor) *
-					     origmf->u.grad.npixels);
-		memcpy(destmf->u.grad.xcs,
-		       origmf->u.grad.xcs,
-		       sizeof(XColor) * origmf->u.grad.npixels);
-		for (i = 0; i<origmf->u.grad.npixels;i++)
-		{
-			fvwmlib_clone_color(origmf->u.grad.xcs[i].pixel);
-		}
-
-		destmf->u.grad.npixels = origmf->u.grad.npixels;
-		destmf->u.grad.do_dither = origmf->u.grad.do_dither;
-		destmf->type = GradientMenu;
-		destmf->gradient_type = origmf->gradient_type;
-		break;
-	case PixmapMenu:
-	case TiledPixmapMenu:
-		fpa.mask = (Pdepth <= 8)?  FPAM_DITHER:0;
-
-		if (destmf->u.p)
-			destmf->u.p = NULL;
-
-		if (origmf->u.p)
-			destmf->u.p = PCacheFvwmPicture(
-				dpy, Scr.NoFocusWin, NULL, origmf->u.p->name,
-				fpa);
-
-		destmf->type = origmf->type;
-		break;
-	default:
-		break;
-	}
-}
-
 static void parse_vertical_spacing_line(
 	char *args, signed char *above, signed char *below,
 	signed char above_default, signed char below_default)
@@ -259,7 +169,6 @@ void menustyle_free(MenuStyle *ms)
 	{
 		return;
 	}
-	menustyle_free_face(&ST_FACE(ms));
 	if (FORE_GC(ST_MENU_INACTIVE_GCS(ms)))
 	{
 		XFreeGC(dpy, FORE_GC(ST_MENU_INACTIVE_GCS(ms)));
@@ -329,24 +238,6 @@ void menustyle_free(MenuStyle *ms)
 		free(ST_ITEM_FORMAT(ms));
 	}
 
-	fvwmlib_free_colors(dpy, &ST_MENU_COLORS(ms).back,1,True);
-	fvwmlib_free_colors(dpy, &ST_MENU_COLORS(ms).fore,1,True);
-	if (ST_HAS_STIPPLE_FORE(ms))
-	{
-		fvwmlib_free_colors(
-			dpy, &ST_MENU_STIPPLE_COLORS(ms).fore,1,True);
-	}
-	if (ST_HAS_ACTIVE_BACK(ms))
-	{
-		fvwmlib_free_colors(
-			dpy, &ST_MENU_ACTIVE_COLORS(ms).back,1,True);
-	}
-	if (ST_HAS_ACTIVE_FORE(ms))
-	{
-		fvwmlib_free_colors(
-			dpy, &ST_MENU_ACTIVE_COLORS(ms).fore,1,True);
-	}
-
 	while (ST_NEXT_STYLE(before) != ms)
 	{
 		/* Not too many checks, may segfault in race conditions */
@@ -380,10 +271,6 @@ void menustyle_update(MenuStyle *ms)
 {
 	XGCValues gcv;
 	unsigned long gcm;
-	color_quad c_inactive;
-	color_quad c_active;
-	color_quad c_stipple;
-	color_quad c_title;
 	colorset_t *menu_cs = &Colorset[ST_CSET_MENU(ms)];
 	colorset_t *active_cs = &Colorset[ST_CSET_ACTIVE(ms)];
 	colorset_t *greyed_cs = &Colorset[ST_CSET_GREYED(ms)];
@@ -404,110 +291,6 @@ void menustyle_update(MenuStyle *ms)
 	{
 		ST_PTITLEFONT(ms) = ST_PSTDFONT(ms);
 	}
-	/* calculate colors based on foreground */
-	if (!ST_HAS_ACTIVE_FORE(ms))
-	{
-		ST_MENU_ACTIVE_COLORS(ms).fore = ST_MENU_COLORS(ms).fore;
-	}
-	/* calculate colors based on background */
-	if (!ST_HAS_ACTIVE_BACK(ms))
-	{
-		ST_MENU_ACTIVE_COLORS(ms).back = ST_MENU_COLORS(ms).back;
-	}
-	if (!ST_HAS_STIPPLE_FORE(ms))
-	{
-		ST_MENU_STIPPLE_COLORS(ms).fore = ST_MENU_COLORS(ms).back;
-	}
-	ST_MENU_STIPPLE_COLORS(ms).back = ST_MENU_COLORS(ms).back;
-	/* prepare colours for changing the gcs */
-	if (ST_HAS_MENU_CSET(ms))
-	{
-		c_inactive.fore = menu_cs->fg;
-		c_inactive.back = menu_cs->bg;
-		c_inactive.hilight = menu_cs->hilite;
-		c_inactive.shadow = menu_cs->shadow;
-	}
-	else
-	{
-		c_inactive.fore = ST_MENU_COLORS(ms).fore;
-		c_inactive.back = ST_MENU_COLORS(ms).back;
-		if (Pdepth > 2)
-		{
-			c_inactive.hilight = GetHilite(ST_MENU_COLORS(ms).back);
-			c_inactive.shadow = GetShadow(ST_MENU_COLORS(ms).back);
-		}
-		else
-		{
-			c_inactive.hilight = GetColor(DEFAULT_HILIGHT_COLOR);
-			c_inactive.shadow = GetColor(DEFAULT_SHADOW_COLOR);
-		}
-	}
-	if (ST_HAS_ACTIVE_CSET(ms))
-	{
-		c_active.fore = active_cs->fg;
-		c_active.back = active_cs->bg;
-		c_active.hilight = active_cs->hilite;
-		c_active.shadow = active_cs->shadow;
-	}
-	else
-	{
-		c_active.fore = ST_MENU_ACTIVE_COLORS(ms).fore;
-		c_active.back = ST_MENU_ACTIVE_COLORS(ms).back;
-		if (Pdepth > 2)
-		{
-			c_active.hilight =
-				GetHilite(ST_MENU_ACTIVE_COLORS(ms).back);
-			c_active.shadow =
-				GetShadow(ST_MENU_ACTIVE_COLORS(ms).back);
-		}
-		else
-		{
-			c_active.hilight = GetColor(DEFAULT_HILIGHT_COLOR);
-			c_active.shadow = GetColor(DEFAULT_SHADOW_COLOR);
-		}
-	}
-	if (ST_HAS_GREYED_CSET(ms))
-	{
-		c_stipple.fore = greyed_cs->fg;
-		c_stipple.back = greyed_cs->fg;
-	}
-	else
-	{
-		c_stipple.fore = ST_MENU_STIPPLE_COLORS(ms).fore;
-		c_stipple.back = ST_MENU_STIPPLE_COLORS(ms).back;
-	}
-	if (ST_HAS_TITLE_CSET(ms))
-	{
-		c_title.fore = title_cs->fg;
-		c_title.back = title_cs->bg;
-		c_title.hilight = title_cs->hilite;
-		c_title.shadow = title_cs->shadow;
-	}
-	else
-	{
-		c_title.fore = c_inactive.fore;
-		c_title.back = c_inactive.back;
-		c_title.hilight = c_inactive.hilight;
-		c_title.shadow = c_inactive.shadow;
-	}
-	/* override highlighting colours if necessary */
-	if (!ST_DO_HILIGHT_FORE(ms))
-	{
-		c_active.fore = c_inactive.fore;
-	}
-	if (!ST_DO_HILIGHT_BACK(ms))
-	{
-		c_active.back = c_inactive.back;
-		c_active.hilight = c_inactive.hilight;
-		c_active.shadow = c_inactive.shadow;
-	}
-	if (!ST_DO_HILIGHT_TITLE_BACK(ms))
-	{
-		c_title.fore = c_inactive.fore;
-		c_title.back = c_inactive.back;
-		c_title.hilight = c_inactive.hilight;
-		c_title.shadow = c_inactive.shadow;
-	}
 	/* make GC's */
 	gcm = GCFunction|GCLineWidth|GCForeground|GCBackground;
 	if (ST_PSTDFONT(ms)->font != NULL)
@@ -518,25 +301,28 @@ void menustyle_update(MenuStyle *ms)
 	gcv.function = GXcopy;
 	gcv.line_width = 0;
 	/* update inactive menu gcs */
-	gcv.foreground = c_inactive.fore;
-	gcv.background = c_inactive.back;
+	gcv.foreground = menu_cs->fg;
+	gcv.background = menu_cs->bg;
 	change_or_make_gc(&FORE_GC(ST_MENU_INACTIVE_GCS(ms)), gcm, &gcv);
 	BACK_GC(ST_MENU_INACTIVE_GCS(ms)) = FORE_GC(ST_MENU_INACTIVE_GCS(ms));
-	gcv.foreground = c_inactive.hilight;
-	gcv.background = c_inactive.shadow;
+	gcv.foreground = menu_cs->hilite;
+	gcv.background = menu_cs->shadow;
 	change_or_make_gc(&HILIGHT_GC(ST_MENU_INACTIVE_GCS(ms)), gcm, &gcv);
-	gcv.foreground = c_inactive.shadow;
-	gcv.background = c_inactive.hilight;
+	gcv.foreground = menu_cs->shadow;
+	gcv.background = menu_cs->hilite;
 	change_or_make_gc(&SHADOW_GC(ST_MENU_INACTIVE_GCS(ms)), gcm, &gcv);
 	/* update active menu gcs */
-	gcv.foreground = c_active.fore;
-	gcv.background = c_active.back;
+	gcv.foreground = (ST_DO_HILIGHT_FORE(ms)) ? active_cs->fg
+						  : menu_cs->fg;
+	gcv.background = (ST_DO_HILIGHT_BACK(ms)) ? active_cs->bg
+						  : menu_cs->bg;
 	change_or_make_gc(&FORE_GC(ST_MENU_ACTIVE_GCS(ms)), gcm, &gcv);
-	gcv.foreground = c_active.back;
-	gcv.background = c_active.fore;
+	gcv.foreground = (ST_DO_HILIGHT_BACK(ms)) ? active_cs->bg
+						  : menu_cs->bg;
+	gcv.background = (ST_DO_HILIGHT_FORE(ms)) ? active_cs->fg
+						  : menu_cs->fg;
 
-	if (ST_HAS_ACTIVE_CSET(ms) && active_cs->pixmap &&
-	    active_cs->pixmap_type == PIXMAP_TILED)
+	if (active_cs->pixmap && active_cs->pixmap_type == PIXMAP_TILED)
 	{
 		gcv.tile = active_cs->pixmap;
 		gcv.fill_style = FillTiled;
@@ -550,12 +336,15 @@ void menustyle_update(MenuStyle *ms)
 				  gcm | GCFillStyle , &gcv);
 	}
 
-
-	gcv.foreground = c_active.hilight;
-	gcv.background = c_active.shadow;
+	gcv.foreground = (ST_DO_HILIGHT_BACK(ms)) ? active_cs->hilite
+						  : menu_cs->hilite;
+	gcv.background = (ST_DO_HILIGHT_BACK(ms)) ? active_cs->shadow
+						  : menu_cs->shadow;
 	change_or_make_gc(&HILIGHT_GC(ST_MENU_ACTIVE_GCS(ms)), gcm, &gcv);
-	gcv.foreground = c_active.shadow;
-	gcv.background = c_active.hilight;
+	gcv.foreground = (ST_DO_HILIGHT_BACK(ms)) ? active_cs->shadow
+						  : menu_cs->shadow;
+	gcv.background = (ST_DO_HILIGHT_BACK(ms)) ? active_cs->hilite
+						  : menu_cs->hilite;
 	change_or_make_gc(&SHADOW_GC(ST_MENU_ACTIVE_GCS(ms)), gcm, &gcv);
 	/* update title gcs */
 	if (ST_PTITLEFONT(ms)->font != NULL && ST_PSTDFONT(ms)->font == NULL)
@@ -566,14 +355,17 @@ void menustyle_update(MenuStyle *ms)
 		}
 		gcv.font = ST_PTITLEFONT(ms)->font->fid;
 	}
-	gcv.foreground = c_title.fore;
-	gcv.background = c_title.back;
+	gcv.foreground = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->fg
+							: menu_cs->fg;
+	gcv.background = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->bg
+							: menu_cs->bg;
 	change_or_make_gc(&FORE_GC(ST_MENU_TITLE_GCS(ms)), gcm, &gcv);
-	gcv.foreground = c_title.back;
-	gcv.background = c_title.fore;
+	gcv.foreground = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->bg
+							: menu_cs->bg;
+	gcv.background = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->fg
+							: menu_cs->fg;
 
-	if (ST_HAS_TITLE_CSET(ms) && title_cs->pixmap &&
-	    title_cs->pixmap_type == PIXMAP_TILED)
+	if (title_cs->pixmap && title_cs->pixmap_type == PIXMAP_TILED)
 	{
 		gcv.tile = title_cs->pixmap;
 		gcv.fill_style = FillTiled;
@@ -587,11 +379,15 @@ void menustyle_update(MenuStyle *ms)
 				  gcm | GCFillStyle , &gcv);
 	}
 
-	gcv.foreground = c_title.hilight;
-	gcv.background = c_title.shadow;
+	gcv.foreground = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->hilite
+							: menu_cs->hilite;
+	gcv.background = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->shadow
+							: menu_cs->shadow;
 	change_or_make_gc(&HILIGHT_GC(ST_MENU_TITLE_GCS(ms)), gcm, &gcv);
-	gcv.foreground = c_title.shadow;
-	gcv.background = c_title.hilight;
+	gcv.foreground = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->shadow
+							: menu_cs->shadow;
+	gcv.background = (ST_DO_HILIGHT_TITLE_BACK(ms)) ? title_cs->hilite
+							: menu_cs->hilite;
 	change_or_make_gc(&SHADOW_GC(ST_MENU_TITLE_GCS(ms)), gcm, &gcv);
 	/* update stipple menu gcs */
 	SHADOW_GC(ST_MENU_STIPPLE_GCS(ms)) =
@@ -607,8 +403,8 @@ void menustyle_update(MenuStyle *ms)
 	}
 	else
 	{
-		gcv.foreground = c_stipple.fore;
-		gcv.background = c_stipple.back;
+		gcv.foreground = greyed_cs->fg;
+		gcv.background = greyed_cs->bg;
 		HILIGHT_GC(ST_MENU_STIPPLE_GCS(ms)) =
 			HILIGHT_GC(ST_MENU_INACTIVE_GCS(ms));
 	}
@@ -675,17 +471,12 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 		{
 			/* some default configuration goes here for the new
 			 * menu style */
-			ST_HAS_MENU_CSET(tmpms) = 1;
 			ST_CSET_MENU(tmpms) = 0;
-			ST_HAS_ACTIVE_CSET(tmpms) = 1;
 			ST_CSET_ACTIVE(tmpms) = 0;
-			ST_HAS_TITLE_CSET(tmpms) = 1;
 			ST_CSET_TITLE(tmpms) = 0;
-			ST_HAS_GREYED_CSET(tmpms) = 1;
 			ST_CSET_GREYED(tmpms) = 0;
 			ST_PSTDFONT(tmpms) = Scr.DefaultFont;
 			ST_USING_DEFAULT_FONT(tmpms) = True;
-			ST_FACE(tmpms).type = SimpleMenu;
 			ST_HAS_ACTIVE_FORE(tmpms) = 0;
 			ST_HAS_ACTIVE_BACK(tmpms) = 0;
 			ST_DO_POPUP_AS(tmpms) = MDP_POST_MENU;
@@ -798,8 +589,6 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			 * always close the menu and run the action.
 			 */
 			ST_HOTKEY_ACTIVATES_IMMEDIATE(tmpms) = 1;
-			menustyle_free_face(&ST_FACE(tmpms));
-			ST_FACE(tmpms).type = SimpleMenu;
 			if (ST_PSTDFONT(tmpms) && !ST_USING_DEFAULT_FONT(tmpms))
 			{
 				FlocaleUnloadFont(dpy, ST_PSTDFONT(tmpms));
@@ -1347,36 +1136,8 @@ void menustyle_copy(MenuStyle *origms, MenuStyle *destms)
 	/* Copy origms to destms, be aware of all pointers in the MenuStyle
 	   structure. Use  the same order as in menustyle_parse_style */
 
-	/* menu colors */
-	fvwmlib_copy_color(
-		dpy, &ST_MENU_COLORS(destms).fore,
-		&ST_MENU_COLORS(origms).fore, True, True);
-	fvwmlib_copy_color(
-		dpy, &ST_MENU_COLORS(destms).back,
-		&ST_MENU_COLORS(origms).back, True, True);
-	/* Greyed */
-	fvwmlib_copy_color(
-		dpy, &ST_MENU_STIPPLE_COLORS(destms).fore,
-		&ST_MENU_STIPPLE_COLORS(origms).fore,
-		ST_HAS_STIPPLE_FORE(destms), ST_HAS_STIPPLE_FORE(origms));
-	ST_MENU_STIPPLE_COLORS(destms).back =
-		ST_MENU_STIPPLE_COLORS(origms).back;
-	ST_HAS_STIPPLE_FORE(destms) = ST_HAS_STIPPLE_FORE(origms);
-
-	/* HilightBack */
-	fvwmlib_copy_color(
-		dpy, &ST_MENU_ACTIVE_COLORS(destms).back,
-		&ST_MENU_ACTIVE_COLORS(origms).back,
-		ST_HAS_ACTIVE_BACK(destms), ST_HAS_ACTIVE_BACK(origms));
-	ST_HAS_ACTIVE_BACK(destms) = ST_HAS_ACTIVE_BACK(origms);
+	/* HilightBack / ActiveFore */
 	ST_DO_HILIGHT_BACK(destms) = ST_DO_HILIGHT_BACK(origms);
-
-	/* ActiveFore */
-	fvwmlib_copy_color(
-		dpy, &ST_MENU_ACTIVE_COLORS(destms).fore,
-		&ST_MENU_ACTIVE_COLORS(origms).fore,
-		ST_HAS_ACTIVE_FORE(destms), ST_HAS_ACTIVE_FORE(origms));
-	ST_HAS_ACTIVE_FORE(destms) = ST_HAS_ACTIVE_FORE(origms);
 	ST_DO_HILIGHT_FORE(destms) = ST_DO_HILIGHT_FORE(origms);
 
 	/* Hilight3D */
@@ -1437,8 +1198,6 @@ void menustyle_copy(MenuStyle *origms, MenuStyle *destms)
 		ST_USING_DEFAULT_TITLEFONT(destms) = True;
 		ST_PTITLEFONT(destms) = Scr.DefaultFont;
 	}
-	/* MenuFace */
-	menustyle_copy_face(&ST_FACE(destms), &ST_FACE(origms));
 
 	/* PopupDelay */
 	ST_POPUP_DELAY(destms) = ST_POPUP_DELAY(origms);
@@ -1514,17 +1273,10 @@ void menustyle_copy(MenuStyle *origms, MenuStyle *destms)
 	ST_ITEM_GAP_BELOW(destms) = ST_ITEM_GAP_BELOW(origms);
 	ST_TITLE_GAP_ABOVE(destms) = ST_TITLE_GAP_ABOVE(origms);
 	ST_TITLE_GAP_BELOW(destms) = ST_TITLE_GAP_BELOW(origms);
-	/* MenuColorset */
-	ST_HAS_MENU_CSET(destms) = ST_HAS_MENU_CSET(origms);
+	/* MenuColorsets */
 	ST_CSET_MENU(destms) = ST_CSET_MENU(origms);
-	/* ActiveColorset */
-	ST_HAS_ACTIVE_CSET(destms) = ST_HAS_ACTIVE_CSET(origms);
 	ST_CSET_ACTIVE(destms) = ST_CSET_ACTIVE(origms);
-	/* MenuColorset */
-	ST_HAS_GREYED_CSET(destms) = ST_HAS_GREYED_CSET(origms);
 	ST_CSET_GREYED(destms) = ST_CSET_GREYED(origms);
-	/* TitleColorset */
-	ST_HAS_TITLE_CSET(destms) = ST_HAS_TITLE_CSET(origms);
 	ST_CSET_TITLE(destms) = ST_CSET_TITLE(origms);
 	/* SelectOnRelease */
 	ST_SELECT_ON_RELEASE_KEY(destms) = ST_SELECT_ON_RELEASE_KEY(origms);

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -324,53 +324,6 @@ static void parse_vertical_margins_line(
 	return;
 }
 
-static MenuStyle *menustyle_parse_old_style(F_CMD_ARGS)
-{
-	char *buffer, *rest;
-	char *fore, *back, *stipple, *font, *style, *animated;
-	MenuStyle *ms = NULL;
-
-	rest = GetNextToken(action,&fore);
-	rest = GetNextToken(rest,&back);
-	rest = GetNextToken(rest,&stipple);
-	rest = GetNextToken(rest,&font);
-	rest = GetNextToken(rest,&style);
-	rest = GetNextToken(rest,&animated);
-
-	if (!fore || !back || !stipple || !font || !style)
-	{
-		fvwm_debug(__func__,
-			   "error in %s style specification", action);
-	}
-	else
-	{
-		xasprintf(&buffer,
-			"* \"%s\", Foreground \"%s\", Background \"%s\", "
-			"Greyed \"%s\", Font \"%s\", \"%s\"",
-			style, fore, back, stipple, font,
-			(animated && StrEquals(animated, "anim")) ?
-			"Animation" : "AnimationOff");
-		fvwm_debug(__func__,
-			   "The old MenuStyle syntax has been deprecated.  "
-			   "Use 'MenuStyle %s' instead of 'MenuStyle %s'\n",
-			   buffer, action);
-
-		action = buffer;
-		ms = menustyle_parse_style(F_PASS_ARGS);
-
-		free(buffer);
-	}
-
-	free(fore);
-	free(back);
-	free(stipple);
-	free(font);
-	free(style);
-	free(animated);
-
-	return ms;
-}
-
 static int menustyle_get_styleopt_index(char *option)
 {
 	char *optlist[] = {
@@ -1931,27 +1884,6 @@ void CMD_CopyMenuStyle(F_CMD_ARGS)
 
 void CMD_MenuStyle(F_CMD_ARGS)
 {
-	char *option;
-	char *poption;
-
-	GetNextSimpleOption(SkipNTokens(action, 1), &option);
-	poption = option;
-	while (poption && poption[0] == '!')
-	{
-		poption++;
-	}
-	if (option == NULL || menustyle_get_styleopt_index(poption) != -1)
-	{
-		(void)menustyle_parse_style(F_PASS_ARGS);
-	}
-	else
-	{
-		(void)menustyle_parse_old_style(F_PASS_ARGS);
-	}
-	if (option)
-	{
-		free(option);
-	}
-
+	(void)menustyle_parse_style(F_PASS_ARGS);
 	return;
 }

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -329,14 +329,13 @@ static int menustyle_get_styleopt_index(char *option)
 	char *optlist[] = {
 		"fvwm", "mwm", "win",
 		"Foreground", "Background", "Greyed",
-		"HilightBack", "HilightBackOff",
-		"ActiveFore", "ActiveForeOff",
+		"HilightBack", "ActiveFore",
 		"Hilight3DThick", "Hilight3DThin", "Hilight3DOff",
-		"Animation", "AnimationOff",
+		"Animation",
 		"Font",
 		"MenuFace",
 		"PopupDelay", "PopupOffset",
-		"TitleWarp", "TitleWarpOff",
+		"TitleWarp",
 		"TitleUnderlines0", "TitleUnderlines1", "TitleUnderlines2",
 		"SeparatorsLong", "SeparatorsShort",
 		"TrianglesSolid", "TrianglesRelief",
@@ -349,7 +348,7 @@ static int menustyle_get_styleopt_index(char *option)
 		"BorderWidth",
 		"Hilight3DThickness",
 		"ItemFormat",
-		"AutomaticHotkeys", "AutomaticHotkeysOff",
+		"AutomaticHotkeys",
 		"VerticalItemSpacing",
 		"VerticalTitleSpacing",
 		"MenuColorset", "ActiveColorset", "GreyedColorset",
@@ -1021,9 +1020,6 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			has_gc_changed = True;
 			break;
 
-		case 7: /* HilightBackOff */
-			on ^= 1;
-			/* fall throw */
 		case 6: /* HilightBack */
 			if (ST_HAS_ACTIVE_BACK(tmpms))
 			{
@@ -1046,10 +1042,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			has_gc_changed = True;
 			break;
 
-		case 9: /* ActiveForeOff */
-			on ^= 1;
-			/* fall throw */
-		case 8: /* ActiveFore */
+		case 7: /* ActiveFore */
 			if (ST_HAS_ACTIVE_FORE(tmpms))
 			{
 				fvwmlib_free_colors(
@@ -1071,27 +1064,23 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			has_gc_changed = True;
 			break;
 
-		case 10: /* Hilight3DThick */
+		case 8: /* Hilight3DThick */
 			ST_RELIEF_THICKNESS(tmpms) = 2;
 			break;
 
-		case 11: /* Hilight3DThin */
+		case 9: /* Hilight3DThin */
 			ST_RELIEF_THICKNESS(tmpms) = 1;
 			break;
 
-		case 12: /* Hilight3DOff */
+		case 10: /* Hilight3DOff */
 			ST_RELIEF_THICKNESS(tmpms) = 0;
 			break;
 
-		case 13: /* Animation */
+		case 11: /* Animation */
 			ST_IS_ANIMATED(tmpms) = on;
 			break;
 
-		case 14: /* AnimationOff */
-			ST_IS_ANIMATED(tmpms) = !on;
-			break;
-
-		case 15: /* Font */
+		case 12: /* Font */
 			if (arg1 != NULL &&
 			    !(new_font = FlocaleLoadFont(dpy, arg1, "fvwm")))
 			{
@@ -1117,7 +1106,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			has_gc_changed = True;
 			break;
 
-		case 16: /* MenuFace */
+		case 13: /* MenuFace */
 			while (args && *args != '\0' &&
 			       isspace((unsigned char)*args))
 			{
@@ -1126,7 +1115,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			menustyle_parse_face(args, &ST_FACE(tmpms), True);
 			break;
 
-		case 17: /* PopupDelay */
+		case 14: /* PopupDelay */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1138,7 +1127,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 18: /* PopupOffset */
+		case 15: /* PopupOffset */
 			if ((n = GetIntegerArguments(args, NULL, val, 2)) == 0)
 			{
 				fvwm_debug(__func__,
@@ -1159,51 +1148,47 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 19: /* TitleWarp */
+		case 16: /* TitleWarp */
 			ST_DO_WARP_TO_TITLE(tmpms) = on;
 			break;
 
-		case 20: /* TitleWarpOff */
-			ST_DO_WARP_TO_TITLE(tmpms) = !on;
-			break;
-
-		case 21: /* TitleUnderlines0 */
+		case 17: /* TitleUnderlines0 */
 			ST_TITLE_UNDERLINES(tmpms) = 0;
 			break;
 
-		case 22: /* TitleUnderlines1 */
+		case 18: /* TitleUnderlines1 */
 			ST_TITLE_UNDERLINES(tmpms) = 1;
 			break;
 
-		case 23: /* TitleUnderlines2 */
+		case 19: /* TitleUnderlines2 */
 			ST_TITLE_UNDERLINES(tmpms) = 2;
 			break;
 
-		case 24: /* SeparatorsLong */
+		case 20: /* SeparatorsLong */
 			ST_HAS_LONG_SEPARATORS(tmpms) = on;
 			break;
 
-		case 25: /* SeparatorsShort */
+		case 21: /* SeparatorsShort */
 			ST_HAS_LONG_SEPARATORS(tmpms) = !on;
 			break;
 
-		case 26: /* TrianglesSolid */
+		case 22: /* TrianglesSolid */
 			ST_HAS_TRIANGLE_RELIEF(tmpms) = !on;
 			break;
 
-		case 27: /* TrianglesRelief */
+		case 23: /* TrianglesRelief */
 			ST_HAS_TRIANGLE_RELIEF(tmpms) = on;
 			break;
 
-		case 28: /* PopupImmediately */
+		case 24: /* PopupImmediately */
 			ST_DO_POPUP_IMMEDIATELY(tmpms) = on;
 			break;
 
-		case 29: /* PopupDelayed */
+		case 25: /* PopupDelayed */
 			ST_DO_POPUP_IMMEDIATELY(tmpms) = !on;
 			break;
 
-		case 30: /* DoubleClickTime */
+		case 26: /* DoubleClickTime */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1216,7 +1201,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 31: /* SidePic */
+		case 27: /* SidePic */
 			if (ST_SIDEPIC(tmpms))
 			{
 				PDestroyFvwmPicture(dpy, ST_SIDEPIC(tmpms));
@@ -1236,7 +1221,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 32: /* SideColor */
+		case 28: /* SideColor */
 			if (ST_HAS_SIDE_COLOR(tmpms) == 1)
 			{
 				fvwmlib_free_colors(
@@ -1250,31 +1235,31 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 33: /* PopupAsRootmenu */
+		case 29: /* PopupAsRootmenu */
 			ST_DO_POPUP_AS(tmpms) = MDP_ROOT_MENU;
 			break;
 
-		case 34: /* PopupAsSubmenu */
+		case 30: /* PopupAsSubmenu */
 			ST_DO_POPUP_AS(tmpms) = MDP_POST_MENU;
 			break;
 
-		case 35: /* RemoveSubmenus */
+		case 31: /* RemoveSubmenus */
 			ST_DO_UNMAP_SUBMENU_ON_POPDOWN(tmpms) = on;
 			break;
 
-		case 36: /* HoldSubmenus */
+		case 32: /* HoldSubmenus */
 			ST_DO_UNMAP_SUBMENU_ON_POPDOWN(tmpms) = !on;
 			break;
 
-		case 37: /* SubmenusRight */
+		case 33: /* SubmenusRight */
 			ST_USE_LEFT_SUBMENUS(tmpms) = !on;
 			break;
 
-		case 38: /* SubmenusLeft */
+		case 34: /* SubmenusLeft */
 			ST_USE_LEFT_SUBMENUS(tmpms) = on;
 			break;
 
-		case 39: /* BorderWidth */
+		case 35: /* BorderWidth */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0 || *val > MAX_MENU_BORDER_WIDTH)
 			{
@@ -1287,7 +1272,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 40: /* Hilight3DThickness */
+		case 36: /* Hilight3DThickness */
 			if (GetIntegerArguments(args, NULL, val, 1) > 0)
 			{
 				if (*val < 0)
@@ -1305,7 +1290,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 41: /* ItemFormat */
+		case 37: /* ItemFormat */
 			if (ST_ITEM_FORMAT(tmpms))
 			{
 				free(ST_ITEM_FORMAT(tmpms));
@@ -1317,15 +1302,11 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 42: /* AutomaticHotkeys */
+		case 38: /* AutomaticHotkeys */
 			ST_USE_AUTOMATIC_HOTKEYS(tmpms) = on;
 			break;
 
-		case 43: /* AutomaticHotkeysOff */
-			ST_USE_AUTOMATIC_HOTKEYS(tmpms) = !on;
-			break;
-
-		case 44: /* VerticalItemSpacing */
+		case 39: /* VerticalItemSpacing */
 			parse_vertical_spacing_line(
 				args, &ST_ITEM_GAP_ABOVE(tmpms),
 				&ST_ITEM_GAP_BELOW(tmpms),
@@ -1333,14 +1314,15 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 				DEFAULT_MENU_ITEM_TEXT_Y_OFFSET2);
 			break;
 
-		case 45: /* VerticalTitleSpacing */
+		case 40: /* VerticalTitleSpacing */
 			parse_vertical_spacing_line(
 				args, &ST_TITLE_GAP_ABOVE(tmpms),
 				&ST_TITLE_GAP_BELOW(tmpms),
 				DEFAULT_MENU_TITLE_TEXT_Y_OFFSET,
 				DEFAULT_MENU_TITLE_TEXT_Y_OFFSET2);
 			break;
-		case 46: /* MenuColorset */
+
+		case 41: /* MenuColorset */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1355,7 +1337,8 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			has_gc_changed = True;
 			break;
-		case 47: /* ActiveColorset */
+
+		case 42: /* ActiveColorset */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1371,7 +1354,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			has_gc_changed = True;
 			break;
 
-		case 48: /* GreyedColorset */
+		case 43: /* GreyedColorset */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1387,7 +1370,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			has_gc_changed = True;
 			break;
 
-		case 49: /* SelectOnRelease */
+		case 44: /* SelectOnRelease */
 			keycode = 0;
 			if (arg1)
 			{
@@ -1397,15 +1380,15 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			ST_SELECT_ON_RELEASE_KEY(tmpms) = keycode;
 			break;
 
-		case 50: /* PopdownImmediately */
+		case 45: /* PopdownImmediately */
 			ST_DO_POPDOWN_IMMEDIATELY(tmpms) = 1;
 			break;
 
-		case 51: /* PopdownDelayed */
+		case 46: /* PopdownDelayed */
 			ST_DO_POPDOWN_IMMEDIATELY(tmpms) = 0;
 			break;
 
-		case 52: /* PopdownDelay */
+		case 47: /* PopdownDelay */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1417,7 +1400,7 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 53: /* PopupActiveArea */
+		case 48: /* PopupActiveArea */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val <= 50 || *val > 100)
 			{
@@ -1430,17 +1413,17 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			break;
 
-		case 54: /* PopupIgnore */
+		case 49: /* PopupIgnore */
 			ST_DO_POPUP_AS(tmpms) = MDP_IGNORE;
 			break;
 
-		case 55: /* PopupClose */
+		case 50: /* PopupClose */
 			ST_DO_POPUP_AS(tmpms) = MDP_CLOSE;
 			break;
 
-		case 56: /* MouseWheel */
+		case 51: /* MouseWheel */
 			if (arg1)
-		        {
+			{
 				if (StrEquals(arg1, "ActivatesItem"))
 				{
 					ST_MOUSE_WHEEL(tmpms) = MMW_OFF;
@@ -1467,21 +1450,23 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 						   arg1);
 					ST_MOUSE_WHEEL(tmpms) = MMW_POINTER;
 				}
-		        }
-		        else
-		        {
-		        	ST_MOUSE_WHEEL(tmpms) =
+			}
+			else
+			{
+				ST_MOUSE_WHEEL(tmpms) =
 					(on) ? MMW_POINTER : MMW_OFF;
 			}
 			break;
-		case 57: /* ScrollOffPage */
-	        	ST_SCROLL_OFF_PAGE(tmpms) = on;
+
+		case 52: /* ScrollOffPage */
+			ST_SCROLL_OFF_PAGE(tmpms) = on;
 			break;
 
-		case 58: /* TrianglesUseFore */
+		case 53: /* TrianglesUseFore */
 			ST_TRIANGLES_USE_FORE(tmpms) = on;
 			break;
-		case 59: /* TitleColorset */
+
+		case 54: /* TitleColorset */
 			if (GetIntegerArguments(args, NULL, val, 1) == 0 ||
 			    *val < 0)
 			{
@@ -1496,11 +1481,13 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			has_gc_changed = True;
 			break;
-		case 60: /* TitleHilightBack */
+
+		case 55: /* TitleHilightBack */
 			ST_DO_HILIGHT_TITLE_BACK(tmpms) = on;
 			has_gc_changed = True;
 			break;
-		case 61: /* TitleFont */
+
+		case 56: /* TitleFont */
 			if (arg1 != NULL &&
 			    !(new_font = FlocaleLoadFont(dpy, arg1, "fvwm")))
 			{
@@ -1527,13 +1514,15 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			}
 			has_gc_changed = True;
 			break;
-		case 62: /* VerticalMargins */
+
+		case 57: /* VerticalMargins */
 			parse_vertical_margins_line(
 				args, &ST_VERTICAL_MARGIN_TOP(tmpms),
 				&ST_VERTICAL_MARGIN_BOTTOM(tmpms),
 				0, 0);
 			break;
-		case 63: /* UniqueHotKeyActivatesImmediate */
+
+		case 58: /* UniqueHotKeyActivatesImmediate */
 			ST_HOTKEY_ACTIVATES_IMMEDIATE(tmpms) = on;
 			break;
 

--- a/fvwm/menustyle.h
+++ b/fvwm/menustyle.h
@@ -20,8 +20,6 @@
 #define ST_IS_UPDATED(s)              ((s)->flags.is_updated)
 #define MST_IS_UPDATED(m)             ((m)->s->ms->flags.is_updated)
 /* look */
-#define ST_FACE(s)                    ((s)->look.face)
-#define MST_FACE(m)                   ((m)->s->ms->look.face)
 #define ST_DO_HILIGHT_BACK(s)         ((s)->look.flags.do_hilight_back)
 #define MST_DO_HILIGHT_BACK(m)        ((m)->s->ms->look.flags.do_hilight_back)
 #define ST_DO_HILIGHT_FORE(s)         ((s)->look.flags.do_hilight_fore)
@@ -43,14 +41,6 @@
 	((m)->s->ms->look.flags.has_triangle_relief)
 #define ST_HAS_SIDE_COLOR(s)          ((s)->look.flags.has_side_color)
 #define MST_HAS_SIDE_COLOR(m)         ((m)->s->ms->look.flags.has_side_color)
-#define ST_HAS_MENU_CSET(s)           ((s)->look.flags.has_menu_cset)
-#define MST_HAS_MENU_CSET(m)          ((m)->s->ms->look.flags.has_menu_cset)
-#define ST_HAS_ACTIVE_CSET(s)         ((s)->look.flags.has_active_cset)
-#define MST_HAS_ACTIVE_CSET(m)        ((m)->s->ms->look.flags.has_active_cset)
-#define ST_HAS_GREYED_CSET(s)         ((s)->look.flags.has_greyed_cset)
-#define MST_HAS_GREYED_CSET(m)        ((m)->s->ms->look.flags.has_greyed_cset)
-#define ST_HAS_TITLE_CSET(s)          ((s)->look.flags.has_title_cset)
-#define MST_HAS_TITLE_CSET(m)         ((m)->s->ms->look.flags.has_title_cset)
 #define ST_IS_ITEM_RELIEF_REVERSED(s) ((s)->look.flags.is_item_relief_reversed)
 #define MST_IS_ITEM_RELIEF_REVERSED(m)				\
 	((m)->s->ms->look.flags.is_item_relief_reversed)
@@ -115,12 +105,6 @@
 #define SHADOW_GC(g)                  ((g).shadow_gc)
 #define ST_MENU_STIPPLE_GC(s)         ((s)->look.MenuStippleGC)
 #define MST_MENU_STIPPLE_GC(m)        ((m)->s->ms->look.MenuStippleGC)
-#define ST_MENU_COLORS(s)             ((s)->look.MenuColors)
-#define MST_MENU_COLORS(m)            ((m)->s->ms->look.MenuColors)
-#define ST_MENU_ACTIVE_COLORS(s)      ((s)->look.MenuActiveColors)
-#define MST_MENU_ACTIVE_COLORS(m)     ((m)->s->ms->look.MenuActiveColors)
-#define ST_MENU_STIPPLE_COLORS(s)     ((s)->look.MenuStippleColors)
-#define MST_MENU_STIPPLE_COLORS(m)    ((m)->s->ms->look.MenuStippleColors)
 #define ST_PSTDFONT(s)                ((s)->look.pStdFont)
 #define MST_PSTDFONT(m)               ((m)->s->ms->look.pStdFont)
 #define ST_PTITLEFONT(s)              ((s)->look.pTitleFont)
@@ -185,17 +169,6 @@
 
 typedef enum
 {
-	/* menu types */
-	SimpleMenu = 0,
-	GradientMenu,
-	PixmapMenu,
-	TiledPixmapMenu,
-	SolidMenu
-	/* max button is 8 (0x8) */
-} MenuFaceType;
-
-typedef enum
-{
 	MDP_POST_MENU = 0,
 	MDP_ROOT_MENU = 1,
 	MDP_IGNORE = 2,
@@ -236,23 +209,6 @@ typedef struct MenuFeel
 	KeyCode select_on_release_key;
 } MenuFeel;
 
-typedef struct MenuFace
-{
-	union
-	{
-		FvwmPicture *p;
-		Pixel back;
-		struct
-		{
-			int npixels;
-			XColor *xcs;
-			Bool do_dither;
-		} grad;
-	} u;
-	MenuFaceType type;
-	char gradient_type;
-} MenuFace;
-
 typedef struct
 {
 	GC fore_gc;
@@ -263,7 +219,6 @@ typedef struct
 
 typedef struct MenuLook
 {
-	MenuFace face;
 	struct
 	{
 		unsigned do_hilight_back : 1;
@@ -274,13 +229,9 @@ typedef struct MenuLook
 		unsigned has_long_separators : 1;
 		unsigned has_triangle_relief : 1;
 		unsigned has_side_color : 1;
-		unsigned has_menu_cset : 1;
-		unsigned has_active_cset : 1;
-		unsigned has_greyed_cset : 1;
 		unsigned is_item_relief_reversed : 1;
 		unsigned using_default_font : 1;
 		unsigned triangles_use_fore : 1;
-		unsigned has_title_cset : 1;
 		unsigned do_hilight_title_back : 1;
 		unsigned using_default_titlefont : 1;
 	} flags;
@@ -314,9 +265,6 @@ typedef struct MenuLook
 	gc_quad_t active_gcs;
 	gc_quad_t stipple_gcs;
 	gc_quad_t title_gcs;
-	ColorPair MenuColors;
-	ColorPair MenuActiveColors;
-	ColorPair MenuStippleColors;
 	FlocaleFont *pStdFont;
 	FlocaleFont *pTitleFont;
 	int FontHeight;

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -920,8 +920,7 @@ void CMD_Send_WindowList(F_CMD_ARGS)
 		{
 			SendPacket(
 				mod, M_FOCUS_CHANGE, 5, 0, 0, (unsigned long)True,
-				(long)GetColor(DEFAULT_FORE_COLOR),
-				(long)GetColor(DEFAULT_BACK_COLOR));
+				(long)Colorset[0].fg, (long)Colorset[0].bg);
 		}
 		if (Scr.DefaultIcon != NULL)
 		{
@@ -996,9 +995,8 @@ void CMD_Send_WindowList(F_CMD_ARGS)
 		{
 			BroadcastPacket(
 				M_FOCUS_CHANGE, 5, (long)0, (long)0,
-				(unsigned long)True,
-				(long)GetColor(DEFAULT_FORE_COLOR),
-				(long)GetColor(DEFAULT_BACK_COLOR));
+				(unsigned long)True, (long)Colorset[0].fg,
+				(long)Colorset[0].bg);
 		}
 		else
 		{

--- a/libs/defaults.h
+++ b/libs/defaults.h
@@ -100,10 +100,6 @@
 #define DEFAULT_MENU_GRADIENT_PIXMAP_THICKNESS 4
 
 /*** colours ***/
-#define DEFAULT_FORE_COLOR                "black"
-#define DEFAULT_BACK_COLOR                "gray"
-#define DEFAULT_HILIGHT_COLOR             "white"
-#define DEFAULT_SHADOW_COLOR              "black"
 #define DEFAULT_CURSOR_FORE_COLOR         "black"
 #define DEFAULT_CURSOR_BACK_COLOR         "white"
 

--- a/libs/defaults.h
+++ b/libs/defaults.h
@@ -44,9 +44,7 @@
  */
 /* The first option of the default menu style must be fvwm/win/mwm/....
  * fvwm may crash if not. */
-#define DEFAULT_MENU_STYLE \
-        "MenuStyle * fvwm, Foreground black, Background grey, " \
-        "Greyed slategrey, MenuColorset, ActiveColorset, GreyedColorset"
+#define DEFAULT_MENU_STYLE "MenuStyle * fvwm"
 #define DEFAULT_CLICKTIME                150 /* ms */
 #define DEFAULT_POPUP_DELAY               15 /* ms*10 */
 #define DEFAULT_POPDOWN_DELAY             15 /* ms*10 */


### PR DESCRIPTION
MenuStyle updates. Remove the old parser, it has been depreciated long enough. Same for the old 'FooOff' options.

Remove the ability to configure the menu using the old Foreground, Background, Greyed, and MenuFace options. This is all done via Colorsets now. This address #753 

This just removes the ability to configure or set MenuStyle via those old methods, there is still a lot of cleanup left in the code. There are multiple macros like ST_MENU_COLORS that no longer need to be used, in addition lots of conditional statements around them that can be removed, as it can now be assumed there will always be a colorset configured.

This is just a draft to start.