### PR TITLE
libs/FShm.h: Remove trailing semicolon

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2009,7 +2009,7 @@ toggle_prev_monitor_state(struct monitor *this, struct monitor *prev,
 
 #if DEBUG_ENTERNOTIFY
 static int ecount=0;
-#define ENTER_DBG(x) fprintf x;
+#define ENTER_DBG(x) fprintf x
 #else
 #define ENTER_DBG(x) do { } while (0)
 #endif

--- a/fvwm/focus.h
+++ b/fvwm/focus.h
@@ -13,11 +13,11 @@
 #define FOCUS_SET(w, fw) _focus_set(w, fw)
 #define FOCUS_RESET() _focus_reset()
 
-#define SetFocusWindow(a, b, c) _SetFocusWindow(a, b, c, False);
-#define SetFocusWindowClientEntered(a, b, c) _SetFocusWindow(a, b, c, True);
-#define ReturnFocusWindow(a) _ReturnFocusWindow(a);
-#define DeleteFocus(a) _DeleteFocus(a);
-#define ForceDeleteFocus() _ForceDeleteFocus();
+#define SetFocusWindow(a, b, c) _SetFocusWindow(a, b, c, False)
+#define SetFocusWindowClientEntered(a, b, c) _SetFocusWindow(a, b, c, True)
+#define ReturnFocusWindow(a) _ReturnFocusWindow(a)
+#define DeleteFocus(a) _DeleteFocus(a)
+#define ForceDeleteFocus() _ForceDeleteFocus()
 
 
 /* ---------------------------- type definitions --------------------------- */

--- a/libs/FShm.h
+++ b/libs/FShm.h
@@ -52,7 +52,7 @@ typedef struct {
 
 /* shm */
 #define Fshmget(a, b, c) 0
-#define Fshmat(a, b, c)  NULL;
+#define Fshmat(a, b, c)  NULL
 #define Fshmdt(a)
 #define Fshmctl(a, b, c)
 


### PR DESCRIPTION
Macros should not use a trailing semicolon, so remove it.

Signed-off-by: Elyes Haouas <ehaouas@noos.fr>