### PR TITLE
AddWindow: don't crash reparenting

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2599,12 +2599,12 @@ FvwmWindow *AddWindow(
 	}
 	{
 		unsigned int nchildren;
-		Window parent, *children;
+		Window parent, *children = NULL;
 		Status rc;
 
 		rc = XQueryTree(
 			dpy, w, &JunkRoot, &parent, &children, &nchildren);
-		if (nchildren > 0)
+		if (nchildren > 0 && children != NULL)
 		{
 			XFree(children);
 		}


### PR DESCRIPTION
When identifying windows via XQueryTree(), ensure that both children and
nchildren are considered.

Fixes #785

Signed-off-by: Thomas Adam <thomas@fvwm.org>
