### PR TITLE
dist: doc: include all doc sources

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -17,7 +17,7 @@ else
 MODULE_ADOC = $(MODULE_ADOC_SRCS)
 endif
 
-EXTRA_DIST = $(MODULE_ADOC)
+EXTRA_DIST = $(MODULE_ADOC_SRCS)
 
 nothing:
 


### PR DESCRIPTION
Even though we filter out some documentation sources when building fvwm3
(due to FvwmConsole not always being needed if FvwmPrompt is being
used), we still need to make sure that *all* sources are included, as
this is something which can be decided at ./configure time.
