### PR TITLE
Use the global screen for geometry strings which don't specify a monitor

### DIFF
--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -219,8 +219,7 @@ monitor_resolve_name(const char *scr)
 	}
 	/* "@g" is for the global screen. */
 	if (strcmp(scr, "g") == 0) {
-		monitor_refresh_global();
-		m = monitor_global;
+		m = monitor_get_global();
 	}
 	/* "@c" is for the current screen. */
 	else if (strcmp(scr, "c") == 0)
@@ -678,15 +677,13 @@ FindScreen(fscreen_scr_arg *arg, fscreen_scr_t screen)
 	fscreen_scr_arg  tmp;
 
 	if (monitor_get_count() == 0) {
-		monitor_refresh_global();
-		return (monitor_global);
+		return (monitor_get_global());
 	}
 
 	switch (screen)
 	{
 	case FSCREEN_GLOBAL:
-		monitor_refresh_global();
-		m = monitor_global;
+		m = monitor_get_global();
 		break;
 	case FSCREEN_PRIMARY:
 		m = monitor_by_primary();
@@ -769,8 +766,7 @@ Bool FScreenGetScrRect(fscreen_scr_arg *arg, fscreen_scr_t screen,
 	struct monitor	*m = FindScreen(arg, screen);
 	if (m == NULL) {
 		fvwm_debug(__func__, "m is NULL, using global screen\n");
-		monitor_refresh_global();
-		m = monitor_global;
+		m = monitor_get_global();
 	}
 
 	if (x)

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -986,7 +986,7 @@ int FScreenParseGeometry(
 	char *parsestring, int *x_return, int *y_return,
 	unsigned int *width_return, unsigned int *height_return)
 {
-	struct monitor	*m = monitor_get_current();
+	struct monitor	*m = NULL;
 	int		 rc, x, y, w, h;
 
 	x = 0;
@@ -1001,11 +1001,16 @@ int FScreenParseGeometry(
 			parsestring, x_return, y_return, width_return,
 			height_return, &scr);
 
-		m = monitor_resolve_name(scr);
-		if (m == NULL)
-		{
-			/* fall back to current screen */
-			m = monitor_get_current();
+		if ((m = monitor_resolve_name(scr)) == NULL) {
+			/* If the monitor we tried to look up is NULL, it will
+			 * be because there was no geometry string specifying
+			 * the monitor name.
+			 *
+			 * In such cases, we should assume that the user has
+			 * requested the geometry to be relevant to the global
+			 * screen.
+			 */
+			m = monitor_get_global();
 		}
 		x = m->si->x;
 		y = m->si->y;

--- a/modules/FvwmIconMan/x.c
+++ b/modules/FvwmIconMan/x.c
@@ -737,22 +737,10 @@ void X_init_manager (int man_id)
 	man->geometry.boxheight = height;
     }
   }
-  FScreenGetScrRect(NULL, FSCREEN_PRIMARY, &man->managed_g.x, &man->managed_g.y,
-		    &man->managed_g.width, &man->managed_g.height);
-  man->geometry.x = man->managed_g.x;
-  man->geometry.y = man->managed_g.y;
   if (man->geometry_str) {
-    fscreen_scr_arg arg;
-    arg.mouse_ev = NULL;
-    arg.name = NULL;
-
-    geometry_mask = FScreenParseGeometryWithScreen(
+    geometry_mask = FScreenParseGeometry(
       man->geometry_str, &man->geometry.x, &man->geometry.y,
-      &man->geometry.cols, &man->geometry.rows, NULL);
-
-    FScreenGetScrRect(
-      &arg, FSCREEN_BY_NAME, &man->managed_g.x, &man->managed_g.y,
-      &man->managed_g.width, &man->managed_g.height);
+      &man->geometry.cols, &man->geometry.rows);
 
     if (geometry_mask & XValue)
       man->geometry.x += man->managed_g.x;


### PR DESCRIPTION
When interpreting geometry strings, fvwm has an extension to specify a screen name, such as:

```
100x100+2+90@HDMI-1
```

This would therefore make the window appear at position `100x100+2+90` relative to monitor `HDMI-1`.

Normal X11 geometry strings do not have this monitor specifier -- and in such cases, that geometry should be interpreted relative to the position of **all** the screens, which is called the global screen.

Without this change in this PR, the geometry was relative to the current screen which is confusing.

Fixes #813
Fixes #810 