### PR TITLE
code: rename functions with two underscores

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -1408,7 +1408,7 @@ static void setup_key_and_button_grabs(FvwmWindow *fw)
 	return;
 }
 
-static void __add_window_handle_x_resources(FvwmWindow *fw)
+static void _add_window_handle_x_resources(FvwmWindow *fw)
 {
 	int client_argc = 0;
 	char **client_argv = NULL;
@@ -2161,7 +2161,7 @@ FvwmWindow *AddWindow(
 	setup_class_and_resource(fw);
 
 	/****** style setup ******/
-	__add_window_handle_x_resources(fw);
+	_add_window_handle_x_resources(fw);
 	/* get merged styles */
 	lookup_style(fw, &style);
 	sflags = SGET_FLAGS_POINTER(style);

--- a/fvwm/bindings.c
+++ b/fvwm/bindings.c
@@ -213,7 +213,7 @@ static int bind_get_bound_button_contexts(
 	return bcontext;
 }
 
-static void __rebind_global_key(Binding **pblist, int Button_Key)
+static void _rebind_global_key(Binding **pblist, int Button_Key)
 {
 	Binding *b;
 
@@ -464,7 +464,7 @@ static int ParseBinding(
 			}
 			if (ret)
 			{
-				__rebind_global_key(
+				_rebind_global_key(
 					pblist, rmlist->Button_Key);
 			}
 		}

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -507,7 +507,7 @@ static char *ReadTitleButton(
 }
 
 /* Remove the given decor from all windows */
-static void __remove_window_decors(F_CMD_ARGS, FvwmDecor *d)
+static void _remove_window_decors(F_CMD_ARGS, FvwmDecor *d)
 {
 	const exec_context_t *exc2;
 	exec_context_changes_t ecc;
@@ -1287,7 +1287,7 @@ void update_decors_colorset(int cset)
 	}
 }
 
-static Bool __parse_vector_line_one_coord(
+static Bool _parse_vector_line_one_coord(
 	char **ret_action, int *pcoord, int *poff, char *action)
 {
 	int offset;
@@ -1327,7 +1327,7 @@ static Bool __parse_vector_line_one_coord(
 	return True;
 }
 
-static Bool __parse_vector_line(
+static Bool _parse_vector_line(
 	char **ret_action, int *px, int *py, int *pxoff, int *pyoff, int *pc,
 	char *action)
 {
@@ -1336,7 +1336,7 @@ static Bool __parse_vector_line(
 	int n;
 
 	*ret_action = action;
-	if (__parse_vector_line_one_coord(&action, px, pxoff, action) == False)
+	if (_parse_vector_line_one_coord(&action, px, pxoff, action) == False)
 	{
 		return False;
 	}
@@ -1345,7 +1345,7 @@ static Bool __parse_vector_line(
 		return False;
 	}
 	action++;
-	if (__parse_vector_line_one_coord(&action, py, pyoff, action) == False)
+	if (_parse_vector_line_one_coord(&action, py, pyoff, action) == False)
 	{
 		return False;
 	}
@@ -1692,7 +1692,7 @@ Bool ReadDecorFace(char *s, DecorFace *df, int button, int verbose)
 				int yoff = 0;
 				int c;
 
-				if (__parse_vector_line(
+				if (_parse_vector_line(
 					    &s, &x, &y, &xoff, &yoff, &c, s) ==
 				    False)
 				{
@@ -3201,7 +3201,7 @@ void CMD_DestroyDecor(F_CMD_ARGS)
 	{
 		if (!do_recreate)
 		{
-			__remove_window_decors(F_PASS_ARGS, found);
+			_remove_window_decors(F_PASS_ARGS, found);
 		}
 		DestroyFvwmDecor(found);
 		if (do_recreate)
@@ -3753,7 +3753,7 @@ static Bool FKeysymToKeycode (Display *disp, KeySym keysym,
 	return False;
 }
 
-static void __fake_event(F_CMD_ARGS, FakeEventType type)
+static void _fake_event(F_CMD_ARGS, FakeEventType type)
 {
 	char *token;
 	char *optlist[] = {
@@ -4026,14 +4026,14 @@ static void __fake_event(F_CMD_ARGS, FakeEventType type)
 
 void CMD_FakeClick(F_CMD_ARGS)
 {
-	__fake_event(F_PASS_ARGS, FakeMouseEvent);
+	_fake_event(F_PASS_ARGS, FakeMouseEvent);
 
 	return;
 }
 
 void CMD_FakeKeypress(F_CMD_ARGS)
 {
-	__fake_event(F_PASS_ARGS, FakeKeyEvent);
+	_fake_event(F_PASS_ARGS, FakeKeyEvent);
 
 	return;
 }

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -1427,7 +1427,7 @@ static void direction_cmd(F_CMD_ARGS, Bool is_scan)
 	return;
 }
 
-static int __rc_matches_rcstring_consume(
+static int _rc_matches_rcstring_consume(
 	char **ret_rest, cond_rc_t *cond_rc, char *action)
 {
 	cond_rc_enum match_rc;
@@ -1861,7 +1861,7 @@ void CMD_TestRc(F_CMD_ARGS)
 		/* useless if no return code to compare to is given */
 		return;
 	}
-	if (__rc_matches_rcstring_consume(&rest, cond_rc, action) &&
+	if (_rc_matches_rcstring_consume(&rest, cond_rc, action) &&
 	    rest != NULL)
 	{
 		/* execute the command in root window context; overwrite the

--- a/fvwm/decorations.c
+++ b/fvwm/decorations.c
@@ -607,7 +607,7 @@ void SelectDecor(FvwmWindow *t, window_style *pstyle, short *buttons)
 	return;
 }
 
-static Bool __is_resize_allowed(
+static Bool _is_resize_allowed(
 	const FvwmWindow *t, int functions, request_origin_t request_origin)
 {
         if (!HAS_OVERRIDE_SIZE_HINTS(t) &&
@@ -766,7 +766,7 @@ Bool is_function_allowed(
 		}
 		break;
 	case F_RESIZE:
-	        if(!__is_resize_allowed(t, functions, request_origin))
+	        if(!_is_resize_allowed(t, functions, request_origin))
 		{
 		        return False;
 		}
@@ -780,7 +780,7 @@ Bool is_function_allowed(
 		break;
 	case F_MAXIMIZE:
 	        if (IS_MAXIMIZE_FIXED_SIZE_DISALLOWED(t) &&
-		    !__is_resize_allowed(t, functions, request_origin))
+		    !_is_resize_allowed(t, functions, request_origin))
 		{
 		       return False;
 		}

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1356,8 +1356,8 @@ static Bool _pred_button_click(
 	return False;
 }
 
-/* Helper function for __handle_focus_raise_click(). */
-static Bool __test_for_motion(int x0, int y0)
+/* Helper function for _handle_focus_raise_click(). */
+static Bool _test_for_motion(int x0, int y0)
 {
 	int x;
 	int y;
@@ -1410,8 +1410,8 @@ static Bool __test_for_motion(int x0, int y0)
 	return True;
 }
 
-/* Helper function for __handle_focus_raise_click(). */
-static void __check_click_to_focus_or_raise(
+/* Helper function for _handle_focus_raise_click(). */
+static void _check_click_to_focus_or_raise(
 	hfrc_ret_t *ret_args, const exec_context_t *exc)
 {
 	FvwmWindow * const fw = exc->w.fw;
@@ -1452,9 +1452,9 @@ static void __check_click_to_focus_or_raise(
 		/* Pass further events to the application and check if a button
 		 * release or motion event occurs next.  If we don't do this
 		 * here, the pointer will seem to be frozen in
-		 * __test_for_motion(). */
+		 * _test_for_motion(). */
 		XAllowEvents(dpy, ReplayPointer, CurrentTime);
-		if (__test_for_motion(te->xbutton.x_root, te->xbutton.y_root))
+		if (_test_for_motion(te->xbutton.x_root, te->xbutton.y_root))
 		{
 			/* the pointer was moved, process event normally */
 			ret_args->do_focus = 0;
@@ -1483,7 +1483,7 @@ static void __check_click_to_focus_or_raise(
 }
 
 /* Finds out if the click on a window must be used to focus or raise it. */
-static void __handle_focus_raise_click(
+static void _handle_focus_raise_click(
 	hfrc_ret_t *ret_args, const exec_context_t *exc)
 {
 	memset(ret_args, 0, sizeof(*ret_args));
@@ -1510,14 +1510,14 @@ static void __handle_focus_raise_click(
 	}
 	else
 	{
-		__check_click_to_focus_or_raise(ret_args, exc);
+		_check_click_to_focus_or_raise(ret_args, exc);
 	}
 
 	return;
 }
 
 /* Helper function for HandleButtonPress */
-static Bool __is_bpress_window_handled(const exec_context_t *exc)
+static Bool _is_bpress_window_handled(const exec_context_t *exc)
 {
 	Window eventw;
 	const XEvent *te = exc->x.etrigger;
@@ -1556,8 +1556,8 @@ static Bool __is_bpress_window_handled(const exec_context_t *exc)
 	return True;
 }
 
-/* Helper function for __handle_bpress_on_managed */
-static Bool __handle_click_to_focus(const exec_context_t *exc)
+/* Helper function for _handle_bpress_on_managed */
+static Bool _handle_click_to_focus(const exec_context_t *exc)
 {
 	fpol_set_focus_by_t set_by;
 
@@ -1586,8 +1586,8 @@ static Bool __handle_click_to_focus(const exec_context_t *exc)
 	return focus_is_focused(exc->w.fw);
 }
 
-/* Helper function for __handle_bpress_on_managed */
-static Bool __handle_click_to_raise(const exec_context_t *exc)
+/* Helper function for _handle_bpress_on_managed */
+static Bool _handle_click_to_raise(const exec_context_t *exc)
 {
 	Bool rc = False;
 	int is_focused;
@@ -1601,8 +1601,8 @@ static Bool __handle_click_to_raise(const exec_context_t *exc)
 	return rc;
 }
 
-/* Helper function for __handle_bpress_on_managed */
-static Bool __handle_bpress_action(
+/* Helper function for _handle_bpress_on_managed */
+static Bool _handle_bpress_action(
 	const exec_context_t *exc, char *action)
 {
 	window_parts part;
@@ -1647,7 +1647,7 @@ static Bool __handle_bpress_action(
 }
 
 /* Handles button presses on the root window. */
-static void __handle_bpress_on_root(const exec_context_t *exc)
+static void _handle_bpress_on_root(const exec_context_t *exc)
 {
 	char *action;
 
@@ -1673,7 +1673,7 @@ static void __handle_bpress_on_root(const exec_context_t *exc)
 }
 
 /* Handles button presses on unmanaged windows */
-static void __handle_bpress_on_unmanaged(const exec_context_t *exc)
+static void _handle_bpress_on_unmanaged(const exec_context_t *exc)
 {
 	/* Pass the event to the application. */
 	XAllowEvents(dpy, ReplayPointer, CurrentTime);
@@ -1683,7 +1683,7 @@ static void __handle_bpress_on_unmanaged(const exec_context_t *exc)
 }
 
 /* Handles button presses on managed windows */
-static void __handle_bpress_on_managed(const exec_context_t *exc)
+static void _handle_bpress_on_managed(const exec_context_t *exc)
 {
 	char *action;
 	hfrc_ret_t f;
@@ -1692,11 +1692,11 @@ static void __handle_bpress_on_managed(const exec_context_t *exc)
 
 	e = exc->x.etrigger;
 	/* Now handle click to focus and click to raise. */
-	__handle_focus_raise_click(&f, exc);
+	_handle_focus_raise_click(&f, exc);
 	PressedW = (f.do_forbid_function) ? None : exc->w.w;
 	if (f.do_focus)
 	{
-		if (!__handle_click_to_focus(exc))
+		if (!_handle_click_to_focus(exc))
 		{
 			/* Window didn't accept the focus; pass the click to
 			 * the application. */
@@ -1705,7 +1705,7 @@ static void __handle_bpress_on_managed(const exec_context_t *exc)
 	}
 	if (f.do_raise)
 	{
-		if (__handle_click_to_raise(exc) == True)
+		if (_handle_click_to_raise(exc) == True)
 		{
 			/* We can't raise the window immediately because the
 			 * action bound to the click might be "Lower" or
@@ -1724,7 +1724,7 @@ static void __handle_bpress_on_managed(const exec_context_t *exc)
 			e->xbutton.state, GetUnusedModifiers(),
 			exc->w.wcontext, BIND_BUTTONPRESS, &fw->class,
 			fw->name.name);
-		if (__handle_bpress_action(exc, action))
+		if (_handle_bpress_action(exc, action))
 		{
 			f.do_swallow_click = 1;
 		}
@@ -1756,7 +1756,7 @@ static void __handle_bpress_on_managed(const exec_context_t *exc)
 }
 
 /* restore focus stolen by unmanaged */
-static void __refocus_stolen_focus_win(const evh_args_t *ea)
+static void _refocus_stolen_focus_win(const evh_args_t *ea)
 {
 	FOCUS_SET(Scr.StolenFocusWin, Scr.StolenFocusFvwmWin);
 	ea->exc->x.etrigger->xfocus.window = Scr.StolenFocusWin;
@@ -1859,17 +1859,17 @@ monitor_emit_broadcast(void)
 void HandleButtonPress(const evh_args_t *ea)
 {
 	GrabEm(CRS_NONE, GRAB_PASSIVE);
-	if (__is_bpress_window_handled(ea->exc) == False)
+	if (_is_bpress_window_handled(ea->exc) == False)
 	{
-		__handle_bpress_on_unmanaged(ea->exc);
+		_handle_bpress_on_unmanaged(ea->exc);
 	}
 	else if (ea->exc->w.fw != NULL)
 	{
-		__handle_bpress_on_managed(ea->exc);
+		_handle_bpress_on_managed(ea->exc);
 	}
 	else
 	{
-		__handle_bpress_on_root(ea->exc);
+		_handle_bpress_on_root(ea->exc);
 	}
 	UngrabEm(GRAB_PASSIVE);
 
@@ -2242,7 +2242,7 @@ void HandleEnterNotify(const evh_args_t *ea)
 			Scr.UnknownWinFocused != None && sf != NULL &&
 			sf == Scr.StolenFocusFvwmWin)
 		{
-			__refocus_stolen_focus_win(ea);
+			_refocus_stolen_focus_win(ea);
 		}
 		if (Scr.ColormapFocus == COLORMAP_FOLLOWS_MOUSE)
 		{
@@ -2276,7 +2276,7 @@ void HandleEnterNotify(const evh_args_t *ea)
 			(sf = get_focus_window()) != NULL &&
 			sf == Scr.StolenFocusFvwmWin)
 		{
-			__refocus_stolen_focus_win(ea);
+			_refocus_stolen_focus_win(ea);
 		}
 		/* check for edge commands */
 		if (ewp->window == m->PanFrameTop.win)
@@ -2400,7 +2400,7 @@ void HandleEnterNotify(const evh_args_t *ea)
 		Scr.UnknownWinFocused != None && sf != NULL &&
 		sf == Scr.StolenFocusFvwmWin)
 	{
-			__refocus_stolen_focus_win(ea);
+			_refocus_stolen_focus_win(ea);
 	}
 	/* We get an EnterNotify with mode == UnGrab when fvwm releases the
 	 * grab held during iconification. We have to ignore this, or icon
@@ -2522,7 +2522,7 @@ void HandleFocusIn(const evh_args_t *ea)
 				Scr.focus_in_pending_window->name.name : "");
 		}
 		Scr.focus_in_requested_window = NULL;
-		__refocus_stolen_focus_win(ea);
+		_refocus_stolen_focus_win(ea);
 
 		return;
 	}
@@ -2643,13 +2643,13 @@ void HandleFocusOut(const evh_args_t *ea)
 	if (Scr.UnknownWinFocused != None && Scr.StolenFocusWin != None &&
 	    ea->exc->x.etrigger->xfocus.window == Scr.UnknownWinFocused)
 	{
-		__refocus_stolen_focus_win(ea);
+		_refocus_stolen_focus_win(ea);
 	}
 
 	return;
 }
 
-void __handle_key(const evh_args_t *ea, Bool is_press)
+void _handle_key(const evh_args_t *ea, Bool is_press)
 {
 	char *action;
 	FvwmWindow *sf;
@@ -2760,12 +2760,12 @@ void __handle_key(const evh_args_t *ea, Bool is_press)
 
 void HandleKeyPress(const evh_args_t *ea)
 {
-	__handle_key(ea, True);
+	_handle_key(ea, True);
 }
 
 void HandleKeyRelease(const evh_args_t *ea)
 {
-	__handle_key(ea, False);
+	_handle_key(ea, False);
 }
 
 void HandleLeaveNotify(const evh_args_t *ea)

--- a/fvwm/execcontext.c
+++ b/fvwm/execcontext.c
@@ -48,7 +48,7 @@ static int nx = 0;
 
 /* ---------------------------- local functions ---------------------------- */
 
-static void __exc_change_context(
+static void _exc_change_context(
 	exec_context_t *exc, exec_context_changes_t *ecc,
 	exec_context_change_mask_t mask)
 {
@@ -130,7 +130,7 @@ const exec_context_t *exc_create_context(
 		}
 	}
 	exc = (exec_context_t *)exc_create_null_context();
-	__exc_change_context(exc, ecc, mask);
+	_exc_change_context(exc, ecc, mask);
 
 	return exc;
 }
@@ -156,7 +156,7 @@ const exec_context_t *exc_clone_context(
 		fvwm_debug(__func__, "%p\n", exc);
 	}
 	memcpy(exc, excin, sizeof(*exc));
-	__exc_change_context(exc, ecc, mask);
+	_exc_change_context(exc, ecc, mask);
 
 	return exc;
 }

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -248,7 +248,7 @@ enum
 
 /* ---------------------------- local functions ---------------------------- */
 
-int __eae_parse_range(char *input, int *lower, int *upper)
+int _eae_parse_range(char *input, int *lower, int *upper)
 {
 	int rc;
 	int n;
@@ -307,7 +307,7 @@ static signed int expand_args_extended(
 	int i;
 	size_t len;
 
-	rc = __eae_parse_range(input, &lower, &upper);
+	rc = _eae_parse_range(input, &lower, &upper);
 	if (rc == -1)
 	{
 		return -1;

--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -121,7 +121,7 @@ static Bool focus_get_fpol_context_flag(
 /*
  * Helper functions for setting the focus
  */
-static void __try_program_focus(Window w, const FvwmWindow *fw)
+static void _try_program_focus(Window w, const FvwmWindow *fw)
 {
 	if (fw && WM_TAKES_FOCUS(fw) &&
 	    FP_DO_FOCUS_BY_PROGRAM(FW_FOCUS_POLICY(fw)))
@@ -132,7 +132,7 @@ static void __try_program_focus(Window w, const FvwmWindow *fw)
 	return;
 }
 
-static Bool __try_forbid_user_focus(
+static Bool _try_forbid_user_focus(
 	Window w, FvwmWindow *fw)
 {
 	if (fw == NULL ||
@@ -143,7 +143,7 @@ static Bool __try_forbid_user_focus(
 	if (WM_TAKES_FOCUS(fw))
 	{
 		/* give it a chance to take the focus itself */
-		__try_program_focus(w, fw);
+		_try_program_focus(w, fw);
 		XFlush(dpy);
 	}
 	else
@@ -156,7 +156,7 @@ static Bool __try_forbid_user_focus(
 	return True;
 }
 
-static Bool __check_allow_focus(
+static Bool _check_allow_focus(
 	Window w, FvwmWindow *fw, fpol_set_focus_by_t set_by)
 {
 	FvwmWindow *sf;
@@ -183,7 +183,7 @@ static Bool __check_allow_focus(
 	return False;
 }
 
-static void __update_windowlist(
+static void _update_windowlist(
 	FvwmWindow *fw, fpol_set_focus_by_t set_by,
 	int is_focus_by_flip_focus_cmd)
 {
@@ -253,7 +253,7 @@ static void __update_windowlist(
 	return;
 }
 
-static Bool __try_other_screen_focus(const FvwmWindow *fw)
+static Bool _try_other_screen_focus(const FvwmWindow *fw)
 {
 	if (fw == NULL && !Scr.flags.is_pointer_on_this_screen)
 	{
@@ -277,23 +277,23 @@ static Bool __try_other_screen_focus(const FvwmWindow *fw)
 /*
  * Sets the input focus to the indicated window.
  */
-static void __set_focus_to_fwin(
+static void _set_focus_to_fwin(
 	Window w, FvwmWindow *fw, sftfwin_args_t *args)
 {
 	FvwmWindow *sf;
 	struct monitor	*m;
 
-	if (__try_forbid_user_focus(w, fw) == True)
+	if (_try_forbid_user_focus(w, fw) == True)
 	{
 		return;
 	}
-	__try_program_focus(w, fw);
-	if (__check_allow_focus(w, fw, args->set_by) == False)
+	_try_program_focus(w, fw);
+	if (_check_allow_focus(w, fw, args->set_by) == False)
 	{
 		return;
 	}
-	__update_windowlist(fw, args->set_by, args->is_focus_by_flip_focus_cmd);
-	if (__try_other_screen_focus(fw) == True)
+	_update_windowlist(fw, args->set_by, args->is_focus_by_flip_focus_cmd);
+	if (_try_other_screen_focus(fw) == True)
 	{
 		return;
 	}
@@ -406,7 +406,7 @@ static void set_focus_to_fwin(
 		focus_grab_buttons(sf);
 		return;
 	}
-	__set_focus_to_fwin(w, fw, args);
+	_set_focus_to_fwin(w, fw, args);
 	/* Make sure the button grabs on the new and the old focused windows
 	 * are up to date. */
         if (args->client_entered)
@@ -589,7 +589,7 @@ static Bool focus_query_grab_buttons(FvwmWindow *fw, Bool client_entered)
 	return (flag) ? True : False;
 }
 
-static FvwmWindow *__restore_focus_after_unmap(
+static FvwmWindow *_restore_focus_after_unmap(
 	const FvwmWindow *fw, Bool do_skip_marked_transients)
 {
 	FvwmWindow *t = NULL;
@@ -642,7 +642,7 @@ static FvwmWindow *__restore_focus_after_unmap(
  * Moves focus to specified window; only to be called bay Focus and FlipFocus
  *
  */
-static void __activate_window_by_command(
+static void _activate_window_by_command(
 	F_CMD_ARGS, int is_focus_by_flip_focus_cmd)
 {
 	int cx;
@@ -755,7 +755,7 @@ static void __activate_window_by_command(
 	return;
 }
 
-static void __focus_grab_one_button(
+static void _focus_grab_one_button(
 	FvwmWindow *fw, int button, int grab_buttons)
 {
 	Bool do_grab;
@@ -886,7 +886,7 @@ Bool focus_query_close_release_focus(const FvwmWindow *fw)
 	return False;
 }
 
-static void __focus_grab_buttons(FvwmWindow *fw, Bool client_entered)
+static void _focus_grab_buttons(FvwmWindow *fw, Bool client_entered)
 {
 	int i;
 	Bool do_grab_window = False;
@@ -909,7 +909,7 @@ static void __focus_grab_buttons(FvwmWindow *fw, Bool client_entered)
 		MyXGrabServer(dpy);
 		for (i = 0; i < NUMBER_OF_EXTENDED_MOUSE_BUTTONS; i++)
 		{
-			__focus_grab_one_button(fw, i, grab_buttons);
+			_focus_grab_one_button(fw, i, grab_buttons);
 		}
 		MyXUngrabServer (dpy);
 	}
@@ -919,12 +919,12 @@ static void __focus_grab_buttons(FvwmWindow *fw, Bool client_entered)
 
 void focus_grab_buttons(FvwmWindow *fw)
 {
-        __focus_grab_buttons(fw, False);
+        _focus_grab_buttons(fw, False);
 }
 
 void focus_grab_buttons_client_entered(FvwmWindow *fw)
 {
-        __focus_grab_buttons(fw, True);
+        _focus_grab_buttons(fw, True);
 }
 
 void focus_grab_buttons_on_layer(int layer)
@@ -1040,7 +1040,7 @@ void restore_focus_after_unmap(
 
 	if (focus_is_focused(fw))
 	{
-		set_focus_to = __restore_focus_after_unmap(
+		set_focus_to = _restore_focus_after_unmap(
 			fw, do_skip_marked_transients);
 	}
 	if (fw == Scr.pushed_window)
@@ -1207,14 +1207,14 @@ void refresh_focus(const FvwmWindow *fw)
 void CMD_FlipFocus(F_CMD_ARGS)
 {
 	/* Reorder the window list */
-	__activate_window_by_command(F_PASS_ARGS, 1);
+	_activate_window_by_command(F_PASS_ARGS, 1);
 
 	return;
 }
 
 void CMD_Focus(F_CMD_ARGS)
 {
-	__activate_window_by_command(F_PASS_ARGS, 0);
+	_activate_window_by_command(F_PASS_ARGS, 0);
 
 	return;
 }

--- a/fvwm/frame.c
+++ b/fvwm/frame.c
@@ -347,7 +347,7 @@ static void frame_setup_titlebar(
 	return;
 }
 
-static void __frame_setup_window(
+static void _frame_setup_window(
 	FvwmWindow *fw, rectangle *frame_g, Bool do_send_configure_notify,
 	Bool do_force, Bool is_application_request)
 {
@@ -2054,7 +2054,7 @@ void frame_setup_window(
 	g.y = y;
 	g.width = w;
 	g.height = h;
-	__frame_setup_window(fw, &g, do_send_configure_notify, False, False);
+	_frame_setup_window(fw, &g, do_send_configure_notify, False, False);
 
 	return;
 }
@@ -2069,7 +2069,7 @@ void frame_setup_window_app_request(
 	g.y = y;
 	g.width = w;
 	g.height = h;
-	__frame_setup_window(fw, &g, do_send_configure_notify, False, True);
+	_frame_setup_window(fw, &g, do_send_configure_notify, False, True);
 
 	return;
 }
@@ -2084,7 +2084,7 @@ void frame_force_setup_window(
 	g.y = y;
 	g.width = w;
 	g.height = h;
-	__frame_setup_window(fw, &g, do_send_configure_notify, True, False);
+	_frame_setup_window(fw, &g, do_send_configure_notify, True, False);
 
 	return;
 }

--- a/fvwm/functions.c
+++ b/fvwm/functions.c
@@ -88,7 +88,7 @@ static const cmdparser_hooks_t *cmdparser_hooks = NULL;
 
 /* ---------------------------- local functions ---------------------------- */
 
-static int __context_has_window(
+static int _context_has_window(
 	const exec_context_t *exc, execute_flags_t flags)
 {
 	if (exc->w.fw != NULL)
@@ -388,7 +388,7 @@ static Bool DeferExecution(
 	return False;
 }
 
-static void __execute_command_line(
+static void _execute_command_line(
 	cond_rc_t *cond_rc, const exec_context_t *exc, char *xaction,
 	cmdparser_context_t *caller_pc,
 	func_flags_t exec_flags, char *all_pos_args_string,
@@ -640,7 +640,7 @@ static void __execute_command_line(
 		}
 		else if (
 			(bif->flags & FUNC_NEEDS_WINDOW) &&
-			!__context_has_window(
+			!_context_has_window(
 				exc, bif->flags & FUNC_ALLOW_UNMANAGED))
 		{
 			if (PARSER_DEBUG)
@@ -828,7 +828,7 @@ static cfunc_action_t CheckActionType(
 	return (is_button_pressed) ? CF_HOLD : CF_TIMEOUT;
 }
 
-static void __run_complex_function_items(
+static void _run_complex_function_items(
 	cond_rc_t *cond_rc, char cond, FvwmFunction *func,
 	const exec_context_t *exc, cmdparser_context_t *caller_pc,
 	char *all_pos_args_string, char *pos_arg_tokens[],
@@ -864,7 +864,7 @@ static void __run_complex_function_items(
 				return;
 			}
 			(*run_item_count)++;
-			__execute_command_line(
+			_execute_command_line(
 				cond_rc, exc, fi->action, caller_pc,
 				FUNC_DONT_DEFER, all_pos_args_string,
 				pos_arg_tokens, has_ref_window_moved);
@@ -882,7 +882,7 @@ static void __run_complex_function_items(
 	return;
 }
 
-static void __cf_cleanup(
+static void _cf_cleanup(
 	FvwmFunction *func, int *depth, int *run_item_count,
 	char *all_pos_args_string, char **pos_arg_tokens, cond_rc_t *cond_rc)
 {
@@ -1057,7 +1057,7 @@ static void execute_complex_function(
 	if (has_immediate)
 	{
 		exc2 = exc_clone_context(exc, &ecc, mask);
-		__run_complex_function_items(
+		_run_complex_function_items(
 			cond_rc, CF_IMMEDIATE, func, exc2, pc,
 			all_pos_args_string, pos_arg_tokens, &run_item_count,
 			has_ref_window_moved);
@@ -1138,7 +1138,7 @@ static void execute_complex_function(
 	if (do_run_late_immediate)
 	{
 		exc2 = exc_clone_context(exc, &ecc, mask);
-		__run_complex_function_items(
+		_run_complex_function_items(
 			cond_rc, CF_LATE_IMMEDIATE, func, exc2, pc,
 			all_pos_args_string, pos_arg_tokens, &run_item_count,
 			has_ref_window_moved);
@@ -1208,19 +1208,19 @@ static void execute_complex_function(
 	exc2 = exc_clone_context(exc, &ecc, mask);
 	if (do_run_late_immediate)
 	{
-		__run_complex_function_items(
+		_run_complex_function_items(
 			cond_rc, CF_LATE_IMMEDIATE, func, exc2, pc,
 			all_pos_args_string, pos_arg_tokens, &run_item_count,
 			has_ref_window_moved);
 	}
-	__run_complex_function_items(
+	_run_complex_function_items(
 		cond_rc, type, func, exc2, pc, all_pos_args_string,
 		pos_arg_tokens, &run_item_count, has_ref_window_moved);
 	exc_destroy_context(exc2);
 
   ungrab_exit:
 	func->use_depth--;
-	__cf_cleanup(
+	_cf_cleanup(
 		func, &depth, &run_item_count, all_pos_args_string,
 		pos_arg_tokens, cond_rc);
 	if (do_ungrab)
@@ -1242,7 +1242,7 @@ void functions_init(void)
 
 void execute_function(F_CMD_ARGS, func_flags_t exec_flags)
 {
-	__execute_command_line(F_PASS_ARGS, exec_flags, NULL, NULL, False);
+	_execute_command_line(F_PASS_ARGS, exec_flags, NULL, NULL, False);
 
 	return;
 }

--- a/fvwm/functions.h
+++ b/fvwm/functions.h
@@ -19,7 +19,7 @@ typedef enum
 	FUNC_ADD_TO              = 0x04,
 	FUNC_DECOR               = 0x08,
 	FUNC_ALLOW_UNMANAGED     = 0x10,
-	/* only used in __execute_command_line */
+	/* only used in _execute_command_line */
 	FUNC_IS_MOVE_TYPE        = 0x20,
 	/* only to be passed to execute_function() */
 	FUNC_IS_UNMANAGED        = 0x40,

--- a/fvwm/geometry.c
+++ b/fvwm/geometry.c
@@ -691,7 +691,7 @@ void maximize_adjust_offset(FvwmWindow *fw)
 }
 
 #define MAKEMULT(a,b) ((b==1) ? (a) : (((int)((a)/(b))) * (b)) )
-static void __cs_handle_aspect_ratio(
+static void _cs_handle_aspect_ratio(
 	size_rect *ret_s, FvwmWindow *fw, size_rect s, const size_rect base,
 	const size_rect inc, size_rect min, size_rect max, int xmotion,
 	int ymotion, int flags)
@@ -1007,7 +1007,7 @@ void constrain_size(
 	 */
 	if (fw->hints.flags & PAspect)
 	{
-		__cs_handle_aspect_ratio(
+		_cs_handle_aspect_ratio(
 			&d, fw, d, base, inc, min, max, xmotion, ymotion,
 			flags);
 	}

--- a/fvwm/menubindings.c
+++ b/fvwm/menubindings.c
@@ -168,7 +168,7 @@ static int get_selectable_item_count(MenuRoot *mr, int *ret_sections)
 	return count;
 }
 
-static Binding *__menu_binding_is_mouse(
+static Binding *_menu_binding_is_mouse(
 	Binding *blist, XEvent* event, int context)
 {
 	Binding *b;
@@ -335,7 +335,7 @@ static void parse_menu_action(
 	return;
 }
 
-static Binding *__menu_binding_is_key(
+static Binding *_menu_binding_is_key(
 	Binding *blist, XEvent* event, int context)
 {
 	Binding *b;
@@ -371,10 +371,10 @@ Binding *menu_binding_is_mouse(XEvent* event, int context)
 {
 	Binding *b;
 
-	b = __menu_binding_is_mouse(menu_bindings_regular, event, context);
+	b = _menu_binding_is_mouse(menu_bindings_regular, event, context);
 	if (b == NULL)
 	{
-		b = __menu_binding_is_mouse(
+		b = _menu_binding_is_mouse(
 			menu_bindings_fallback, event, context);
 	}
 
@@ -385,10 +385,10 @@ Binding *menu_binding_is_key(XEvent* event, int context)
 {
 	Binding *b;
 
-	b = __menu_binding_is_key(menu_bindings_regular, event, context);
+	b = _menu_binding_is_key(menu_bindings_regular, event, context);
 	if (b == NULL)
 	{
-		b = __menu_binding_is_key(
+		b = _menu_binding_is_key(
 			menu_bindings_fallback, event, context);
 	}
 

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -240,7 +240,7 @@ static MenuInfo Menus;
 
 /* ---------------------------- local functions ---------------------------- */
 
-static void __menu_execute_function(const exec_context_t **pexc, char *action)
+static void _menu_execute_function(const exec_context_t **pexc, char *action)
 {
 	const exec_context_t *exc;
 	exec_context_changes_t ecc;
@@ -746,7 +746,7 @@ static void scanForHotkeys(
 	return;
 }
 
-static void __copy_down(char *remove_from, char *remove_to)
+static void _copy_down(char *remove_from, char *remove_to)
 {
 	char *t1;
 	char *t2;
@@ -760,7 +760,7 @@ static void __copy_down(char *remove_from, char *remove_to)
 	return;
 }
 
-static int __check_for_delimiter(char *s, const string_def_t *string_defs)
+static int _check_for_delimiter(char *s, const string_def_t *string_defs)
 {
 	int type;
 
@@ -776,7 +776,7 @@ static int __check_for_delimiter(char *s, const string_def_t *string_defs)
 			{
 				/* escaped delimiter, copy the
 				 * string down over it */
-				__copy_down(s, s+1);
+				_copy_down(s, s+1);
 
 				return -1;
 			}
@@ -805,7 +805,7 @@ static void scanForStrings(
 		if (type < 0)
 		{
 			/* look for starting delimiters */
-			type = __check_for_delimiter(s, string_defs);
+			type = _check_for_delimiter(s, string_defs);
 			if (type >= 0)
 			{
 				/* start of a string */
@@ -830,7 +830,7 @@ static void scanForStrings(
 			{
 				/* the string was OK, remove it from
 				 * instring */
-				__copy_down(string - 1, s + 1);
+				_copy_down(string - 1, s + 1);
 				/* continue next iteration at the
 				 * first character after the string */
 				s = string - 2;
@@ -842,14 +842,14 @@ static void scanForStrings(
 		{
 			/* escaped delimiter, copy the string down over
 			 * it */
-			__copy_down(s, s + 1);
+			_copy_down(s, s + 1);
 		}
 	}
 }
 
 /* Side picture support: this scans for a color int the menu name
    for colorization */
-static Bool __scan_for_color(
+static Bool _scan_for_color(
 	char *name, char type, string_context_t *context)
 {
 	if (type != '^' || SCTX_GET_MR(*context) == NULL)
@@ -868,7 +868,7 @@ static Bool __scan_for_color(
 	return True;
 }
 
-static Bool __scan_for_pixmap(
+static Bool _scan_for_pixmap(
 	char *name, char type, string_context_t *context)
 {
 	FvwmPicture *p;
@@ -2801,7 +2801,7 @@ static int pop_menu_up(
 			is_busy_grabbed = GrabEm(CRS_WAIT, GRAB_BUSYMENU);
 		}
 		/* Execute the action */
-		__menu_execute_function(pmp->pexc, MR_POPUP_ACTION(mr));
+		_menu_execute_function(pmp->pexc, MR_POPUP_ACTION(mr));
 		if (is_busy_grabbed)
 		{
 			UngrabEm(GRAB_BUSYMENU);
@@ -3447,7 +3447,7 @@ static void pop_menu_down(MenuRoot **pmr, MenuParameters *pmp)
 		 * overwritten */
 		pos_hints = last_saved_pos_hints;
 		/* Execute the action */
-		__menu_execute_function(pmp->pexc, MR_POPDOWN_ACTION(*pmr));
+		_menu_execute_function(pmp->pexc, MR_POPDOWN_ACTION(*pmr));
 		/* restore the stuff we saved */
 		last_saved_pos_hints = pos_hints;
 	}
@@ -3541,7 +3541,7 @@ static void pop_menu_down_and_repaint_parent(
 
 /* ---------------------------- menu main loop ------------------------------ */
 
-static void __mloop_init(
+static void _mloop_init(
 	MenuParameters *pmp, MenuReturn *pmret,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi,
 	MenuOptions *pops)
@@ -3568,7 +3568,7 @@ static void __mloop_init(
 	return;
 }
 
-static void __mloop_get_event_timeout_loop(
+static void _mloop_get_event_timeout_loop(
 	MenuParameters *pmp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi)
 {
@@ -3670,7 +3670,7 @@ static void __mloop_get_event_timeout_loop(
 	return;
 }
 
-static mloop_ret_code_t __mloop_get_event(
+static mloop_ret_code_t _mloop_get_event(
 	MenuParameters *pmp, MenuReturn *pmret,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi)
 {
@@ -3756,7 +3756,7 @@ static mloop_ret_code_t __mloop_get_event(
 			    in->mif.is_pointer_in_active_item_area ||
 			    is_popdown_timer_active || is_popup_timer_active)
 			{
-				__mloop_get_event_timeout_loop(
+				_mloop_get_event_timeout_loop(
 					pmp, in, med, msi);
 			}
 			else
@@ -3787,7 +3787,7 @@ static mloop_ret_code_t __mloop_get_event(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static mloop_ret_code_t __mloop_handle_event(
+static mloop_ret_code_t _mloop_handle_event(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi)
 {
@@ -4217,7 +4217,7 @@ static mloop_ret_code_t __mloop_handle_event(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static void __mloop_select_item(
+static void _mloop_select_item(
 	MenuParameters *pmp, mloop_evh_input_t *in, mloop_evh_data_t *med,
 	Bool does_submenu_overlap, Bool *pdoes_popdown_submenu_overlap)
 {
@@ -4248,7 +4248,7 @@ static void __mloop_select_item(
 	return;
 }
 
-static void __mloop_wants_popup(
+static void _mloop_wants_popup(
 	MenuParameters *pmp, mloop_evh_input_t *in, mloop_evh_data_t *med,
 	MenuRoot *mrMiPopup)
 {
@@ -4306,7 +4306,7 @@ static void __mloop_wants_popup(
 	return;
 }
 
-static mloop_ret_code_t __mloop_make_popup(
+static mloop_ret_code_t _mloop_make_popup(
 	MenuParameters *pmp, MenuReturn *pmret,
 	mloop_evh_input_t *in, mloop_evh_data_t *med,
 	MenuOptions *pops, Bool *pdoes_submenu_overlap)
@@ -4348,7 +4348,7 @@ static mloop_ret_code_t __mloop_make_popup(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static mloop_ret_code_t __mloop_get_mi_actions(
+static mloop_ret_code_t _mloop_get_mi_actions(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi,
 	MenuRoot *mrMiPopup, Bool *pdoes_submenu_overlap,
@@ -4411,7 +4411,7 @@ static mloop_ret_code_t __mloop_get_mi_actions(
 		else if (!in->mrPopup || in->mrPopup != mrMiPopup ||
 			 in->mif.do_popup_and_warp)
 		{
-			__mloop_wants_popup(pmp, in, med, mrMiPopup);
+			_mloop_wants_popup(pmp, in, med, mrMiPopup);
 		}
 	}
 	if (in->mif.do_popdown_now)
@@ -4447,7 +4447,7 @@ static mloop_ret_code_t __mloop_get_mi_actions(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static void __mloop_do_popdown(
+static void _mloop_do_popdown(
 	MenuParameters *pmp, mloop_evh_input_t *in,
 	Bool *pdoes_popdown_submenu_overlap)
 {
@@ -4468,7 +4468,7 @@ static void __mloop_do_popdown(
 	return;
 }
 
-static mloop_ret_code_t __mloop_do_popup(
+static mloop_ret_code_t _mloop_do_popup(
 	MenuParameters *pmp, MenuReturn *pmret,
 	mloop_evh_input_t *in, mloop_evh_data_t *med,
 	MenuOptions *pops, MenuRoot *mrMiPopup, Bool *pdoes_submenu_overlap,
@@ -4526,7 +4526,7 @@ static mloop_ret_code_t __mloop_do_popup(
 			is_busy_grabbed = GrabEm(CRS_WAIT, GRAB_BUSYMENU);
 		}
 		/* Execute the action */
-		__menu_execute_function(pmp->pexc, action);
+		_menu_execute_function(pmp->pexc, action);
 		if (is_complex_function)
 		{
 			free(action);
@@ -4546,7 +4546,7 @@ static mloop_ret_code_t __mloop_do_popup(
 	}
 	else
 	{
-		if (__mloop_make_popup(
+		if (_mloop_make_popup(
 			    pmp, pmret, in, med, pops, pdoes_submenu_overlap)
 		    == MENU_MLOOP_RET_END)
 		{
@@ -4599,7 +4599,7 @@ static mloop_ret_code_t __mloop_do_popup(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static mloop_ret_code_t __mloop_do_menu(
+static mloop_ret_code_t _mloop_do_menu(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, MenuOptions *pops,
 	Bool *pdoes_submenu_overlap)
@@ -4670,7 +4670,7 @@ static mloop_ret_code_t __mloop_do_menu(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static mloop_ret_code_t __mloop_handle_action_with_mi(
+static mloop_ret_code_t _mloop_handle_action_with_mi(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi,
 	MenuOptions *pops, Bool *pdoes_submenu_overlap,
@@ -4708,7 +4708,7 @@ static mloop_ret_code_t __mloop_handle_action_with_mi(
 	if (med->mi != MR_SELECTED_ITEM(pmp->menu) && med->mrMi == pmp->menu)
 	{
 		/* new item of the same menu */
-		__mloop_select_item(
+		_mloop_select_item(
 			pmp, in, med, *pdoes_submenu_overlap,
 			pdoes_popdown_submenu_overlap);
 	}
@@ -4725,7 +4725,7 @@ static mloop_ret_code_t __mloop_handle_action_with_mi(
 	}
 	mrMiPopup = mr_popup_for_mi(pmp->menu, med->mi);
 	/* check what has to be done with the item */
-	if (__mloop_get_mi_actions(
+	if (_mloop_get_mi_actions(
 		    pmp, pmret, pdkp, in, med, msi, mrMiPopup,
 		    pdoes_submenu_overlap, pdoes_popdown_submenu_overlap) ==
 	    MENU_MLOOP_RET_END)
@@ -4736,11 +4736,11 @@ static mloop_ret_code_t __mloop_handle_action_with_mi(
 	if (in->mif.do_popdown && !in->mif.do_popup)
 	{
 		/* popdown previous popup */
-		__mloop_do_popdown(pmp, in, pdoes_popdown_submenu_overlap);
+		_mloop_do_popdown(pmp, in, pdoes_popdown_submenu_overlap);
 	}
 	if (in->mif.do_popup)
 	{
-		if (__mloop_do_popup(
+		if (_mloop_do_popup(
 			    pmp, pmret, in, med, pops, mrMiPopup,
 			    pdoes_submenu_overlap,
 			    pdoes_popdown_submenu_overlap) ==
@@ -4763,7 +4763,7 @@ static mloop_ret_code_t __mloop_handle_action_with_mi(
 	{
 		mloop_ret_code_t rc;
 
-		rc = __mloop_do_menu(
+		rc = _mloop_do_menu(
 			pmp, pmret, pdkp, in, med, pops,
 			pdoes_submenu_overlap);
 		if (rc != MENU_MLOOP_RET_NORMAL)
@@ -4808,7 +4808,7 @@ static mloop_ret_code_t __mloop_handle_action_with_mi(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static mloop_ret_code_t __mloop_handle_action_without_mi(
+static mloop_ret_code_t _mloop_handle_action_without_mi(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi,
 	MenuOptions *pops, Bool *pdoes_submenu_overlap,
@@ -4876,7 +4876,7 @@ static mloop_ret_code_t __mloop_handle_action_without_mi(
 	return MENU_MLOOP_RET_NORMAL;
 }
 
-static void __mloop_exit_warp_back(MenuParameters *pmp)
+static void _mloop_exit_warp_back(MenuParameters *pmp)
 {
 	MenuRoot *tmrMi;
 
@@ -4898,7 +4898,7 @@ static void __mloop_exit_warp_back(MenuParameters *pmp)
 	return;
 }
 
-static void __mloop_exit_select_in_place(
+static void _mloop_exit_select_in_place(
 	MenuParameters *pmp, mloop_evh_data_t *med, MenuOptions *pops)
 {
 	MenuRoot *submenu;
@@ -4943,7 +4943,7 @@ static void __mloop_exit_select_in_place(
 	return;
 }
 
-static void __mloop_exit_selected(
+static void _mloop_exit_selected(
 	MenuParameters *pmp, MenuReturn *pmret, mloop_evh_data_t *med,
 	MenuOptions *pops)
 {
@@ -4971,7 +4971,7 @@ static void __mloop_exit_selected(
 		get_popup_options(pmp, med->mi, pops);
 		if (pops->flags.do_select_in_place)
 		{
-			__mloop_exit_select_in_place(pmp, med, pops);
+			_mloop_exit_select_in_place(pmp, med, pops);
 		}
 		else
 		{
@@ -4986,7 +4986,7 @@ static void __mloop_exit_selected(
 	return;
 }
 
-static void __mloop_exit(
+static void _mloop_exit(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp,
 	mloop_evh_input_t *in, mloop_evh_data_t *med, mloop_static_info_t *msi,
 	MenuOptions *pops)
@@ -5030,7 +5030,7 @@ static void __mloop_exit(
 				/* abort a root menu rather than pop it down */
 				pmret->rc = MENU_ABORTED;
 			}
-			__mloop_exit_warp_back(pmp);
+			_mloop_exit_warp_back(pmp);
 		}
 		break;
 	case MENU_ABORTED:
@@ -5040,7 +5040,7 @@ static void __mloop_exit(
 		break;
 	case MENU_SELECTED:
 	case MENU_EXEC_CMD:
-		__mloop_exit_selected(pmp, pmret, med, pops);
+		_mloop_exit_selected(pmp, pmret, med, pops);
 		pmret->rc = MENU_DONE;
 		break;
 	default:
@@ -5067,7 +5067,7 @@ static void __mloop_exit(
 	return;
 }
 
-static void __menu_loop(
+static void _menu_loop(
 	MenuParameters *pmp, MenuReturn *pmret, double_keypress *pdkp)
 {
 	mloop_evh_input_t mei;
@@ -5079,10 +5079,10 @@ static void __menu_loop(
 	Bool does_submenu_overlap = False;
 	Bool does_popdown_submenu_overlap = False;
 
-	__mloop_init(pmp, pmret, &mei, &med, &msi, &mops);
+	_mloop_init(pmp, pmret, &mei, &med, &msi, &mops);
 	for (is_finished = False; !is_finished; )
 	{
-		mloop_ret = __mloop_get_event(pmp, pmret, &mei, &med, &msi);
+		mloop_ret = _mloop_get_event(pmp, pmret, &mei, &med, &msi);
 		switch (mloop_ret)
 		{
 		case MENU_MLOOP_RET_END:
@@ -5092,7 +5092,7 @@ static void __menu_loop(
 		default:
 			break;
 		}
-		mloop_ret = __mloop_handle_event(
+		mloop_ret = _mloop_handle_event(
 			pmp, pmret, pdkp, &mei, &med, &msi);
 		switch (mloop_ret)
 		{
@@ -5108,14 +5108,14 @@ static void __menu_loop(
 		 * a pointer motion event. */
 		if (med.mi != NULL)
 		{
-			mloop_ret = __mloop_handle_action_with_mi(
+			mloop_ret = _mloop_handle_action_with_mi(
 				pmp, pmret, pdkp, &mei, &med, &msi, &mops,
 				&does_submenu_overlap,
 				&does_popdown_submenu_overlap);
 		}
 		else
 		{
-			mloop_ret = __mloop_handle_action_without_mi(
+			mloop_ret = _mloop_handle_action_without_mi(
 				pmp, pmret, pdkp, &mei, &med, &msi, &mops,
 				&does_submenu_overlap,
 				&does_popdown_submenu_overlap);
@@ -5126,7 +5126,7 @@ static void __menu_loop(
 		}
 		XFlush(dpy);
 	}
-	__mloop_exit(pmp, pmret, pdkp, &mei, &med, &msi, &mops);
+	_mloop_exit(pmp, pmret, pdkp, &mei, &med, &msi, &mops);
 
 	return;
 }
@@ -5723,7 +5723,7 @@ void do_menu(MenuParameters *pmp, MenuReturn *pmret)
 					dpy, Scr.NoFocusWin, XEVMASK_MENUNFW);
 				XFlush(dpy);
 			}
-			__menu_loop(pmp, pmret, &dkp);
+			_menu_loop(pmp, pmret, &dkp);
 			if (!pmp->flags.is_submenu)
 			{
 				XSelectInput(
@@ -5822,7 +5822,7 @@ void do_menu(MenuParameters *pmp, MenuReturn *pmret)
 				{
 					indirect_depth++;
 					/* Execute the action */
-					__menu_execute_function(
+					_menu_execute_function(
 						pmp->pexc, *pmp->ret_paction);
 					indirect_depth--;
 					free(*pmp->ret_paction);
@@ -6477,8 +6477,8 @@ void AddToMenu(
 			if (fPixmapsOk)
 			{
 				string_def_t item_pixmaps[] = {
-					{'*', __scan_for_pixmap},
-					{'%', __scan_for_pixmap},
+					{'*', _scan_for_pixmap},
+					{'%', _scan_for_pixmap},
 					{'\0', NULL}};
 				string_context_t ctx;
 
@@ -6590,8 +6590,8 @@ MenuRoot *NewMenuRoot(char *name)
 {
 	MenuRoot *mr;
 	string_def_t root_strings[] = {
-		{'@', __scan_for_pixmap},
-		{'^', __scan_for_color},
+		{'@', _scan_for_pixmap},
+		{'^', _scan_for_color},
 		{'\0', NULL}};
 	string_context_t ctx;
 

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -173,7 +173,7 @@ fprintf(stderr, "%s: mldata '%s', mlaliaslen %d\n", __func__, this->data, this->
 	exc_destroy_context(exc);
 	/* Free rline only if it is xasprintf'd memory (not pointing at tline
 	 * anymore). If we free our tline argument it causes a crash in
-	 * __execute_function. */
+	 * _execute_function. */
 	if (rline != tline)
 		free(rline);
 

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -267,7 +267,7 @@ static void BroadcastNewPacket(unsigned long event_type,
 	return;
 }
 
-action_flags *__get_allowed_actions(const FvwmWindow *fw)
+action_flags *_get_allowed_actions(const FvwmWindow *fw)
 {
 	static action_flags act;
 	act.is_movable = is_function_allowed(
@@ -368,7 +368,7 @@ action_flags *__get_allowed_actions(const FvwmWindow *fw)
 		(unsigned long)(sizeof((*(_fw))->flags)),	\
 		&(*(_fw))->flags,				\
 		(unsigned long)(sizeof(action_flags)),		\
-		__get_allowed_actions((*(_fw)))
+		_get_allowed_actions((*(_fw)))
 
 void SendConfig(fmodule *module, unsigned long event_type, const FvwmWindow *t)
 {

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -349,7 +349,7 @@ static void move_to_next_monitor(
 	if (check_vert) {
 		if (win_r->y < y1) {
 			win_r->y = y1;
-		} else if (win_r->y + win_r->height > y2) { 
+		} else if (win_r->y + win_r->height > y2) {
 			win_r->y = y2 - win_r->height;
 		}
 	} else if (check_hor) {
@@ -1575,7 +1575,7 @@ static void InteractiveMove(
 	{
 		size_rect sz = { drag.width, drag.height };
 
-		__move_loop(exc, offset, sz, pFinal, do_move_opaque, CRS_MOVE);
+		move_loop(exc, offset, sz, pFinal, do_move_opaque, CRS_MOVE);
 	}
 	if (!Scr.gs.do_hide_position_window)
 	{
@@ -1956,7 +1956,7 @@ int placement_binding(int button, KeySym keysym, int modifier, char *action)
  * Start a window move operation
  *
  */
-void __move_icon(
+void move_icon(
 	FvwmWindow *fw, position new, position old,
 	Bool do_move_animated, Bool do_warp_pointer)
 {
@@ -2022,7 +2022,7 @@ void __move_icon(
 	return;
 }
 
-static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
+static void _move_window(F_CMD_ARGS, Bool do_animate, int mode)
 {
 	position final = { 0, 0 };
 	int n;
@@ -2214,7 +2214,7 @@ static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
 	}
 	else /* icon window */
 	{
-		__move_icon(fw, final, p, do_animate, fWarp);
+		move_icon(fw, final, p, do_animate, fWarp);
 		XFlush(dpy);
 	}
 	focus_grab_buttons_on_layer(fw->layer);
@@ -2224,25 +2224,25 @@ static void __move_window(F_CMD_ARGS, Bool do_animate, int mode)
 
 void CMD_Move(F_CMD_ARGS)
 {
-	__move_window(F_PASS_ARGS, False, MOVE_NORMAL);
+	_move_window(F_PASS_ARGS, False, MOVE_NORMAL);
 	update_fvwm_monitor(exc->w.fw);
 }
 
 void CMD_AnimatedMove(F_CMD_ARGS)
 {
-	__move_window(F_PASS_ARGS, True, MOVE_NORMAL);
+	_move_window(F_PASS_ARGS, True, MOVE_NORMAL);
 	update_fvwm_monitor(exc->w.fw);
 }
 
 void CMD_MoveToPage(F_CMD_ARGS)
 {
-	__move_window(F_PASS_ARGS, False, MOVE_PAGE);
+	_move_window(F_PASS_ARGS, False, MOVE_PAGE);
 	update_fvwm_monitor(exc->w.fw);
 }
 
 void CMD_MoveToScreen(F_CMD_ARGS)
 {
-	__move_window(F_PASS_ARGS, False, MOVE_SCREEN);
+	_move_window(F_PASS_ARGS, False, MOVE_SCREEN);
 	update_fvwm_monitor(exc->w.fw);
 }
 
@@ -2557,7 +2557,7 @@ extern Window bad_window;
  * Returns True if the window has to be resized after the move.
  *
  */
-Bool __move_loop(
+Bool move_loop(
 	const exec_context_t *exc, position offset, size_rect sz,
 	position *pFinal, Bool do_move_opaque, int cursor)
 {
@@ -3526,7 +3526,7 @@ void CMD_XorPixmap(F_CMD_ARGS)
  * as the quadrants drawn by the rubber-band, if "ResizeOpaque" has not been
  * set.
  */
-static direction_t __resize_get_dir_from_resize_quadrant(
+static direction_t _resize_get_dir_from_resize_quadrant(
 	position off, position p)
 {
 	direction_t dir = DIR_NONE;
@@ -3600,7 +3600,7 @@ static direction_t __resize_get_dir_from_resize_quadrant(
 	return dir;
 }
 
-static void __resize_get_dir_from_window(
+static void _resize_get_dir_from_window(
 	position *ret_motion, FvwmWindow *fw, Window context_w)
 {
 	if (context_w != Scr.Root && context_w != None)
@@ -3646,7 +3646,7 @@ static void __resize_get_dir_from_window(
 	return;
 }
 
-static void __resize_get_dir_proximity(
+static void _resize_get_dir_proximity(
 	position *ret_motion, FvwmWindow *fw, position off,
 	position p, position *warp, Bool find_nearest_border)
 {
@@ -3689,7 +3689,7 @@ static void __resize_get_dir_proximity(
 	}
 
 	/* Get the direction from the quadrant the pointer is in. */
-	dir = __resize_get_dir_from_resize_quadrant(off, p);
+	dir = _resize_get_dir_from_resize_quadrant(off, p);
 
 	switch (dir)
 	{
@@ -3744,7 +3744,7 @@ static void __resize_get_dir_proximity(
 	return;
 }
 
-static void __resize_get_refpos(
+static void _resize_get_refpos(
 	position *ret, position motion, size_rect sz, FvwmWindow *fw)
 {
 	if (motion.x > 0)
@@ -3776,7 +3776,7 @@ static void __resize_get_refpos(
 }
 
 /* Procedure:
- *      __resize_step - move the rubberband around.  This is called for
+ *      _resize_step - move the rubberband around.  This is called for
  *                 each motion event when we are resizing
  *
  *  Inputs:
@@ -3787,7 +3787,7 @@ static void __resize_get_refpos(
  *      pmotion  - pointer to motion in resize_window
  *
  */
-static void __resize_step(
+static void _resize_step(
 	const exec_context_t *exc, position root, position *off,
 	rectangle *drag, const rectangle *orig, position *pmotion,
 	Bool do_resize_opaque, Bool is_direction_fixed)
@@ -3932,7 +3932,7 @@ static void __resize_step(
 }
 
 /* Starts a window resize operation */
-static Bool __resize_window(F_CMD_ARGS)
+static Bool _resize_window(F_CMD_ARGS)
 {
 	FvwmWindow *fw = exc->w.fw;
 	Bool is_finished = False, is_done = False, is_aborted = False;
@@ -4178,7 +4178,7 @@ static Bool __resize_window(F_CMD_ARGS)
 	{
 		position toff = { orig->width, orig->height };
 
-		dir = __resize_get_dir_from_resize_quadrant(toff, p2);
+		dir = _resize_get_dir_from_resize_quadrant(toff, p2);
 	}
 
 	if (dir != DIR_NONE)
@@ -4192,7 +4192,7 @@ static Bool __resize_window(F_CMD_ARGS)
 	}
 	if (motion.x == 0 && motion.y == 0)
 	{
-		__resize_get_dir_from_window(&motion, fw, PressedW);
+		_resize_get_dir_from_window(&motion, fw, PressedW);
 	}
 	if (FW_W_TITLE(fw) != None && PressedW == FW_W_TITLE(fw))
 	{
@@ -4220,7 +4220,7 @@ static Bool __resize_window(F_CMD_ARGS)
 	{
 		position toff = { orig->width, orig->height };
 
-		__resize_get_dir_proximity(
+		_resize_get_dir_proximity(
 			&motion, fw, toff, p2, &warp,
 			automatic_border_direction);
 		if (motion.x != 0 || motion.y != 0)
@@ -4232,7 +4232,7 @@ static Bool __resize_window(F_CMD_ARGS)
 	{
 		size_rect sz = { orig->width, orig->height };
 
-		__resize_get_refpos(&ref, motion, sz, fw);
+		_resize_get_refpos(&ref, motion, sz, fw);
 	}
 	else
 	{
@@ -4283,7 +4283,7 @@ static Bool __resize_window(F_CMD_ARGS)
 				fw->g.frame.width, fw->g.frame.height
 			};
 
-			__resize_get_refpos(&ref, motion, sz, fw);
+			_resize_get_refpos(&ref, motion, sz, fw);
 		}
 	}
 	off.x = 0;
@@ -4344,7 +4344,7 @@ static Bool __resize_window(F_CMD_ARGS)
 			stashed.x = 0;
 			stashed.y = 0;
 		}
-		__resize_step(
+		_resize_step(
 			exc, stashed, &toff, drag, orig,
 			&motion, do_resize_opaque, True);
 	}
@@ -4530,7 +4530,7 @@ static Bool __resize_window(F_CMD_ARGS)
 				p.y = ev.xmotion.y_root;
 				/* resize before paging request to prevent
 				 * resize from lagging * mouse - mab */
-				__resize_step(
+				_resize_step(
 					exc, p, &off, drag, orig,
 					&motion, do_resize_opaque,
 					is_direction_fixed);
@@ -4548,7 +4548,7 @@ static Bool __resize_window(F_CMD_ARGS)
 				drag->x -= delta.x;
 				drag->y -= delta.y;
 
-				__resize_step(
+				_resize_step(
 					exc, p, &off, drag, orig,
 					&motion, do_resize_opaque,
 					is_direction_fixed);
@@ -4646,7 +4646,7 @@ static Bool __resize_window(F_CMD_ARGS)
 
 			motion.x = 1;
 			motion.y = 1;
-			__resize_step(
+			_resize_step(
 				exc, psorig, &toff, &g, orig,
 				&motion, do_resize_opaque, True);
 		}
@@ -4764,7 +4764,7 @@ void CMD_Resize(F_CMD_ARGS)
 		return;
 	}
 
-	__resize_window(F_PASS_ARGS);
+	_resize_window(F_PASS_ARGS);
 	update_fvwm_monitor(fw);
 
 	return;
@@ -5445,7 +5445,7 @@ void CMD_ResizeMaximize(F_CMD_ARGS)
 	/* keep a copy of the old geometry */
 	normal_g = fw->g.normal;
 	/* resize the window normally */
-	was_resized = __resize_window(F_PASS_ARGS);
+	was_resized = _resize_window(F_PASS_ARGS);
 	if (was_resized == True)
 	{
 		/* set the new geometry as the maximized geometry and restore
@@ -5513,7 +5513,7 @@ int stick_across_pages(F_CMD_ARGS, int toggle)
 		    fw->m->virtual_scr.CurrentDesk))
 		{
 			action = "";
-			__move_window(F_PASS_ARGS, False, MOVE_PAGE);
+			_move_window(F_PASS_ARGS, False, MOVE_PAGE);
 			update_fvwm_monitor(fw);
 		}
 		SET_STICKY_ACROSS_PAGES(fw, 1);
@@ -5549,7 +5549,7 @@ int stick_across_desks(F_CMD_ARGS, int toggle)
 	return 1;
 }
 
-static void __handle_stick_exit(
+static void _handle_stick_exit(
 	FvwmWindow *fw, int do_not_draw, int do_silently)
 {
 	if (do_not_draw == 0)
@@ -5579,7 +5579,7 @@ void handle_stick_across_pages(
 	did_change = stick_across_pages(F_PASS_ARGS, toggle);
 	if (did_change)
 	{
-		__handle_stick_exit(fw, do_not_draw, do_silently);
+		_handle_stick_exit(fw, do_not_draw, do_silently);
 	}
 
 	return;
@@ -5594,7 +5594,7 @@ void handle_stick_across_desks(
 	did_change = stick_across_desks(F_PASS_ARGS, toggle);
 	if (did_change)
 	{
-		__handle_stick_exit(fw, do_not_draw, do_silently);
+		_handle_stick_exit(fw, do_not_draw, do_silently);
 	}
 
 	return;
@@ -5612,7 +5612,7 @@ void handle_stick(
 	did_change |= stick_across_pages(F_PASS_ARGS, toggle_page);
 	if (did_change)
 	{
-		__handle_stick_exit(fw, do_not_draw, do_silently);
+		_handle_stick_exit(fw, do_not_draw, do_silently);
 	}
 
 	return;

--- a/fvwm/move_resize.h
+++ b/fvwm/move_resize.h
@@ -16,7 +16,7 @@ void AnimatedMoveOfWindow(
 void AnimatedMoveFvwmWindow(
 	FvwmWindow *fw, Window w, position start, position end,
 	Bool fWarpPointerToo, int cmsDelay, float *ppctMovement);
-Bool __move_loop(
+Bool move_loop(
 	const exec_context_t *exc, position offset, size_rect sz,
 	position *pFinal, Bool do_move_opaque, int cursor);
 int is_window_sticky_across_pages(FvwmWindow *fw);
@@ -25,7 +25,7 @@ void handle_stick(
 	F_CMD_ARGS, int toggle_page, int toggle_desk, int do_not_draw,
 	int do_silently);
 void resize_geometry_window(void);
-void __move_icon(
+void move_icon(
 	FvwmWindow *fw, position new, position old,
 	Bool do_move_animated, Bool do_warp_pointer);
 int placement_binding(int button,KeySym keysym,int modifier,char *action);

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -247,24 +247,24 @@ typedef struct pl_ret_t
 
 /* ---------------------------- forward declarations ----------------------- */
 
-static pl_loop_rc_t __pl_minoverlap_get_first_pos(
+static pl_loop_rc_t _pl_minoverlap_get_first_pos(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg);
-static pl_loop_rc_t __pl_minoverlap_get_next_pos(
+static pl_loop_rc_t _pl_minoverlap_get_next_pos(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg,
 	position hint_p);
-static pl_penalty_t __pl_minoverlap_get_pos_penalty(
+static pl_penalty_t _pl_minoverlap_get_pos_penalty(
 	position *ret_hint_p, struct pl_ret_t *ret, const pl_arg_t *arg);
 
-static pl_penalty_t __pl_smart_get_pos_penalty(
+static pl_penalty_t _pl_smart_get_pos_penalty(
 	position *ret_hint_p, struct pl_ret_t *ret, const pl_arg_t *arg);
 
-static pl_penalty_t __pl_position_get_pos_simple(
+static pl_penalty_t _pl_position_get_pos_simple(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg);
 
-static pl_penalty_t __pl_cascade_get_pos_simple(
+static pl_penalty_t _pl_cascade_get_pos_simple(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg);
 
-static pl_penalty_t __pl_manual_get_pos_simple(
+static pl_penalty_t _pl_manual_get_pos_simple(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg);
 
 /* ---------------------------- local variables ---------------------------- */
@@ -272,32 +272,32 @@ static pl_penalty_t __pl_manual_get_pos_simple(
 const pl_algo_t minoverlap_placement_algo =
 {
 	NULL,
-	__pl_minoverlap_get_first_pos,
-	__pl_minoverlap_get_next_pos,
-	__pl_minoverlap_get_pos_penalty
+	_pl_minoverlap_get_first_pos,
+	_pl_minoverlap_get_next_pos,
+	_pl_minoverlap_get_pos_penalty
 };
 
 const pl_algo_t smart_placement_algo =
 {
 	NULL,
-	__pl_minoverlap_get_first_pos,
-	__pl_minoverlap_get_next_pos,
-	__pl_smart_get_pos_penalty
+	_pl_minoverlap_get_first_pos,
+	_pl_minoverlap_get_next_pos,
+	_pl_smart_get_pos_penalty
 };
 
 const pl_algo_t position_placement_algo =
 {
-	__pl_position_get_pos_simple
+	_pl_position_get_pos_simple
 };
 
 const pl_algo_t cascade_placement_algo =
 {
-	__pl_cascade_get_pos_simple
+	_pl_cascade_get_pos_simple
 };
 
 const pl_algo_t manual_placement_algo =
 {
-	__pl_manual_get_pos_simple
+	_pl_manual_get_pos_simple
 };
 
 /* ---------------------------- exported variables (globals) --------------- */
@@ -386,7 +386,7 @@ done:
 	}
 }
 
-static pl_penalty_t __pl_position_get_pos_simple(
+static pl_penalty_t _pl_position_get_pos_simple(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg)
 {
 	char *spos;
@@ -497,7 +497,7 @@ static pl_penalty_t __pl_position_get_pos_simple(
 
 /* ---------------------------- local functions (CascadePlacement)---------- */
 
-static pl_penalty_t __pl_cascade_get_pos_simple(
+static pl_penalty_t _pl_cascade_get_pos_simple(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg)
 {
 	size_borders b;
@@ -591,7 +591,7 @@ static pl_penalty_t __pl_cascade_get_pos_simple(
 
 /* ---------------------------- local functions (ManualPlacement)----------- */
 
-static pl_penalty_t __pl_manual_get_pos_simple(
+static pl_penalty_t _pl_manual_get_pos_simple(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg)
 {
 	ret_p->x = 0;
@@ -626,7 +626,7 @@ static pl_penalty_t __pl_manual_get_pos_simple(
 			XMapRaised(dpy, Scr.SizeWindow.win);
 		}
 		FScreenGetScrRect(NULL, FSCREEN_GLOBAL, &m.x, &m.y, NULL, NULL);
-		if (__move_loop(arg->exc, m, drag, ret_p, False, CRS_POSITION))
+		if (move_loop(arg->exc, m, drag, ret_p, False, CRS_POSITION))
 		{
 			ret->flags.do_resize_too = 1;
 		}
@@ -663,7 +663,7 @@ static pl_penalty_t __pl_manual_get_pos_simple(
  * interference, fine.  Otherwise, it places it so that the area of of
  * interference between the new window and the other windows is minimized */
 
-static int __pl_minoverlap_get_next_x(const pl_arg_t *arg)
+static int _pl_minoverlap_get_next_x(const pl_arg_t *arg)
 {
 	FvwmWindow *other_fw;
 	int xnew;
@@ -802,7 +802,7 @@ static int __pl_minoverlap_get_next_x(const pl_arg_t *arg)
 	return xnew;
 }
 
-static int __pl_minoverlap_get_next_y(const pl_arg_t *arg)
+static int _pl_minoverlap_get_next_y(const pl_arg_t *arg)
 {
 	FvwmWindow *other_fw;
 	int ynew;
@@ -932,7 +932,7 @@ static int __pl_minoverlap_get_next_y(const pl_arg_t *arg)
 	return ynew;
 }
 
-static pl_loop_rc_t __pl_minoverlap_get_first_pos(
+static pl_loop_rc_t _pl_minoverlap_get_first_pos(
 	position *ret_p, struct pl_ret_t *ret, const pl_arg_t *arg)
 {
 	/* top left corner of page */
@@ -942,7 +942,7 @@ static pl_loop_rc_t __pl_minoverlap_get_first_pos(
 	return PL_LOOP_CONT;
 }
 
-static pl_loop_rc_t __pl_minoverlap_get_next_pos(
+static pl_loop_rc_t _pl_minoverlap_get_next_pos(
 	position *ret_p, struct pl_ret_t *ret, const struct pl_arg_t *arg,
 	position hint_p)
 {
@@ -951,14 +951,14 @@ static pl_loop_rc_t __pl_minoverlap_get_next_pos(
 	if (ret_p->x + arg->place_g.width <= arg->page_p2.x)
 	{
 		/* try next x */
-		ret_p->x = __pl_minoverlap_get_next_x(arg);
+		ret_p->x = _pl_minoverlap_get_next_x(arg);
 		ret_p->y = arg->place_g.y;
 	}
 	if (ret_p->x + arg->place_g.width > arg->page_p2.x)
 	{
 		/* out of room in x direction. Try next y. Reset x.*/
 		ret_p->x = arg->page_p1.x;
-		ret_p->y = __pl_minoverlap_get_next_y(arg);
+		ret_p->y = _pl_minoverlap_get_next_y(arg);
 	}
 	if (ret_p->y + arg->place_g.height > arg->page_p2.y)
 	{
@@ -969,7 +969,7 @@ static pl_loop_rc_t __pl_minoverlap_get_next_pos(
 	return PL_LOOP_CONT;
 }
 
-static pl_penalty_t __pl_minoverlap_get_avoidance_penalty(
+static pl_penalty_t _pl_minoverlap_get_avoidance_penalty(
 	const pl_arg_t *arg, FvwmWindow *other_fw, const rectangle *other_g)
 {
 	pl_penalty_t anew;
@@ -1072,7 +1072,7 @@ static pl_penalty_t __pl_minoverlap_get_avoidance_penalty(
 	return anew;
 }
 
-static pl_penalty_t __pl_minoverlap_get_pos_penalty(
+static pl_penalty_t _pl_minoverlap_get_pos_penalty(
 	position *ret_hint_p, struct pl_ret_t *ret, const struct pl_arg_t *arg)
 {
 	FvwmWindow *other_fw;
@@ -1114,7 +1114,7 @@ static pl_penalty_t __pl_minoverlap_get_pos_penalty(
 		{
 			pl_penalty_t anew;
 
-			anew = __pl_minoverlap_get_avoidance_penalty(
+			anew = _pl_minoverlap_get_avoidance_penalty(
 				arg, other_fw, &other_g);
 			penalty += anew;
 			if (
@@ -1180,14 +1180,14 @@ static pl_penalty_t __pl_minoverlap_get_pos_penalty(
 
 /* ---------------------------- local functions (SmartPlacement) ----------- */
 
-static pl_penalty_t __pl_smart_get_pos_penalty(
+static pl_penalty_t _pl_smart_get_pos_penalty(
 	position *ret_hint_p, struct pl_ret_t *ret, const struct pl_arg_t *arg)
 {
 	pl_penalty_t p;
 
 	arg->scratch->pp = &default_pl_penalty;
 	arg->scratch->ppp = &default_pl_percent_penalty;
-	p = __pl_minoverlap_get_pos_penalty(ret_hint_p, ret, arg);
+	p = _pl_minoverlap_get_pos_penalty(ret_hint_p, ret, arg);
 	if (p != 0)
 	{
 		p = -1;
@@ -1264,7 +1264,7 @@ static int placement_loop(pl_ret_t *ret, pl_arg_t *arg)
 	return (ret->best_penalty == -1) ? -1 : 0;
 }
 
-static void __place_get_placement_flags(
+static void _place_get_placement_flags(
 	pl_flags_t *ret_flags, FvwmWindow *fw, window_style *pstyle,
 	initial_window_options_t *win_opts, int mode, pl_reason_t *reason)
 {
@@ -1344,7 +1344,7 @@ static void __place_get_placement_flags(
 	return;
 }
 
-static int __add_algo(
+static int _add_algo(
 	const pl_algo_t **algos, int num_algos, const pl_algo_t *new_algo)
 {
 	if (num_algos >= MAX_NUM_PLACEMENT_ALGOS)
@@ -1357,7 +1357,7 @@ static int __add_algo(
 	return num_algos;
 }
 
-static int __place_get_wm_pos(
+static int _place_get_wm_pos(
 	const exec_context_t *exc, window_style *pstyle, rectangle *attr_g,
 	pl_flags_t flags, rectangle screen_g, pl_start_style_t start_style,
 	int mode, initial_window_options_t *win_opts, pl_reason_t *reason,
@@ -1418,36 +1418,36 @@ static int __place_get_wm_pos(
 	switch (placement_mode)
 	{
 	case PLACE_POSITION:
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &position_placement_algo);
 		break;
 	case PLACE_TILEMANUAL:
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &smart_placement_algo);
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &manual_placement_algo);
 		break;
 	case PLACE_MINOVERLAPPERCENT:
 		arg.flags.use_percent = 1;
 		/* fall through */
 	case PLACE_MINOVERLAP:
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &minoverlap_placement_algo);
 		break;
 	case PLACE_TILECASCADE:
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &smart_placement_algo);
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &cascade_placement_algo);
 		break;
 	case PLACE_MANUAL:
 	case PLACE_MANUAL_B:
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &manual_placement_algo);
 		break;
 	case PLACE_CASCADE:
 	case PLACE_CASCADE_B:
-		num_algos = __add_algo(
+		num_algos = _add_algo(
 			algos, num_algos, &cascade_placement_algo);
 		break;
 	default:
@@ -1477,7 +1477,7 @@ static int __place_get_wm_pos(
 	return ret.flags.do_resize_too;
 }
 
-static int __place_get_nowm_pos(
+static int _place_get_nowm_pos(
 	const exec_context_t *exc, window_style *pstyle, rectangle *attr_g,
 	pl_flags_t flags, rectangle screen_g, pl_start_style_t start_style,
 	int mode, initial_window_options_t *win_opts, pl_reason_t *reason,
@@ -1639,7 +1639,7 @@ static int __place_get_nowm_pos(
  *   0 = window lost
  *   1 = OK
  *   2 = OK, window must be resized too */
-static int __place_window(
+static int _place_window(
 	const exec_context_t *exc, window_style *pstyle, rectangle *attr_g,
 	pl_start_style_t start_style, int mode,
 	initial_window_options_t *win_opts, pl_reason_t *reason)
@@ -1972,17 +1972,17 @@ static int __place_window(
 	}
 
 	/* pick a location for the window. */
-	__place_get_placement_flags(
+	_place_get_placement_flags(
 		&flags, fw, pstyle, win_opts, mode, reason);
 	if (flags.do_not_use_wm_placement)
 	{
-		rc = __place_get_nowm_pos(
+		rc = _place_get_nowm_pos(
 			exc, pstyle, attr_g, flags, screen_g, start_style,
 			mode, win_opts, reason, pdeltax, pdeltay);
 	}
 	else
 	{
-		rc = __place_get_wm_pos(
+		rc = _place_get_wm_pos(
 			exc, pstyle, attr_g, flags, screen_g, start_style,
 			mode, win_opts, reason, pdeltax, pdeltay);
 	}
@@ -2003,7 +2003,7 @@ static int __place_window(
 	return rc;
 }
 
-static void __place_handle_x_resources(
+static void _place_handle_x_resources(
 	FvwmWindow *fw, window_style *pstyle, pl_reason_t *reason)
 {
 	int client_argc = 0;
@@ -2104,7 +2104,7 @@ static void __place_handle_x_resources(
 	return;
 }
 
-static void __explain_placement(FvwmWindow *fw, pl_reason_t *reason)
+static void _explain_placement(FvwmWindow *fw, pl_reason_t *reason)
 {
 	char explanation[2048];
 	char *r;
@@ -2394,7 +2394,7 @@ Bool setup_window_placement(
 		reason.screen.reason = PR_SCREEN_STYLE;
 		reason.screen.screen = SGET_START_SCREEN(*pstyle);
 	}
-	__place_handle_x_resources(fw, pstyle, &reason);
+	_place_handle_x_resources(fw, pstyle, &reason);
 	if (pstyle->flags.do_start_iconic)
 	{
 		win_opts->initial_state = IconicState;
@@ -2424,7 +2424,7 @@ Bool setup_window_placement(
 	start_style.screen = (e != NULL) ? fxstrdup(e) : fxstrdup("");
 	fvwm_debug(__func__, "Expanding screen from '%s' -> '%s'",
 			sc ? sc : "null", start_style.screen);
-	rc = __place_window(
+	rc = _place_window(
 		exc, pstyle, attr_g, start_style, mode, win_opts, &reason);
 
 	exc_destroy_context(exc);
@@ -2433,7 +2433,7 @@ Bool setup_window_placement(
 
 	if (Scr.bo.do_explain_window_placement == 1)
 	{
-		__explain_placement(fw, &reason);
+		_explain_placement(fw, &reason);
 	}
 
 	desk_add_fw(fw);
@@ -2494,7 +2494,7 @@ void CMD_PlaceAgain(F_CMD_ARGS)
 			position new_p = { new_g.x, new_g.y };
 			position old_p = { old_g.x, old_g.y };
 
-			__move_icon(fw, new_p, old_p, do_move_animated, False);
+			move_icon(fw, new_p, old_p, do_move_animated, False);
 		}
 	}
 	else

--- a/fvwm/stack.c
+++ b/fvwm/stack.c
@@ -74,7 +74,7 @@ typedef enum
 
 /* ---------------------------- forward declarations ----------------------- */
 
-static void __raise_or_lower_window(
+static void _raise_or_lower_window(
 	FvwmWindow *t, stack_mode_t mode, Bool allow_recursion,
 	Bool is_new_window, Bool is_client_request);
 static void raise_or_lower_window(
@@ -358,7 +358,7 @@ static void raise_over_unmanaged(FvwmWindow *t)
 	return;
 }
 
-static Bool __is_restack_transients_needed(
+static Bool _is_restack_transients_needed(
 	FvwmWindow *t, stack_mode_t mode)
 {
 	if (DO_RAISE_TRANSIENT(t))
@@ -379,7 +379,7 @@ static Bool __is_restack_transients_needed(
 	return False;
 }
 
-static Bool __must_move_transients(
+static Bool _must_move_transients(
 	FvwmWindow *t, stack_mode_t mode)
 {
 	if (IS_ICONIFIED(t))
@@ -387,7 +387,7 @@ static Bool __must_move_transients(
 		return False;
 	}
 	/* raise */
-	if (__is_restack_transients_needed(t, mode) == True)
+	if (_is_restack_transients_needed(t, mode) == True)
 	{
 		Bool scanning_above_window = True;
 		FvwmWindow *q;
@@ -430,7 +430,7 @@ static Bool __must_move_transients(
 	return False;
 }
 
-static Window __get_stacking_sibling(FvwmWindow *fw, Bool do_stack_below)
+static Window _get_stacking_sibling(FvwmWindow *fw, Bool do_stack_below)
 {
 	Window w;
 
@@ -452,7 +452,7 @@ static Window __get_stacking_sibling(FvwmWindow *fw, Bool do_stack_below)
 	return w;
 }
 
-static void __sort_transient_ring(FvwmWindow *ring)
+static void _sort_transient_ring(FvwmWindow *ring)
 {
 	FvwmWindow *s;
 	FvwmWindow *t;
@@ -507,7 +507,7 @@ static void __sort_transient_ring(FvwmWindow *ring)
 	return;
 }
 
-static void __restack_window_list(
+static void _restack_window_list(
 	FvwmWindow *r, FvwmWindow *s, int count, Bool do_broadcast_all,
 	Bool do_lower)
 {
@@ -550,10 +550,10 @@ static void __restack_window_list(
 			}
 		}
 	}
-	changes.sibling = __get_stacking_sibling(r, True);
+	changes.sibling = _get_stacking_sibling(r, True);
 	if (changes.sibling == None)
 	{
-		changes.sibling = __get_stacking_sibling(s, False);
+		changes.sibling = _get_stacking_sibling(s, False);
 		is_reversed = 1;
 	}
 	else
@@ -594,7 +594,7 @@ static void __restack_window_list(
 	return;
 }
 
-FvwmWindow *__get_window_to_insert_after(FvwmWindow *fw, stack_mode_t mode)
+FvwmWindow *_get_window_to_insert_after(FvwmWindow *fw, stack_mode_t mode)
 {
 	int test_layer;
 	FvwmWindow *s;
@@ -627,7 +627,7 @@ FvwmWindow *__get_window_to_insert_after(FvwmWindow *fw, stack_mode_t mode)
 	return s;
 }
 
-static void __mark_group_member(
+static void _mark_group_member(
 	FvwmWindow *fw, FvwmWindow *start, FvwmWindow *end)
 {
 	FvwmWindow *t;
@@ -650,7 +650,7 @@ static void __mark_group_member(
 
 }
 
-static Bool __mark_transient_subtree_test(
+static Bool _mark_transient_subtree_test(
 	FvwmWindow *s, FvwmWindow *start, FvwmWindow *end, int mark_mode,
 	Bool do_ignore_icons, Bool use_window_group_hint)
 {
@@ -683,7 +683,7 @@ static Bool __mark_transient_subtree_test(
 	{
 		if (r && IS_IN_TRANSIENT_SUBTREE(r) &&
 		    ((mark_mode == MARK_ALL) ||
-		     __is_restack_transients_needed(
+		     _is_restack_transients_needed(
 			     r, (stack_mode_t)mark_mode) == True))
 		{
 			/* have to move this one too */
@@ -695,7 +695,7 @@ static Bool __mark_transient_subtree_test(
 	}
 	if (use_group_hint && !IS_IN_TRANSIENT_SUBTREE(s))
 	{
-		__mark_group_member(s, start, end);
+		_mark_group_member(s, start, end);
 		if (IS_IN_TRANSIENT_SUBTREE(s))
 		{
 			/* need another scan through the list */
@@ -806,7 +806,7 @@ static Bool is_transient_subtree_straight(
 	     s = s->stack_prev)
 	{
 		if (
-			__mark_transient_subtree_test(
+			_mark_transient_subtree_test(
 				s, start, end, mark_mode,
 				do_ignore_icons,
 				use_window_group_hint))
@@ -834,7 +834,7 @@ static Bool is_transient_subtree_straight(
 	for (s = start; s != t; s = s->stack_prev)
 	{
 		if (
-			__mark_transient_subtree_test(
+			_mark_transient_subtree_test(
 				s, start, end, mark_mode,
 				do_ignore_icons,
 				use_window_group_hint))
@@ -847,7 +847,7 @@ static Bool is_transient_subtree_straight(
 }
 
 /* function to test if all windows are at correct place from start. */
-static Bool __is_restack_needed(
+static Bool _is_restack_needed(
 	FvwmWindow *t, stack_mode_t mode, Bool do_restack_transients,
 	Bool is_new_window)
 {
@@ -885,7 +885,7 @@ static Bool __is_restack_needed(
 	return True;
 }
 
-static Bool __restack_window(
+static Bool _restack_window(
 	FvwmWindow *t, stack_mode_t mode, Bool do_restack_transients,
 	Bool is_new_window, Bool is_client_request)
 {
@@ -894,7 +894,7 @@ static Bool __restack_window(
 	FvwmWindow tmp_r;
 	int count;
 
-	if (!__is_restack_needed(
+	if (!_is_restack_needed(
 		    t, mode, do_restack_transients, is_new_window))
 	{
 		/* need to cancel out the effect of any M_RAISE/M_LOWER that
@@ -941,7 +941,7 @@ static Bool __restack_window(
 	}
 	else
 	{
-		s = __get_window_to_insert_after(t, mode);
+		s = _get_window_to_insert_after(t, mode);
 	}
 	remove_window_from_stack_ring(t);
 	r = s->stack_prev;
@@ -949,7 +949,7 @@ static Bool __restack_window(
 	{
 		/* re-sort the transient windows according to their scratch.i
 		 * register */
-		__sort_transient_ring(&tmp_r);
+		_sort_transient_ring(&tmp_r);
 		/* insert all transients between r and s. */
 		add_windowlist_to_stack_ring_after(&tmp_r, r);
 	}
@@ -978,7 +978,7 @@ static Bool __restack_window(
 	else
 	{
 		/* restack the windows between r and s */
-		__restack_window_list(
+		_restack_window_list(
 			r, s, count, do_restack_transients,
 			mode == (SM_LOWER) ? True : False);
 	}
@@ -986,7 +986,7 @@ static Bool __restack_window(
 	return False;
 }
 
-static Bool __raise_lower_recursion(
+static Bool _raise_lower_recursion(
 	FvwmWindow *t, stack_mode_t mode, Bool is_client_request)
 {
 	FvwmWindow *t2;
@@ -1021,9 +1021,9 @@ static Bool __raise_lower_recursion(
 				 * other branches. */
 				t->scratch.i = MAX_TRANSIENTS_IN_BRANCH;
 			}
-			__raise_or_lower_window(
+			_raise_or_lower_window(
 				t2, mode, True, False, is_client_request);
-			if (__is_restack_transients_needed(t2, mode))
+			if (_is_restack_transients_needed(t2, mode))
 			{
 				/* moving the parent moves our window already */
 				return True;
@@ -1034,7 +1034,7 @@ static Bool __raise_lower_recursion(
 	return False;
 }
 
-static void __raise_or_lower_window(
+static void _raise_or_lower_window(
 	FvwmWindow *t, stack_mode_t mode, Bool allow_recursion,
 	Bool is_new_window, Bool is_client_request)
 {
@@ -1047,9 +1047,9 @@ static void __raise_or_lower_window(
 
 	/* New windows are simply raised/lowered without touching the
 	 * transientfor at first.  Then, further down in the code,
-	 * __raise_or_lower_window() is called again to raise/lower the
+	 * _raise_or_lower_window() is called again to raise/lower the
 	 * transientfor if necessary.  We can not do the recursion stuff for
-	 * new windows because the __must_move_transients() call needs a
+	 * new windows because the _must_move_transients() call needs a
 	 * properly ordered stack ring - but the new window is still at the
 	 * front of the stack ring. */
 	if (allow_recursion && !is_new_window && !IS_ICONIFIED(t))
@@ -1064,7 +1064,7 @@ static void __raise_or_lower_window(
 		 * window). */
 		if (IS_TRANSIENT(t) && DO_STACK_TRANSIENT_PARENT(t))
 		{
-			if (__raise_lower_recursion(
+			if (_raise_lower_recursion(
 				    t, mode, is_client_request) == True)
 			{
 				return;
@@ -1078,9 +1078,9 @@ static void __raise_or_lower_window(
 	}
 	else
 	{
-		do_move_transients = __must_move_transients(t, mode);
+		do_move_transients = _must_move_transients(t, mode);
 	}
-	if (__restack_window(
+	if (_restack_window(
 		    t, mode, do_move_transients, is_new_window,
 		    is_client_request) == True)
 	{
@@ -1155,7 +1155,7 @@ static void raise_or_lower_window(
 	{
 		fw->scratch.i = 0;
 	}
-	__raise_or_lower_window(
+	_raise_or_lower_window(
 		t, mode, allow_recursion, is_new_window, is_client_request);
 
 	return;
@@ -1556,7 +1556,7 @@ static Bool is_on_top_of_layer_ignore_rom(FvwmWindow *fw)
 
 #define EXPERIMENTAL_ROU_HANDLING 0
 #define ROUDEBUG 0
-static Bool __is_on_top_of_layer(FvwmWindow *fw, Bool client_entered)
+static Bool _is_on_top_of_layer(FvwmWindow *fw, Bool client_entered)
 {
 	Window	junk;
 	Bool  ontop	= False;
@@ -1944,7 +1944,7 @@ void mark_transient_subtree(
 		{
 
 			if (
-				__mark_transient_subtree_test(
+				_mark_transient_subtree_test(
 					s, start, end, mark_mode,
 					do_ignore_icons,
 					use_window_group_hint))
@@ -2027,7 +2027,7 @@ void new_layer(FvwmWindow *fw, int layer)
 		EWMH_SetWMState(fw, False);
 	}
 	/* move the windows without modifying their stacking order */
-	__restack_window_list(
+	_restack_window_list(
 		list_head.stack_next->stack_prev, target, count, (count > 1),
 		do_lower);
 	focus_grab_buttons_on_layer(layer);
@@ -2050,12 +2050,12 @@ void init_stack_and_layers(void)
 
 Bool is_on_top_of_layer(FvwmWindow *fw)
 {
-	return __is_on_top_of_layer(fw, False);
+	return _is_on_top_of_layer(fw, False);
 }
 
 Bool is_on_top_of_layer_and_above_unmanaged(FvwmWindow *fw)
 {
-	return __is_on_top_of_layer(fw, True);
+	return _is_on_top_of_layer(fw, True);
 }
 
 /* ----------------------------- built in functions ----------------------- */

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -64,7 +64,7 @@ static window_style *last_style_in_list = NULL;
 
 /* ---------------------------- local functions ---------------------------- */
 
-static Bool __validate_titleformat_string(const char *formatstr)
+static Bool _validate_titleformat_string(const char *formatstr)
 {
 	const char *fmt;
 
@@ -920,7 +920,7 @@ static int remove_all_of_style_from_list(style_id_t style_id)
 	return is_changed;
 }
 
-static int __simplify_style_list(void)
+static int _simplify_style_list(void)
 {
 	window_style *cur;
 	int has_modified;
@@ -2790,7 +2790,7 @@ static Bool style_parse_one_style_option(
 				fmt_string = DEFAULT_TITLE_FORMAT;
 			}
 
-			if (!__validate_titleformat_string(fmt_string))
+			if (!_validate_titleformat_string(fmt_string))
 			{
 				fvwm_debug(__func__,
 					   "TitleFormat string invalid:  %s",
@@ -4146,7 +4146,7 @@ static Bool style_parse_one_style_option(
 				fmt_string = DEFAULT_TITLE_FORMAT;
 			}
 
-			if (!__validate_titleformat_string(fmt_string))
+			if (!_validate_titleformat_string(fmt_string))
 			{
 				fvwm_debug(__func__,
 					   "TitleFormat string invalid:  %s",
@@ -4485,7 +4485,7 @@ void parse_and_set_window_style(char *action, char *prefix, window_style *ps)
  * must be freed in ProcessDestroyStyle().
  */
 
-static void __style_command(F_CMD_ARGS, char *prefix, Bool is_window_style)
+static void _style_command(F_CMD_ARGS, char *prefix, Bool is_window_style)
 {
 	/* temp area to build name list */
 	window_style *ps;
@@ -4621,7 +4621,7 @@ void free_icon_boxes(icon_boxes *ib)
 void simplify_style_list(void)
 {
 	/* one pass through the style list, then process other events first */
-	Scr.flags.do_need_style_list_update = __simplify_style_list();
+	Scr.flags.do_need_style_list_update = _simplify_style_list();
 
 	return;
 }
@@ -5376,21 +5376,21 @@ void print_styles(int verbose)
 
 void CMD_Style(F_CMD_ARGS)
 {
-	__style_command(F_PASS_ARGS, NULL, False);
+	_style_command(F_PASS_ARGS, NULL, False);
 
 	return;
 }
 
 void CMD_WindowStyle(F_CMD_ARGS)
 {
-	__style_command(F_PASS_ARGS, NULL, True);
+	_style_command(F_PASS_ARGS, NULL, True);
 
 	return;
 }
 
 void CMD_FocusStyle(F_CMD_ARGS)
 {
-	__style_command(F_PASS_ARGS, "FP", False);
+	_style_command(F_PASS_ARGS, "FP", False);
 
 	return;
 }

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -137,7 +137,7 @@ static Bool _pred_button_event(Display *display, XEvent *event, XPointer arg)
 		True : False;
 }
 
-static void __drag_viewport(const exec_context_t *exc, int scroll_speed)
+static void _drag_viewport(const exec_context_t *exc, int scroll_speed)
 {
 	XEvent e;
 	int x;
@@ -1441,7 +1441,7 @@ static void move_viewport_delta(
 	 * top to bottom and then unmap windows bottom up.
 	 */
 	/* TA: 2020-01-21:  This change of skipping monitors will
-	 * break using 'Scroll' and __drag_viewport().  We need to
+	 * break using 'Scroll' and _drag_viewport().  We need to
 	 * ensure we handle this case properly.
 	 */
 	t = get_next_window_in_stack_ring(&Scr.FvwmRoot);
@@ -2762,7 +2762,7 @@ void CMD_Scroll(F_CMD_ARGS)
 				scroll_speed *= -1;
 			}
 		}
-		__drag_viewport(exc, scroll_speed);
+		_drag_viewport(exc, scroll_speed);
 
 		return;
 	}

--- a/libs/Bindings.c
+++ b/libs/Bindings.c
@@ -417,7 +417,7 @@ static Bool does_binding_apply_to_window(
 	return False;
 }
 
-static Bool __compare_binding(
+static Bool _compare_binding(
 	Binding *b,
 	int button_keycode, unsigned int modifier, unsigned int used_modifiers,
 	int Context, binding_t type, const XClassHint *win_class,
@@ -475,7 +475,7 @@ void *CheckBinding(
 	modifier &= (used_modifiers & ALL_MODIFIERS);
 	for (b = blist; b != NULL; b = b->NextBinding)
 	{
-		if (__compare_binding(
+		if (_compare_binding(
 			    b, button_keycode, modifier,
 			    used_modifiers, Context, type, win_class,
 			    win_name) == True)
@@ -516,7 +516,7 @@ void *CheckTwoBindings(
 	modifier &= (used_modifiers & ALL_MODIFIERS);
 	for (b = blist; b != NULL; b = b->NextBinding)
 	{
-		if (__compare_binding(
+		if (_compare_binding(
 			    b, button_keycode, modifier,
 			    used_modifiers, Context, type, win_class, win_name)
 		    == True)
@@ -533,7 +533,7 @@ void *CheckTwoBindings(
 				}
 			}
 		}
-		if (__compare_binding(
+		if (_compare_binding(
 			    b, button_keycode, modifier,
 			    used_modifiers, Context2, type2, win_class2,
 			    win_name2) == True)

--- a/libs/FTips.c
+++ b/libs/FTips.c
@@ -77,7 +77,7 @@ static Atom _net_um_for = None;
 /* ---------------------------- local functions ---------------------------- */
 
 static
-unsigned long __get_time(void)
+unsigned long _get_time(void)
 {
 	struct timeval t;
 
@@ -86,7 +86,7 @@ unsigned long __get_time(void)
 }
 
 static
-void __initialize_window(Display *dpy)
+void _initialize_window(Display *dpy)
 {
 	XGCValues xgcv;
 	unsigned long valuemask;
@@ -119,7 +119,7 @@ void __initialize_window(Display *dpy)
 }
 
 static
-void __setup_cs(Display *dpy)
+void _setup_cs(Display *dpy)
 {
 	XSetWindowAttributes xswa;
 	unsigned long valuemask = 0;
@@ -150,7 +150,7 @@ void __setup_cs(Display *dpy)
 }
 
 static
-void __setup_gc(Display *dpy)
+void _setup_gc(Display *dpy)
 {
 	XGCValues xgcv;
 	unsigned long valuemask;
@@ -175,7 +175,7 @@ void __setup_gc(Display *dpy)
 }
 
 static
-void __draw(Display *dpy)
+void _draw(Display *dpy)
 {
 	if (!current_config->Ffont)
 	{
@@ -202,7 +202,7 @@ void __draw(Display *dpy)
 }
 
 static
-void __map_window(Display *dpy)
+void _map_window(Display *dpy)
 {
 	rectangle new_g;
 	rectangle screen_g;
@@ -417,7 +417,7 @@ void __map_window(Display *dpy)
 	/* make changes to window */
 	XMoveResizeWindow(
 		dpy, win, new_g.x, new_g.y, new_g.width, new_g.height);
-	__setup_gc(dpy);
+	_setup_gc(dpy);
 	if (current_config->colorset > -1)
 	{
 		SetWindowBackground(
@@ -456,15 +456,15 @@ Bool FTipsInit(Display *dpy)
 {
 
 	current_config = default_config = FTipsNewConfig();
-	__initialize_window(dpy);
+	_initialize_window(dpy);
 
 	if (gc == None || win == None)
 	{
 		return False;
 	}
 
-	__setup_cs(dpy);
-	__setup_gc(dpy);
+	_setup_cs(dpy);
+	_setup_gc(dpy);
 
 	memset(&fwin_string, 0, sizeof(fwin_string));
 
@@ -521,7 +521,7 @@ void FTipsOn(
 		}
 		return;
 	}
-	onTime = __get_time();
+	onTime = _get_time();
 	if (state == FVWM_TIPS_MAPPED)
 	{
 		FTipsCancel(dpy);
@@ -561,11 +561,11 @@ unsigned long FTipsCheck(Display *dpy)
 		return 0;
 	}
 
-	ct = __get_time();
+	ct = _get_time();
 
 	if (ct >= timeOut)
 	{
-		__map_window(dpy);
+		_map_window(dpy);
 		XFlush(dpy);
 		state = FVWM_TIPS_MAPPED;
 		return 0;
@@ -602,7 +602,7 @@ Bool FTipsExpose(Display *dpy, XEvent *ev)
 		stderr, "\tExpose: %i,%i,%i,%i %i\n",
 		ex, ey, ex2-ex, ey2-ey, ev->xexpose.count);
 #endif
-	__draw(dpy);
+	_draw(dpy);
 
 	return True;
 }
@@ -639,8 +639,8 @@ void FTipsUpdateLabel(Display *dpy, char *str)
 	CopyString(&label, str);
 	if (state == FVWM_TIPS_MAPPED)
 	{
-		__map_window(dpy);
-		__draw(dpy);
+		_map_window(dpy);
+		_draw(dpy);
 	}
 }
 
@@ -650,6 +650,6 @@ void FTipsColorsetChanged(Display *dpy, int cs)
 	{
 		return;
 	}
-	__map_window(dpy);
-	__draw(dpy);
+	_map_window(dpy);
+	_draw(dpy);
 }

--- a/libs/gravity.c
+++ b/libs/gravity.c
@@ -393,7 +393,7 @@ void gravity_split_xy_dir(
 	}
 }
 
-static inline int __gravity_override_one_axis(int dir_orig, int dir_mod)
+static inline int _gravity_override_one_axis(int dir_orig, int dir_mod)
 {
 	int ret_dir;
 
@@ -422,8 +422,8 @@ int gravity_override_dir(
 
 	gravity_split_xy_dir(&orig_x, &orig_y, dir_orig);
 	gravity_split_xy_dir(&mod_x, &mod_y, dir_mod);
-	ret_x = __gravity_override_one_axis(orig_x, mod_x);
-	ret_y = __gravity_override_one_axis(orig_y, mod_y);
+	ret_x = _gravity_override_one_axis(orig_x, mod_x);
+	ret_y = _gravity_override_one_axis(orig_y, mod_y);
 	ret_dir = gravity_combine_xy_dir(ret_x, ret_y);
 
 	return ret_dir;


### PR DESCRIPTION
The C standard discouges non-library functions beginning with a double underscore.  In fvwm's case, although some (but not all) of those were marked as static, and hence were unlikely to clash with anything in the C standard library, this change makes that consistent.