### PR TITLE
FvwmIconMan: populate manager geom via global screen

### DIFF
--- a/modules/FvwmIconMan/x.c
+++ b/modules/FvwmIconMan/x.c
@@ -737,6 +737,16 @@ void X_init_manager (int man_id)
 	man->geometry.boxheight = height;
     }
   }
+
+  /* Populate the managed instance of this FvwmIconMan with the position of
+   * the global screen.  This is potentially overriden if the user supplies
+   * their own ManagerGeometry string.
+   */
+  FScreenGetScrRect(NULL, FSCREEN_GLOBAL, &man->managed_g.x, &man->managed_g.y,
+		  &man->managed_g.width, &man->managed_g.height);
+  man->geometry.x = man->managed_g.x;
+  man->geometry.y = man->managed_g.y;
+
   if (man->geometry_str) {
     geometry_mask = FScreenParseGeometry(
       man->geometry_str, &man->geometry.x, &man->geometry.y,


### PR DESCRIPTION
When calculating the geometry of the FvwmIconMan instance, ensure we
populate it with the dimensions of the global screen.  This is was
previously using the primary screen which isn't guaranteed by RandR to
be set.

The dimensions of the FvwmIconMan instance are then overriden by the
user supplying a ManagerGeometry setting.

Fixes #813
