### PR TITLE
monitor: add prev_primary logic

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -1584,7 +1584,8 @@ $[pointer.screen]::
 +
 This is deprecated; use $[monitor.current] instead.
 
-$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width], $[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.current], $[monitor.prev] $[monitor.output], $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
+$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width],
+$[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.prev_primary], $[monitor.current], $[monitor.prev] $[monitor.output], $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
 	Returns information about the selected monitor. These can be nested, for
 	example: $[monitor.$[monitor.primary].width]
 +
@@ -1609,6 +1610,9 @@ isn't one.
 "pagey" returns the Y page of the referenced monitor.
 +
 "primary" is the name of the output set as primary via xrandr(1).
++
+"prev_primary" is the name of the output which was the previous primary
+monitor.
 +
 "prev_desk" returns the previous desk on the referenced monitor.
 +

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1853,6 +1853,18 @@ monitor_emit_broadcast(void)
 			execute_function_override_window(
 				NULL, NULL, randrfunc, NULL, 0, NULL);
 		}
+
+		if (m->flags & MONITOR_PRIMARY) {
+			struct monitor *pm = m, *mnew;
+
+			if ((mnew = monitor_by_last_primary()) == NULL)
+				break;
+
+			if (pm != mnew) {
+				execute_function_override_window(
+				    NULL, NULL, randrfunc, NULL, 0, NULL);
+			}
+		}
 	}
 }
 

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -513,6 +513,15 @@ static signed int expand_vars_extended(
 			goto GOT_STRING;
 		}
 
+		if (strcmp(rest, "prev_primary") == 0) {
+			struct monitor *m2 = monitor_by_last_primary();
+
+			if (m2 != NULL)
+				string = m2->si->name;
+			should_quote = False;
+			goto GOT_STRING;
+		}
+
 		if (strcmp(rest, "current") == 0) {
 			struct monitor *m2 = monitor_get_current();
 

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -294,6 +294,21 @@ monitor_by_primary(void)
 	return (m);
 }
 
+struct monitor *
+monitor_by_last_primary(void)
+{
+	struct monitor	*m = NULL, *m_loop;
+
+	TAILQ_FOREACH(m_loop, &monitor_q, entry) {
+		if (m_loop->was_primary && !(m_loop->flags & MONITOR_PRIMARY)) {
+			m = m_loop;
+			break;
+		}
+	}
+
+	return (m);
+}
+
 static void
 monitor_check_primary(void)
 {
@@ -476,10 +491,13 @@ set_coords:
 		m->si->w = rrm[i].width;
 		m->si->h = rrm[i].height;
 		m->si->rr_output = *rrm[i].outputs;
-		if (rrm[i].primary > 0)
+		if (rrm[i].primary > 0) {
 			m->flags |= MONITOR_PRIMARY;
-		else
+			m->was_primary = false;
+		} else {
 			m->flags &= ~MONITOR_PRIMARY;
+			m->was_primary = true;
+		}
 
 		XFree(name);
 	}
@@ -549,6 +567,7 @@ void FScreenInit(Display *dpy)
 		m->Desktops->desk = 0;
 		m->flags |= (MONITOR_NEW|MONITOR_ENABLED);
 		m->is_prev = false;
+		m->was_primary = false;
 		monitor_scan_edges(m);
 	}
 

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -81,7 +81,7 @@ struct monitor {
 	int			 flags;
 	int			 emit;
 	int			 dx, dy;
-	bool			 is_prev;
+	bool			 is_prev, was_primary;
 
 	/* info for some desktops; the first entries should be generic info
          * correct for any desktop not in the list
@@ -146,6 +146,7 @@ struct monitor	*monitor_resolve_name(const char *);
 struct monitor	*monitor_by_xy(int, int);
 struct monitor  *monitor_by_output(int);
 struct monitor  *monitor_by_primary(void);
+struct monitor  *monitor_by_last_primary(void);
 struct monitor  *monitor_get_current(void);
 struct monitor  *monitor_get_prev(void);
 struct monitor  *monitor_get_global(void);


### PR DESCRIPTION
Track which monitors hold the current primary bit, and the monitor which
used to have it.

This is sometimes useful to infer when the primary status of a monitor
has changed, and which monitor it is now, and which monitor it used to
be.

For example:

    DestroyFunc RandRFunc
    AddToFunc   RandRFunc
    + I Echo "Primary is: $[monitor.primary], previous: $[monitor.prev_primary]"

Fixes #825
