### PR TITLE
configure: drop check for -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -225,17 +225,6 @@ fi
 AC_ISC_POSIX
 AC_MINIX
 
-# catch -Werror and similar options when running configure
-AC_TRY_COMPILE([#include <stdio.h>],
-[int i; static j; int *p; char *c;
-  switch (*p = p = *c) { case 0: printf("%Q", c, p); }
-  *c = &i; c = p;
-  while (1 || (unsigned int)3 >= 0 || ((int)-1) == ((unsigned int)1));
-], , AC_MSG_ERROR("
-configure is not able to compile programs with warnings.  Please
-remove all offending options like -Werror from the CFLAGS and
-CPPFLAGS variables and run configure again."))
-
 # check size of some types
 ac_save_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS $X_CFLAGS"


### PR DESCRIPTION
This made sense with much older compilers, but now that clang and gcc
are adding errors all the time, this check is redundant.

Fixes #827
