### PR TITLE
make sure we don't free an uninitialized pointer

### DIFF
--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -745,7 +745,7 @@ set_sm_properties(FSmcConn sm_conn, char *filename, char hint)
 	FSmPropValue prop1val, prop2val, prop3val, prop4val, prop7val;
 	struct passwd *pwd;
 	char *user_id;
-	char *discardCommand;
+	char *discardCommand = NULL;
 	char screen_num[32];
 	int numVals, i, priority = 30;
 	Bool is_xsm_detected = False;


### PR DESCRIPTION
Ensuring no uninitialized pointer is passed to `free`.

Fixed #831
