### PR TITLE
FvwmPerl: fix regexp warning for special chars

### DIFF
--- a/modules/FvwmPerl/FvwmPerl.in
+++ b/modules/FvwmPerl/FvwmPerl.in
@@ -321,7 +321,7 @@ sub preprocess ($;$) {
 	}
 
 	# perl code substitution first
-	$$text_ref =~ s/\Q$quote1\E { ( .*? ) } \Q$quote2\E/
+	$$text_ref =~ s/\Q$quote1\E \{ ( .*? ) \} \Q$quote2\E/
 		my $result = eval "
 			no strict;
 			package PreprocessNamespace;


### PR DESCRIPTION
In recent versions of perl (2.5.26+), curly braces need escaping to make
them unambiguous to other internal perl regexp syntax.

Since FvwmPerl uses {} as its own command delimiters, ensure we escape
these in the parsing regexp in FvwmPerl.
