### PR TITLE
FvwmPager: monitor config: skip whitespace

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -1916,6 +1916,8 @@ void ParseOptions(void)
 
     if (StrEquals(resource, "Monitor")) {
 	    free(monitor_to_track);
+	    next = SkipSpaces(next, NULL, 0);
+
 	    if (next == NULL) {
 		    fvwm_debug(__func__, "FvwmPager: no monitor name given "
 				    "using current monitor\n");


### PR DESCRIPTION
When parsing the "Monitor" keyword as part of the configuration syntax,
skip the whitespace which can occur from reading in some configs --
otherwise this is treated literally.

Fixes #841
