### PR TITLE
CI: master -> main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
     https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
-  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/master/doc/README]Documentation updated (where appropriate)
+  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/main/doc/README]Documentation updated (where appropriate)
 
   - Style guide followed (try and match the surrounding code where possible)
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,10 +3,10 @@ name: FVWM3 CI
 on:
     push:
         branches:
-            - master
+            - main
     pull_request:
         branches:
-            - master
+            - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/fvwmorg/fvwm3/releases/generate-notes \
-          -d '{"tag_name":"${{ github.event.inputs.versionRelease }}","target_commitish":"master","configuration_file_path":".github/release.yml"}' | \
+          -d '{"tag_name":"${{ github.event.inputs.versionRelease }}","target_commitish":"main","configuration_file_path":".github/release.yml"}' | \
                 jq -r '.body' >> ./tmp.out
         sed -i '2d' ./tmp.out
         sed -i "2r tmp.out" CHANGELOG.md
@@ -47,7 +47,7 @@ jobs:
       with:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        head: release/${{ github.event.inputs.versionRelease }}
-       base: master
+       base: main
        title: release ${{ github.event.inputs.versionRelease }}
        reviewers: ${{ github.event.issue.user.login }}
        body: |


### PR DESCRIPTION
Some of these were missed when the default branch was renamed to main,
and as such, not all CI checks have been running since then.
