### PR TITLE
Add .desktop entry for XSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ config.h.in
 config.log
 config.status
 configure
+contrib/xsession/fvwm3.desktop
 core
 doc/footer.html
 doc/fvwm.ent

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,14 +15,20 @@ SUBDIRS = \
 	doc \
 	$(POSUB)
 
+XSESSIONFILE = contrib/xsession/fvwm3.desktop
+xsessionsdir = $(datarootdir)/xsessions
+xsessions_DATA = $(XSESSIONFILE)
+
+CLEANFILES = $(XSESSIONFILE)
+
+EXTRA_DIST = CHANGELOG.md $(XSESSIONFILE).in
+
 ## ---------------------------------------------------------------------------
 ## Manage bzip2 archive together with gzip archive
 #  Usage:
 #    make dist2       # instead of make dist
 #    make distcheck2  # instead of make distcheck
 #    make distclean2  # instead of make distclean
-
-EXTRA_DIST = CHANGELOG.md
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-mandoc
 
@@ -41,3 +47,6 @@ distclean2: distclean
 
 uninstall-hook:
 	-rmdir @FVWM_DATADIR@
+
+$(XSESSIONFILE): $(XSESSIONFILE).in
+	${SED} -e 's|[@]bindir@|$(bindir)|g' < "$@.in" > "$@"

--- a/contrib/xsession/fvwm3.desktop.in
+++ b/contrib/xsession/fvwm3.desktop.in
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=FVWM3
+Comment=The fvwm3 window manager
+Type=Application
+Exec=@bindir@/fvwm3


### PR DESCRIPTION
Add a (minimal) .desktop file of type XSession, so fvwm3 is discoverable for display managers following freedesktop.org standards.

Fixes #12

* **What does this PR do?**
  It adds a truly minimal XSession `.desktop` file for FVWM3, installed in `$(xsessionsdir)` which defaults to `$(datarootdir)/xsessions`.

Edit, in case you wonder about the custom make recipe, I just didn't find a better way. When you try to subsitute `@bindir@` from autoconf, it expands to `${exec_prefix}/bin` (literal), so this isn't usable in a .desktop file ....