### PR TITLE
docs: FvwmPerl: fixup examples

### DIFF
--- a/doc/FvwmPerl.adoc
+++ b/doc/FvwmPerl.adoc
@@ -114,7 +114,7 @@ to be preprosessed.
 ModuleSynchronize FvwmPerl
 
 AddToFunc .
-+ I SendToModule FvwmPerl preprocess -c -- $*
++ I SendToModule FvwmPerl preprocess -c $*
 
 . Exec exec xterm -name xterm-%{++$i}%   # use unique name
 
@@ -251,7 +251,7 @@ define the following two shortcut functions:
 DestroyFunc PerlEval
 AddToFunc I SendToModule MyPerl eval $*
 DestroyFunc PP
-AddToFunc I SendToModule MyPerl preprocessc-c -- $*
+AddToFunc I SendToModule MyPerl preprocessc-c $*
 ....
 +
 These 4 actions may be requested in one of 3 ways: 1) in the command


### PR DESCRIPTION
Don't use "--" to imply end of command arguments when using FvwmPerl via
functions, as this won't send anything to FvwmPerl.

Noticed by AlaricToo on irc.
