### PR TITLE
default-config: use primary mon for RightPanel

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -613,7 +613,7 @@ DestroyModuleConfig FvwmScript:*
 #
 # Note - To use the system tray you must have "stalonetray" installed.
 DestroyModuleConfig RightPanel:*
-*RightPanel: Geometry 120x$[monitor.$[monitor.primary].height]-0+0
+*RightPanel: Geometry 120x$[monitor.$[monitor.primary].height]-0+0@p
 *RightPanel: Colorset 10
 *RightPanel: Rows $[monitor.$[monitor.primary].height]
 *RightPanel: Columns 120


### PR DESCRIPTION
When setting up the geometry of the RightPanel, explicitly state that
the geometry is intended to be used on the primary monitor.

Fixes #879
