### PR TITLE
FvwmPager: add fpmonitor impls for widths/heights

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -189,7 +189,17 @@ fpmonitor_by_output(int output)
 	return (NULL);
 }
 
+int
+fpmonitor_get_all_widths(void)
+{
+	return (DisplayWidth(dpy, DefaultScreen(dpy)));
+}
 
+int
+fpmonitor_get_all_heights(void)
+{
+	return (DisplayHeight(dpy, DefaultScreen(dpy)));
+}
 
 struct fpmonitor *
 fpmonitor_this(void)

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -45,6 +45,8 @@ struct fpmonitor		*fpmonitor_by_name(const char *);
 struct fpmonitor		*fpmonitor_by_output(int);
 struct fpmonitor		*fpmonitor_get_current(void);
 struct fpmonitor 		*fpmonitor_this(void);
+int				 fpmonitor_get_all_widths(void);
+int				 fpmonitor_get_all_heights(void);
 
 typedef struct ScreenInfo
 {

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -452,8 +452,8 @@ fvwmrec_to_pager(rectangle *rec, bool is_icon)
 {
 	struct fpmonitor *mon = fpmonitor_this();
 
-	int m_width = monitor_get_all_widths();
-	int m_height = monitor_get_all_heights();
+	int m_width = fpmonitor_get_all_widths();
+	int m_height = fpmonitor_get_all_heights();
 	if (monitor_to_track != NULL) {
 		/* Offset window location based on monitor location. */
 		rec->x -= (m_width - mon->w) * (rec->x / m_width) + mon->x;
@@ -486,8 +486,8 @@ pagerrec_to_fvwm(rectangle *rec, bool is_icon)
 {
 	struct fpmonitor *mon = fpmonitor_this();
 
-	int m_width = monitor_get_all_widths();
-	int m_height = monitor_get_all_heights();
+	int m_width = fpmonitor_get_all_widths();
+	int m_height = fpmonitor_get_all_heights();
 	int offset_x = 0, offset_y = 0;
 
 	int scale_w = desk_w, scale_h = desk_h;
@@ -667,8 +667,8 @@ void initialize_pager(void)
   /* Set window size if not fully set by user to match */
   /* aspect ratio of monitor(s) being shown. */
   if ( pwindow.width == 0 || pwindow.height == 0 ) {
-	  int vWidth  = monitor_get_all_widths();
-	  int vHeight = monitor_get_all_heights();
+	  int vWidth  = fpmonitor_get_all_widths();
+	  int vHeight = fpmonitor_get_all_heights();
 	  if (monitor_to_track != NULL) {
 		  vWidth = mon->w;
 		  vHeight = mon->h;
@@ -716,11 +716,11 @@ void initialize_pager(void)
   if (xneg)
   {
     sizehints.win_gravity = NorthEastGravity;
-    pwindow.x = monitor_get_all_widths() - pwindow.width + pwindow.x;
+    pwindow.x = fpmonitor_get_all_widths() - pwindow.width + pwindow.x;
   }
   if (yneg)
   {
-    pwindow.y = monitor_get_all_heights() - pwindow.height + pwindow.y;
+    pwindow.y = fpmonitor_get_all_heights() - pwindow.height + pwindow.y;
     if(sizehints.win_gravity == NorthEastGravity)
       sizehints.win_gravity = SouthEastGravity;
     else


### PR DESCRIPTION
Module boundaries into libs/ in fvwm can sometimes be problematic.  As
such, calling into X11 libraries with an assumed display variable which
is initialised from fvwm, but not from modules, can sometimes mean this
isn't guaranteed to work.

Implement these X calls local to FvwmPager instead.

Fixes #833
