### PR TITLE
sizehints: tighten check

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -3724,11 +3724,8 @@ void HandlePropertyNotify(const evh_args_t *ea)
 		 * request, due to XSizeHints disallowing resize -- FVWM would
 		 * always use old values if the application decided to toggle
 		 * such things, and FVWM would then never resize the window.
-		 *
-		 * Note that SET_HAS_NEW_WM_NORMAL_HINTS being set here to
-		 * true is still valid.
 		 */
-		GetWindowSizeHintsWithCheck(fw, 1);
+		GetWindowSizeHintsWithCheck(fw, 0);
 		break;
 	default:
 		if (te->xproperty.atom == _XA_WM_PROTOCOLS)


### PR DESCRIPTION
When dealing with WM_NORMAL_HINTS, don't always assume that the size
hints need to be strictly-checked, and instead go based on those values
read; even if they might be considered "erroneous".

Fixes #775
