### PR TITLE
*: code cleanup: remove if (x) free checks

### DIFF
--- a/contrib/coccinelle/remove_unneccessary_pointer_checks.cocci
+++ b/contrib/coccinelle/remove_unneccessary_pointer_checks.cocci
@@ -1,0 +1,5 @@
+@Remove_unnecessary_pointer_checks@
+expression x;
+@@
+-if (\(x != 0 \| x != NULL\))
+    free(x);

--- a/libs/Flocale.c
+++ b/libs/Flocale.c
@@ -1474,8 +1474,7 @@ FlocaleFont *FlocaleLoadFont(Display *dpy, char *fontname, char *module)
 		default:
 			break;
 		}
-		if (opt_str != NULL)
-			free(opt_str);
+		free(opt_str);
 	}
 	if (str && *str)
 	{
@@ -1647,10 +1646,8 @@ void FlocaleUnloadFont(Display *dpy, FlocaleFont *flf)
 	}
 	if (flf->flags.must_free_fc)
 	{
-		if (flf->fc->x)
-			free(flf->fc->x);
-		if (flf->fc->bidi)
-			free(flf->fc->bidi);
+		free(flf->fc->x);
+		free(flf->fc->bidi);
 		if (flf->fc->locale != NULL)
 		{
 			while (FLC_GET_LOCALE_CHARSET(flf->fc,i) != NULL)
@@ -2105,8 +2102,7 @@ void FlocaleDrawString(
 	if(comb_chars != NULL)
 	{
 	        free(comb_chars);
-		if(pixel_pos)
-			free(pixel_pos);
+		free(pixel_pos);
 	}
 
 	return;

--- a/modules/FvwmButtons/parse.c
+++ b/modules/FvwmButtons/parse.c
@@ -728,7 +728,7 @@ static void ParseContainer(char **ss,button_info *b)
 			}
 			break;
     case 5: /* Fore */
-      if (b->c->fore) free(b->c->fore);
+      free(b->c->fore);
       b->c->fore = seekright(&s);
       b->c->flags.b_Fore = (b->c->fore ? 1 : 0);
       break;
@@ -807,8 +807,7 @@ static void ParseContainer(char **ss,button_info *b)
 	  char *temp;
 
 	  temp = seekright(&s);
-	  if (temp)
-	    free(temp);
+	  free(temp);
 	}
       }
       break;
@@ -854,8 +853,7 @@ static void ParseContainer(char **ss,button_info *b)
       t = seekright(&s);
       fvwm_debug(__func__, "%s: Illegal container option \"%s\"\n",MyName,
                  (t)?t:"");
-      if (t)
-	free(t);
+      free(t);
     }
   }
   if (*s)

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -468,21 +468,18 @@ static void ct_Geometry(char *cp)
 }
 static void ct_Fore(char *cp)
 {
-  if (color_names[c_fg])
-    free(color_names[c_fg]);
+  free(color_names[c_fg]);
   color_names[c_fg] = fxstrdup(cp);
   colorset = -1;
   myfprintf((stderr, "ColorFore: %s\n", color_names[c_fg]));
 }
 static void ct_Back(char *cp)
 {
-  if (color_names[c_bg])
-    free(color_names[c_bg]);
+  free(color_names[c_bg]);
   color_names[c_bg] = fxstrdup(cp);
   if (bg_state == 'd')
   {
-    if (screen_background_color)
-      free(screen_background_color);
+    free(screen_background_color);
     screen_background_color = fxstrdup(color_names[c_bg]);
     bg_state = 's';			/* indicate set by command */
   }
@@ -497,16 +494,14 @@ static void ct_Colorset(char *cp)
 }
 static void ct_ItemFore(char *cp)
 {
-  if (color_names[c_item_fg])
-    free(color_names[c_item_fg]);
+  free(color_names[c_item_fg]);
   color_names[c_item_fg] = fxstrdup(cp);
   itemcolorset = -1;
   myfprintf((stderr, "ColorItemFore: %s\n", color_names[c_item_fg]));
 }
 static void ct_ItemBack(char *cp)
 {
-  if (color_names[c_item_bg])
-    free(color_names[c_item_bg]);
+  free(color_names[c_item_bg]);
   color_names[c_item_bg] = fxstrdup(cp);
   itemcolorset = -1;
   myfprintf((stderr, "ColorItemBack: %s\n", color_names[c_item_bg]));
@@ -518,22 +513,19 @@ static void ct_ItemColorset(char *cp)
 }
 static void ct_Font(char *cp)
 {
-  if (font_names[f_text])
-    free(font_names[f_text]);
+  free(font_names[f_text]);
   CopyStringWithQuotes(&font_names[f_text], cp);
   myfprintf((stderr, "Font: %s\n", font_names[f_text]));
 }
 static void ct_TimeoutFont(char *cp)
 {
-  if (font_names[f_timeout])
-    free(font_names[f_timeout]);
+  free(font_names[f_timeout]);
   CopyStringWithQuotes(&font_names[f_timeout], cp);
   myfprintf((stderr, "TimeoutFont: %s\n", font_names[f_timeout]));
 }
 static void ct_ButtonFont(char *cp)
 {
-  if (font_names[f_button])
-    free(font_names[f_button]);
+  free(font_names[f_button]);
   CopyStringWithQuotes(&font_names[f_button], cp);
   myfprintf((stderr, "ButtonFont: %s\n", font_names[f_button]));
 }
@@ -559,8 +551,7 @@ static void ct_ButtonPointer(char *cp)
 }
 static void ct_InputFont(char *cp)
 {
-  if (font_names[f_input])
-    free(font_names[f_input]);
+  free(font_names[f_input]);
   CopyStringWithQuotes(&font_names[f_input], cp);
   myfprintf((stderr, "InputFont: %s\n", font_names[f_input]));
 }
@@ -1051,12 +1042,10 @@ static void PutDataInForm(char *cp)
     do {
       if (strcasecmp(var_name,item->header.name) == 0) {
 	var_len = strlen(cp);
-	if (item->input.init_value)
-	  free(item->input.init_value);
+	free(item->input.init_value);
 	item->input.init_value = fxmalloc(var_len + 1);
 	strcpy(item->input.init_value,cp); /* new initial value in field */
-	if (item->input.value)
-	  free(item->input.value);
+	free(item->input.value);
 	item->input.buf = var_len+1;
 	item->input.value = fxmalloc(item->input.buf);
 	strcpy(item->input.value,cp);	  /* new value in field */
@@ -1666,8 +1655,7 @@ void RedrawTimeout(Item *item)
     item->header.dt_ptr->dt_Fstr->colorset = &Colorset[colorset];
     item->header.dt_ptr->dt_Fstr->flags.has_colorset = True;
   }
-  if (item->header.dt_ptr->dt_Fstr->str != NULL)
-    free(item->header.dt_ptr->dt_Fstr->str);
+  free(item->header.dt_ptr->dt_Fstr->str);
   item->header.dt_ptr->dt_Fstr->str = fxstrdup(tmpbuf);
   item->header.dt_ptr->dt_Fstr->x   = item->header.pos_x + TEXT_SPC;
   item->header.dt_ptr->dt_Fstr->y   = item->header.pos_y + ( CF.padVText / 2 ) +

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -837,14 +837,10 @@ void list_destroy(unsigned long *body)
       XDestroyWindow(dpy,t->IconView);
       if(FocusWin == t)
 	FocusWin = NULL;
-      if(t->res_class != NULL)
-	free(t->res_class);
-      if(t->res_name != NULL)
-	free(t->res_name);
-      if(t->window_name != NULL)
-	free(t->window_name);
-      if(t->icon_name != NULL)
-	free(t->icon_name);
+      free(t->res_class);
+      free(t->res_name);
+      free(t->window_name);
+      free(t->icon_name);
       free(t);
     }
 }
@@ -1309,18 +1305,15 @@ void list_window_name(unsigned long *body,unsigned long type)
     {
       switch (type) {
       case M_RES_CLASS:
-	if(t->res_class != NULL)
-	  free(t->res_class);
+	free(t->res_class);
 	CopyString(&t->res_class,(char *)(&body[3]));
 	break;
       case M_RES_NAME:
-	if(t->res_name != NULL)
-	  free(t->res_name);
+	free(t->res_name);
 	CopyString(&t->res_name,(char *)(&body[3]));
 	break;
       case M_VISIBLE_NAME:
-	if(t->window_name != NULL)
-	  free(t->window_name);
+	free(t->window_name);
 	CopyString(&t->window_name,(char *)(&body[3]));
 	break;
       }
@@ -1368,8 +1361,7 @@ void list_icon_name(unsigned long *body)
     }
   if(t!= NULL)
     {
-      if(t->icon_name != NULL)
-	free(t->icon_name);
+      free(t->icon_name);
       CopyString(&t->icon_name,(char *)(&body[3]));
       /* repaint by clearing window */
       if ((FwindowFont != NULL) && (t->icon_name != NULL)
@@ -2025,8 +2017,7 @@ void ParseOptions(void)
     }
     else if (StrEquals(resource, "Font"))
     {
-      if (font_string)
-	free(font_string);
+      free(font_string);
       CopyStringWithQuotes(&font_string, next);
       if(strncasecmp(font_string,"none",4) == 0)
       {
@@ -2042,8 +2033,7 @@ void ParseOptions(void)
     {
       if(Pdepth > 1)
       {
-	if (PagerFore)
-	  free(PagerFore);
+	free(PagerFore);
 	CopyString(&PagerFore,arg1);
       }
     }
@@ -2051,8 +2041,7 @@ void ParseOptions(void)
     {
       if(Pdepth > 1)
       {
-	if (PagerBack)
-	  free(PagerBack);
+	free(PagerBack);
 	CopyString(&PagerBack,arg1);
       }
     }
@@ -2203,15 +2192,13 @@ void ParseOptions(void)
     {
       if(Pdepth > 1)
       {
-	if (HilightC)
-	  free(HilightC);
+	free(HilightC);
 	CopyString(&HilightC,arg1);
       }
     }
     else if (StrEquals(resource, "SmallFont"))
     {
-      if (smallFont)
-	free(smallFont);
+      free(smallFont);
       CopyStringWithQuotes(&smallFont, next);
       if (strncasecmp(smallFont,"none",4) == 0)
       {
@@ -2263,14 +2250,10 @@ void ParseOptions(void)
     {
       if (Pdepth > 1)
       {
-	if (WindowFore)
-	  free(WindowFore);
-	if (WindowBack)
-	  free(WindowBack);
-	if (WindowHiFore)
-	  free(WindowHiFore);
-	if (WindowHiBack)
-	  free(WindowHiBack);
+	free(WindowFore);
+	free(WindowBack);
+	free(WindowHiFore);
+	free(WindowHiBack);
 	CopyString(&WindowFore, arg1);
 	CopyString(&WindowBack, arg2);
 	tline2 = GetNextToken(tline2, &WindowHiFore);
@@ -2311,8 +2294,7 @@ void ParseOptions(void)
     }
     else if (StrEquals(resource,"WindowLabelFormat"))
     {
-      if (WindowLabelFormat)
-	free(WindowLabelFormat);
+      free(WindowLabelFormat);
       CopyString(&WindowLabelFormat,arg1);
     }
     else if (StrEquals(resource,"UseSkipList"))
@@ -2345,8 +2327,7 @@ void ParseOptions(void)
        -- ric@giccs.georgetown.edu */
     else if (StrEquals(resource, "Balloons"))
     {
-      if (BalloonTypeString)
-	free(BalloonTypeString);
+      free(BalloonTypeString);
       CopyString(&BalloonTypeString, arg1);
 
       if ( strncasecmp(BalloonTypeString, "Pager", 5) == 0 ) {
@@ -2372,8 +2353,7 @@ void ParseOptions(void)
     {
       if (Pdepth > 1)
       {
-	if (BalloonBack)
-	  free(BalloonBack);
+	free(BalloonBack);
 	CopyString(&BalloonBack, arg1);
       }
     }
@@ -2382,23 +2362,20 @@ void ParseOptions(void)
     {
       if (Pdepth > 1)
       {
-	if (BalloonFore)
-	  free(BalloonFore);
+	free(BalloonFore);
 	CopyString(&BalloonFore, arg1);
       }
     }
 
     else if (StrEquals(resource, "BalloonFont"))
     {
-      if (BalloonFont)
-	free(BalloonFont);
+      free(BalloonFont);
       CopyStringWithQuotes(&BalloonFont, next);
     }
 
     else if (StrEquals(resource, "BalloonBorderColor"))
     {
-      if (BalloonBorderColor)
-	free(BalloonBorderColor);
+      free(BalloonBorderColor);
       CopyString(&BalloonBorderColor, arg1);
     }
 
@@ -2424,8 +2401,7 @@ void ParseOptions(void)
     }
     else if (StrEquals(resource,"BalloonStringFormat"))
     {
-      if (BalloonFormatString)
-	free(BalloonFormatString);
+      free(BalloonFormatString);
       CopyString(&BalloonFormatString,arg1);
     }
 

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -2800,10 +2800,7 @@ static void do_label_window(PagerWindow *t, Window w)
   {
     return;
   }
-
-  /* Update the window label for this window */
-  if (t->window_label)
-    free(t->window_label);
+  free(t->window_label);
   t->window_label = GetBalloonLabel(t, WindowLabelFormat);
   if (w != None)
   {

--- a/modules/FvwmScript/FvwmScript.c
+++ b/modules/FvwmScript/FvwmScript.c
@@ -750,8 +750,7 @@ void SendMsgAndString(char *action, char *type)
 	fvwm_debug(__func__, "[%s][%s]: <<WARNING>> no Widget %i\n",
                    ScriptName,type,val[0]);
       }
-      if (token)
-	free(token);
+      free(token);
     }else{
       fvwm_debug(__func__, "[%s][%s]: <<WARNING>> Syntax Error: %s\n",
                  ScriptName,type,action);
@@ -788,8 +787,8 @@ void SendMsgAndString(char *action, char *type)
                        type);
     }
 
-    if(arg1) free(arg1);
-    if(arg2) free(arg2);
+    free(arg1);
+    free(arg2);
 
   }
 }
@@ -1295,9 +1294,7 @@ void MainLoop (void)
 	  action = GetNextToken(action, &token);
 
           SendMsgAndString(action, token);
-
-	  if (token)
-	    free(token);
+	  free(token);
 	}
 	else
 	  for (i=0; i<nbobj; i++)

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -896,8 +896,7 @@ static char *FuncSendMsgAndGet(int *NbArg,long *TabArg)
 
   if (err)
   {
-    if (buf)
-      free(buf);
+    free(buf);
     return fxstrdup("0");
   }
   l = strlen(buf);
@@ -1157,8 +1156,7 @@ static void ChangeFont (int NbArg,long *TabArg)
   i++;
   arg[1] = CalcArg(TabArg,&i);
   IdItem = TabIdObj[atoi(arg[0])];
-  if (tabxobj[IdItem]->font)
-    free(tabxobj[IdItem]->font);
+  free(tabxobj[IdItem]->font);
   tabxobj[IdItem]->font = fxstrdup(arg[1]);
 
   if ((Ffont =
@@ -1219,9 +1217,7 @@ static void ChangeTitle (int NbArg,long *TabArg)
   i++;
   arg[1] = CalcArg(TabArg,&i);
   IdItem = TabIdObj[atoi(arg[0])];
-
-  if (tabxobj[IdItem]->title)
-    free(tabxobj[IdItem]->title);
+  free(tabxobj[IdItem]->title);
   tabxobj[IdItem]->title=fxstrdup(arg[1]);
   if (tabxobj[IdItem]->TypeWidget != SwallowExec)
     XClearWindow(dpy, tabxobj[IdItem]->win);
@@ -1241,9 +1237,7 @@ static void ChangeLocaleTitle (int NbArg,long *TabArg)
   i++;
   arg[1] = CalcArg(TabArg,&i);
   IdItem = TabIdObj[atoi(arg[0])];
-
-  if (tabxobj[IdItem]->title)
-    free(tabxobj[IdItem]->title);
+  free(tabxobj[IdItem]->title);
   tabxobj[IdItem]->title=fxstrdup(FGettext(arg[1]));
   if (tabxobj[IdItem]->TypeWidget != SwallowExec)
     XClearWindow(dpy, tabxobj[IdItem]->win);

--- a/modules/FvwmScript/Widgets/List.c
+++ b/modules/FvwmScript/Widgets/List.c
@@ -223,8 +223,7 @@ void DrawCellule(
 			  inter.x, inter.y, inter.width, inter.height,
 			  False);
 	  }
-	  if (Title != NULL)
-		  free(Title);
+	  free(Title);
   }
 }
 


### PR DESCRIPTION
The C standard has always allowed the following to work:

free(NULL);

So there's no longer a need to do this:

if (x)
    free(x);

Via "elfring" who provided the cocci script on which this change is
based.

Fixes #108
