### PR TITLE
FvwmPrompt: preserve quotes, etc

### DIFF
--- a/bin/FvwmPrompt/FvwmPrompt.go
+++ b/bin/FvwmPrompt/FvwmPrompt.go
@@ -134,7 +134,7 @@ func main() {
 	shell.SetHistoryPath(consoleHistory)
 
 	shell.NotFound(func(c *ishell.Context) {
-		handleInput(c, strings.Join(c.Args, " "), writeToFMD)
+		handleInput(c, strings.Join(c.RawArgs, " "), writeToFMD)
 	})
 
 	// register a function for overriding Fvwm3's "Quit" command, to


### PR DESCRIPTION
When dealing with input entered into FvwmPrompt, using shell.c.Args meant
that the input had been parsed, which doesn't preserve quotes.  Hence,
the following:

    Exec exec xterm -T "Foo Bar" -e mc

Was parsed as this:

    Exec exec xterm -T Fooo Bar -e mc

Which is not the same thing.

It turns out that ishell preserves the argument list in RawArgs in its
context struct, so use this when parsing input from the user.

Fixes #662
