### PR TITLE
*: code cleanup: remove if (x) free checks (2)

### DIFF
--- a/contrib/coccinelle/remove_unneccessary_pointer_checks.cocci
+++ b/contrib/coccinelle/remove_unneccessary_pointer_checks.cocci
@@ -1,5 +1,37 @@
 @Remove_unnecessary_pointer_checks@
 expression x;
 @@
+(
 -if (\(x != 0 \| x != NULL\))
     free(x);
+|
+-if (\(x != 0 \| x != NULL\)) {
+    free(x);
+    x = \(0 \| NULL\);
+-}
+)
+
+@Remove_unnecessary_pointer_checks2@
+expression a, b;
+@@
+(
+-if (\(a != 0 \| a != NULL\) && \(b != 0 \| b != NULL\))
++if (a)
+    free(b);
+|
+-if (\(a != 0 \| a != NULL\) && \(b != 0 \| b != NULL\)) {
++if (a) {
+    free(b);
+    b = \(0 \| NULL\);
+ }
+|
+-if (\(a != 0 \| a != NULL\) && \(b == 0 \| b == NULL\))
++if (!b)
+    free(a);
+|
+-if (\(a != 0 \| a != NULL\) && \(b == 0 \| b == NULL\)) {
++if (!b) {
+    free(a);
+    a = \(0 \| NULL\);
+ }
+)

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -3301,12 +3301,8 @@ void destroy_window(FvwmWindow *fw)
 	/****** free strings ******/
 
 	free_window_names(fw, True, True);
-
-	if (fw->style_name)
-	{
-		free(fw->style_name);
-		fw->style_name = NULL;
-	}
+	free(fw->style_name);
+	fw->style_name = NULL;
 	if (fw->class.res_name && fw->class.res_name != NoResource)
 	{
 		XFree ((char *)fw->class.res_name);

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -868,11 +868,8 @@ static void DestroyFvwmDecor(FvwmDecor *decor)
 	}
 	FreeDecorFace(dpy, &decor->BorderStyle.active);
 	FreeDecorFace(dpy, &decor->BorderStyle.inactive);
-	if (decor->tag)
-	{
-		free(decor->tag);
-		decor->tag = NULL;
-	}
+	free(decor->tag);
+	decor->tag = NULL;
 
 	return;
 }
@@ -1838,11 +1835,8 @@ Bool ReadDecorFace(char *s, DecorFace *df, int button, int verbose)
 				}
 				return False;
 			}
-			if (file)
-			{
-				free(file);
-				file = NULL;
-			}
+			free(file);
+			file = NULL;
 
 			memset(&df->style, 0, sizeof(df->style));
 			if (strncasecmp(style,"Tiled",5)==0)

--- a/fvwm/colorset.c
+++ b/fvwm/colorset.c
@@ -263,12 +263,8 @@ static char *get_simple_color(
 	int special_flag, char *special_string)
 {
 	char *rest;
-
-	if (*color)
-	{
-		free(*color);
-		*color = NULL;
-	}
+	free(*color);
+	*color = NULL;
 	rest = GetNextToken(string, color);
 	if (*color)
 	{
@@ -360,16 +356,10 @@ static void free_colorset_background(colorset_t *cs, Bool do_free_args)
 	}
 	if (do_free_args)
 	{
-		if (cs->pixmap_args != NULL)
-		{
-			free(cs->pixmap_args);
-			cs->pixmap_args = NULL;
-		}
-		if (cs->gradient_args != NULL)
-		{
-			free(cs->gradient_args);
-			cs->gradient_args = NULL;
-		}
+		free(cs->pixmap_args);
+		cs->pixmap_args = NULL;
+		free(cs->gradient_args);
+		cs->gradient_args = NULL;
 		cs->is_maybe_root_transparent = False;
 		cs->pixmap_type = 0;
 	}
@@ -950,12 +940,8 @@ void parse_colorset(int n, char *line)
 			}
 			break;
 		} /* switch */
-
-		if (option)
-		{
-			free(option);
-			option = NULL;
-		}
+		free(option);
+		option = NULL;
 		free(optstring);
 		optstring = NULL;
 	} /* while (line && *line) */

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -786,11 +786,8 @@ void CreateConditionMask(char *flags, WindowConditionMask *mask)
 			    "Use comma instead of whitespace to separate "
 			    "conditions");
 		} else {
-			if (allocated_condition != NULL)
-			{
-				free(allocated_condition);
-				allocated_condition = NULL;
-			}
+			free(allocated_condition);
+			allocated_condition = NULL;
 			if (next_condition && *next_condition)
 			{
 				next_condition = GetNextFullOption(

--- a/fvwm/menucmd.c
+++ b/fvwm/menucmd.c
@@ -90,11 +90,8 @@ static void menu_func(F_CMD_ARGS, Bool fStaysUp)
 		}
 		return;
 	}
-	if (menu_name)
-	{
-		free(menu_name);
-		menu_name = NULL;
-	}
+	free(menu_name);
+	menu_name = NULL;
 
 	memset(&mp, 0, sizeof(mp));
 	mp.menu = menu;

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -847,11 +847,8 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			break;
 
 		case 33: /* ItemFormat */
-			if (ST_ITEM_FORMAT(tmpms))
-			{
-				free(ST_ITEM_FORMAT(tmpms));
-				ST_ITEM_FORMAT(tmpms) = NULL;
-			}
+			free(ST_ITEM_FORMAT(tmpms));
+			ST_ITEM_FORMAT(tmpms) = NULL;
 			if (arg1)
 			{
 				ST_ITEM_FORMAT(tmpms) = fxstrdup(arg1);
@@ -1097,19 +1094,12 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 				   poption);
 			break;
 		} /* switch */
-
-		if (option)
-		{
-			free(option);
-			option = NULL;
-		}
+		free(option);
+		option = NULL;
 		free(optstring);
 		optstring = NULL;
-		if (arg1)
-		{
-			free(arg1);
-			arg1 = NULL;
-		}
+		free(arg1);
+		arg1 = NULL;
 	} /* while */
 
 	if (has_gc_changed)
@@ -1266,13 +1256,8 @@ void menustyle_copy(MenuStyle *origms, MenuStyle *destms)
 	/* Hilight3DThickness */
 	ST_IS_ITEM_RELIEF_REVERSED(destms) =
 		ST_IS_ITEM_RELIEF_REVERSED(origms);
-
-	/* ItemFormat */
-	if (ST_ITEM_FORMAT(destms))
-	{
-		free(ST_ITEM_FORMAT(destms));
-		ST_ITEM_FORMAT(destms) = NULL;
-	}
+	free(ST_ITEM_FORMAT(destms));
+	ST_ITEM_FORMAT(destms) = NULL;
 	if (ST_ITEM_FORMAT(origms))
 	{
 		ST_ITEM_FORMAT(destms) = fxstrdup(ST_ITEM_FORMAT(origms));

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -3010,11 +3010,8 @@ apply_desktops_monitor(struct monitor *m)
 
 		if (d != NULL)
 		{
-			if (d->name != NULL)
-			{
-				free(d->name);
-				d->name = NULL;
-			}
+			free(d->name);
+			d->name = NULL;
 			CopyString(&d->name, dc->name);
 		}
 		else

--- a/libs/Flocale.c
+++ b/libs/Flocale.c
@@ -1461,11 +1461,8 @@ FlocaleFont *FlocaleLoadFont(Display *dpy, char *fontname, char *module)
 				&shadow_dir, fontname, module);
 			break;
 		case 1: /* encoding= */
-			if (encoding != NULL)
-			{
-				free(encoding);
-				encoding = NULL;
-			}
+			free(encoding);
+			encoding = NULL;
 			if (opt_str && *opt_str)
 			{
 				CopyString(&encoding, opt_str);
@@ -2086,18 +2083,11 @@ void FlocaleDrawString(
 
 	if (do_free)
 	{
-		if (fws->e_str != NULL)
-		{
-			free(fws->e_str);
-			fws->e_str = NULL;
-		}
+		free(fws->e_str);
+		fws->e_str = NULL;
 	}
-
-	if (fws->str2b != NULL)
-	{
-		free(fws->str2b);
-		fws->str2b = NULL;
-	}
+	free(fws->str2b);
+	fws->str2b = NULL;
 
 	if(comb_chars != NULL)
 	{
@@ -2156,12 +2146,8 @@ void FlocaleDrawUnderline(
 		free(fws->e_str);
 		fws->e_str = NULL;
 	}
-
-	if(fws->str2b != NULL)
-	{
-		free(fws->str2b);
-		fws->str2b = NULL;
-	}
+	free(fws->str2b);
+	fws->str2b = NULL;
 	free(l_to_v);
 
 	return;

--- a/libs/Graphics.c
+++ b/libs/Graphics.c
@@ -625,11 +625,8 @@ static XColor *AllocNonlinearGradient(
 			}
 			curpixel += n - 1;
 		}
-		if (c)
-		{
-			free(c);
-			c = NULL;
-		}
+		free(c);
+		c = NULL;
 		if (curpixel != seg_end_colors[i])
 		{
 			fvwm_debug(__func__,

--- a/libs/log.c
+++ b/libs/log.c
@@ -38,11 +38,8 @@ int	lib_log_level = 0;
 void
 set_log_file(char *name)
 {
-	if (log_file_name != NULL)
-	{
-		free(log_file_name);
-		log_file_name = NULL;
-	}
+	free(log_file_name);
+	log_file_name = NULL;
 	if (name != NULL)
 	{
 		log_file_name = fxstrdup(name);

--- a/modules/FvwmAnimate/FvwmAnimate.c
+++ b/modules/FvwmAnimate/FvwmAnimate.c
@@ -1137,20 +1137,15 @@ void ParseConfigLine(char *buf) {
 	}
 	break;
       case Color_arg:                   /* Color */
-	if (Animate.color) {
-	  free(Animate.color);          /* release storage holding color name */
-	  Animate.color = 0;            /* show its gone */
-	}
+	free(Animate.color);          /* release storage holding color name */
+	Animate.color = 0;
 	if ((strcasecmp(q,"None") != 0) /* If not color "none"  */
 	    && (strcasecmp(q,"Black^White") != 0)
 	    && (strcasecmp(q,"White^Black") != 0)) {
 	  Animate.color = fxstrdup(q); /* make copy of name */
 	}
-	/* override the pixmap option */
-	if (Animate.pixmap) {
-	  free(Animate.pixmap);
-	  Animate.pixmap = 0;
-	}
+	free(Animate.pixmap);
+	Animate.pixmap = 0;
 	if (pixmap) {
 	  XFreePixmap(dpy, pixmap);
 	  pixmap = None;
@@ -1158,10 +1153,8 @@ void ParseConfigLine(char *buf) {
 	CreateDrawGC();                /* update GC */
 	break;
       case Pixmap_arg:
-	if (Animate.pixmap) {
-	  free(Animate.pixmap);        /* release storage holding pixmap name */
-	  Animate.pixmap = 0;          /* show its gone */
-	}
+	free(Animate.pixmap);        /* release storage holding pixmap name */
+	Animate.pixmap = 0;
 	if (strcasecmp(q,"None") != 0) { /* If not pixmap "none"  */
 	  Animate.pixmap = fxstrdup(q); /* make copy of name */
 	}

--- a/modules/FvwmButtons/FvwmButtons.c
+++ b/modules/FvwmButtons/FvwmButtons.c
@@ -1310,11 +1310,8 @@ void Loop(void)
 	{
 	  XUngrabPointer(Dpy, CurrentTime); /* And fall through */
 	}
-	if (act)
-	{
-	  free(act);
-	  act = NULL;
-	}
+	free(act);
+	act = NULL;
 	/* fall through */
 
       case KeyRelease:
@@ -1351,12 +1348,8 @@ void Loop(void)
 	act = GetButtonAction(b,Event.xbutton.button);
 
 	ButtonPressProcess(b, &act);
-
-	if (act != NULL)
-	{
-	  free(act);
-	  act = NULL;
-	}
+	free(act);
+	act = NULL;
 	b = CurrentButton;
 	CurrentButton = NULL;
 	ActiveButton = b;

--- a/modules/FvwmIconMan/xmanager.c
+++ b/modules/FvwmIconMan/xmanager.c
@@ -2560,12 +2560,8 @@ static char *get_tips(WinManager *man, Button *b)
 	{
 		return NULL;
 	}
-
-	if (free_str != NULL)
-	{
-		free(free_str);
-		free_str = NULL;
-	}
+	free(free_str);
+	free_str = NULL;
 
 	if (man->tips_formatstring && b->drawn_state.win)
 	{

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -994,11 +994,8 @@ void list_new_desk(unsigned long *body)
 	ChangeDeskForWindow(t, t->desk);
     }
     item = FindDeskStrings(m->virtual_scr.CurrentDesk);
-    if (Desks[0].label != NULL)
-    {
-      free(Desks[0].label);
-      Desks[0].label = NULL;
-    }
+    free(Desks[0].label);
+    Desks[0].label = NULL;
     if (item->next != NULL && item->next->label != NULL)
     {
       CopyString(&Desks[0].label, item->next->label);
@@ -1016,12 +1013,8 @@ void list_new_desk(unsigned long *body)
       PDestroyFvwmPicture(dpy, Desks[0].bgPixmap);
       Desks[0].bgPixmap = NULL;
     }
-
-    if (Desks[0].Dcolor != NULL)
-    {
-      free (Desks[0].Dcolor);
-      Desks[0].Dcolor = NULL;
-    }
+    free (Desks[0].Dcolor);
+    Desks[0].Dcolor = NULL;
 
     if (item->next != NULL)
     {
@@ -1740,12 +1733,8 @@ static void SetDeskLabel(struct fpmonitor *m, int desk, const char *label)
     item = FindDeskStrings(desk);
     if (item->next != NULL)
     {
-      /* replace label */
-      if (item->next->label != NULL)
-      {
-	free(item->next->label);
-	item->next->label = NULL;
-      }
+      free(item->next->label);
+item->next->label = NULL;
       CopyString(&(item->next->label), label);
     }
     else
@@ -1830,11 +1819,8 @@ void ParseOptions(void)
     }
     else if (StrEquals(token, "ImagePath"))
     {
-      if (ImagePath != NULL)
-      {
-	free(ImagePath);
-	ImagePath = NULL;
-      }
+      free(ImagePath);
+ImagePath = NULL;
       GetNextToken(next, &ImagePath);
 
       continue;
@@ -2022,11 +2008,8 @@ void ParseOptions(void)
       if(strncasecmp(font_string,"none",4) == 0)
       {
 	uselabel = 0;
-	if (font_string)
-	{
-	  free(font_string);
-	  font_string = NULL;
-	}
+	free(font_string);
+	font_string = NULL;
       }
     }
     else if (StrEquals(resource, "Fore"))
@@ -2063,12 +2046,8 @@ void ParseOptions(void)
 	item = FindDeskStrings(desk);
 	if (item->next != NULL)
 	{
-	  /* replace Dcolor */
-	  if (item->next->Dcolor != NULL)
-	  {
-	    free(item->next->Dcolor);
-	    item->next->Dcolor = NULL;
-	  }
+	  free(item->next->Dcolor);
+	  item->next->Dcolor = NULL;
 	  CopyString(&(item->next->Dcolor), arg2);
 	}
 	else

--- a/modules/FvwmScript/FvwmScript.c
+++ b/modules/FvwmScript/FvwmScript.c
@@ -738,10 +738,8 @@ void SendMsgAndString(char *action, char *type)
 	/* skip the integer argument */
 	action = GetNextToken(action, &token);
 	action = GetNextToken(action, &token);
-	if (LastString != NULL) {
-	  free(LastString);
-	  LastString = NULL;
-	}
+	free(LastString);
+	LastString = NULL;
 	if (action != NULL && strlen(action) > 0)
 	  CopyString(&LastString,action);
 


### PR DESCRIPTION
The C standard has always allowed the following to work:

free(NULL);

So there's no longer a need to do this:

if (x)
    free(x);

Via "elfring" who provided the cocci script on which this change is
based.

Note that this is marked as (2) because elfring provided an updated
cocci script included with this commit to catch additional clauses not
originally found with the first cocci version used.

Fixes #108
