### PR TITLE
conditional: Screen+Desk is not mutually-exclusive

### DIFF
--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -1125,14 +1125,23 @@ Bool MatchesConditionMask(FvwmWindow *fw, WindowConditionMask *mask)
 			return False;
 		}
 	}
+
+	if (mask->my_flags.do_check_cond_desk &&
+	    mask->my_flags.do_check_screen) {
+		if (fw->Desk == mask->desk) {
+			/*Check the screen. */
+			if (mask->my_flags.do_not_check_screen) {
+				/* Negation of (!screen n) specified. */
+				return (fw->m != mask->screen);
+			} else
+				return (fw->m == mask->screen);
+		}
+		return False;
+	}
+
 	if (mask->my_flags.do_check_cond_desk)
 	{
 		if (fw->Desk == mask->desk)
-			return True;
-		else
-			return False;
-
-		if (fw->Desk != mask->desk)
 			return True;
 		else
 			return False;


### PR DESCRIPTION
When a conditional has both screen and desk in, such as:

    All (Screen HDMI-1, Desk 0) Echo "$[w.name]"

the previous logiv was to treat those options as mutually exclusive --
hence, one or the other would match, but never both.

This commit fixes this by checking for both conditions if they're
present, otherwise defaulting to treating them separately if only one of
them appears.

Fixes #741
