### PR TITLE
MaskUsedModifiers: remove bits used for XKB group index

### DIFF
--- a/fvwm/bindings.c
+++ b/fvwm/bindings.c
@@ -600,7 +600,7 @@ void print_bindings(void)
 /* Removes all unused modifiers from in_modifiers */
 unsigned int MaskUsedModifiers(unsigned int in_modifiers)
 {
-	return in_modifiers & ~mods_unused;
+	return in_modifiers & ~mods_unused & ~DEFAULT_XKB_MODS_IGNORED;
 }
 
 unsigned int GetUnusedModifiers(void)

--- a/libs/defaults.h
+++ b/libs/defaults.h
@@ -38,6 +38,16 @@
         ((Button1MotionMask * ((1 << NUMBER_OF_MOUSE_BUTTONS) - 1)))
 #define DEFAULT_MODS_UNUSED                LockMask
 
+/* Default modifier bits to ignore in XEvent.xkey.state or XEvent.xbutton.state.
+ * According to section "Xkb State to Core Protocol State Transformation" of the
+ * "The X Keyboard Extension: Library Specification", the Xkb-aware server
+ * reports group index in bits 13 and 14, which interferes with FVWM's modifier
+ * handling as described in https://github.com/fvwmorg/fvwm3/issues/861. */
+#ifdef HAVE_X11_XKBLIB_H
+#define DEFAULT_XKB_MODS_IGNORED ((1 << 13) | (1 << 14))
+#else
+#define DEFAULT_XKB_MODS_IGNORED 0
+#endif
 
 /*
  * These values may be adjusted to fine tune the menu looks.


### PR DESCRIPTION
* **What does this PR do?**

According to section [Xkb State to Core Protocol State Transformation](https://www.x.org/releases/X11R7.6/doc/libX11/specs/XKB/xkblib.html#xkb_state_to_core_protocol_state_transformation), the Xkb-aware server reports group index in bits 13 and 14 of `XEvent.xkey.state` or `XEvent.xbutton.state`.  This interferes with FVWM's modifier handling, so remove these bits in function `MaskUsedModifiers`.

Fixes #861
