### PR TITLE
Simplify _NET_WM_NAME setting

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1916,7 +1916,7 @@ void EWMH_Init(struct monitor *m)
 	int supported_count = 0;
 	long val;
 	XTextProperty text;
-	unsigned char utf_name[5];
+	unsigned char *utf_name = "FVWM3";
 	char *names[1];
 	XClassHint classhints;
 
@@ -1950,16 +1950,9 @@ void EWMH_Init(struct monitor *m)
 		XFree(text.value);
 	}
 
-	/* FVWM in UTF8 */
-	utf_name[0] = 0x46;
-	utf_name[1] = 0x56;
-	utf_name[2] = 0x57;
-	utf_name[3] = 0x4D;
-	utf_name[4] = 0x3;
-
 	ewmh_ChangeProperty(
 		Scr.NoFocusWin, "_NET_WM_NAME", EWMH_ATOM_LIST_PROPERTY_NOTIFY,
-		(unsigned char *)&utf_name, 4);
+		utf_name, strlen(utf_name));
 
 	clean_up();
 


### PR DESCRIPTION
Other than the off-by-one, it didn't always NUL-terminate the string being sent, causing issues in programs that expect the window manager name to be NUL-terminated.

Spotted after an issue with rofi reported by Mikhail and fixed thanks to Thomas Adam pointing me at the right chunk of code.

Have to admit that I'm still puzzled though, since the previous length of 4 should still result in "FVWM" being set as the WM name, so this change should actually be a no-op, yet I can't make rofi crash anymore.

P.S.: I'm assuming that the last 0x3 was a typo for 0x33 (i.e. '3')