### PR TITLE
Fix implicit function declaration in configure

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -996,6 +996,7 @@ AC_DEFUN([AM_SAFETY_CHECK_MKSTEMP],[
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 int main(void)
 {
   char template[128];


### PR DESCRIPTION
* **What does this PR do?**

Add missing `unistd.h` include for `close` and `unlink`

