### PR TITLE
EdgeScroll: implement per monitor

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -7390,9 +7390,13 @@ Style * EdgeMoveResistance moving screen-scrolling
 +
 Fvwm does this substitution automatically and prints a warning.
 
-*EdgeScroll* _horizontal_[p] _vertical_[p] [wrap | wrapx | wrapy]::
+*EdgeScroll* [_screen RANDRNAME_] _horizontal_[p] _vertical_[p] [wrap | wrapx | wrapy]::
 	Specifies the percentage of a page to scroll when the cursor hits the
-	edge of a page. A trailing '_p_' changes the interpretation to mean
+	edge of a page.
+	The optional '_screen RANDRNAME_' specifies the RandR monitor which
+	this setting should apply to, ignoring all other monitors.  Without
+	this option, it applies the value to all monitors.
+	A trailing '_p_' changes the interpretation to mean
 	pixels. If you do not want any paging or scrolling when you hit the
 	edge of a page include
 +
@@ -7426,10 +7430,14 @@ EdgeScroll 100000 100000
 is used fvwm scrolls by whole pages, wrapping around at the edge of
 the desktop.
 
-*EdgeThickness* 0 | 1 | 2::
+*EdgeThickness* [_screen RANDRNAME_] 0 | 1 | 2::
 	This is the width or height of the invisible window that fvwm creates
 	on the edges of the screen that are used for the edge scrolling
 	feature.
++
+The optional '_screen RANDRNAME_' specifies the RandR monitor which
+this setting should apply to, ignoring all other monitors.  Without
+this option, it applies the value to all monitors.
 +
 In order to enable page scrolling via the mouse, four windows called
 the "pan frames" are placed at the very edge of the screen. This is

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -4186,7 +4186,7 @@ void dispatch_event(XEvent *e)
 			XRRUpdateConfiguration(e);
 			monitor_update_ewmh();
 			monitor_emit_broadcast();
-			initPanFrames();
+			initPanFrames(NULL);
 			break;
 		}
 	}

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -733,6 +733,8 @@ int HandlePaging(
 	int mwidth, mheight;
 	int edge_thickness = m->virtual_scr.edge_thickness;
 
+	fvwm_debug(__func__, "ET (%s) is: %d", m->si->name, edge_thickness);
+
 	mwidth = monitor_get_all_widths();
 	mheight = monitor_get_all_heights();
 
@@ -1302,9 +1304,6 @@ void initPanFrames(struct monitor *ref)
 	if (ref == NULL)
 		return;
 
-	if (ref->pan_frames_mapped)
-		return;
-
 	edge_thickness = ref->virtual_scr.edge_thickness;
 
 	/* Not creating the frames disables all subsequent behavior */
@@ -1363,7 +1362,6 @@ void initPanFrames(struct monitor *ref)
 		checkPanFrames(m);
 	}
 	ref->virtual_scr.edge_thickness = saved_thickness;
-	ref->pan_frames_mapped = true;
 	fvwm_debug(__func__, "finished setting up per-monitor panframes");
 }
 

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2140,8 +2140,22 @@ void CMD_EdgeThickness(F_CMD_ARGS)
 void CMD_EdgeScroll(F_CMD_ARGS)
 {
 	int val1, val2, val1_unit, val2_unit, n;
-	char *token;
-	struct monitor	*m;
+	char *token, *option;
+	struct monitor	*m = NULL, *m_this = NULL;
+
+	option = PeekToken(action, NULL);
+	if (StrEquals(option, "screen")) {
+		/* Skip literal 'screen' */
+		option = PeekToken(action, &action);
+		/* Actually get the screen value. */
+		option = PeekToken(action, &action);
+
+		if ((m = monitor_resolve_name(option)) == NULL) {
+			fvwm_debug(__func__, "Invalid screen: %s", option);
+			return;
+		}
+	}
+
 
 	n = GetTwoArguments(action, &val1, &val2, &val1_unit, &val2_unit);
 	if (n != 2)
@@ -2194,10 +2208,20 @@ void CMD_EdgeScroll(F_CMD_ARGS)
 		}
 	}
 
-	TAILQ_FOREACH(m, &monitor_q, entry) {
+	if (m != NULL) {
 		m->virtual_scr.EdgeScrollX = val1 * val1_unit / 100;
 		m->virtual_scr.EdgeScrollY = val2 * val2_unit / 100;
 		checkPanFrames(m);
+
+		return;
+	}
+
+	TAILQ_FOREACH(m_this, &monitor_q, entry) {
+		if (m != NULL && m == m_this)
+			continue;
+		m_this->virtual_scr.EdgeScrollX = val1 * val1_unit / 100;
+		m_this->virtual_scr.EdgeScrollY = val2 * val2_unit / 100;
+		checkPanFrames(m_this);
 	}
 
 

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -11,7 +11,7 @@ int HandlePaging(
 	XEvent *pev, position warp_size, position *p, position *delta,
 	Bool Grab, Bool fLoop,	Bool do_continue_previous, int delay);
 void raisePanFrames(void);
-void initPanFrames(void);
+void initPanFrames(struct monitor *);
 Bool is_pan_frame(Window w);
 void MoveViewport(struct monitor *, int newx, int newy,Bool);
 void goto_desk(int desk, struct monitor *);

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -470,7 +470,10 @@ scan_screens(Display *dpy)
 			m->flags |= MONITOR_NEW;
 			m->si = screen_info_new();
 			m->si->name = strdup(name);
+
 			memset(&m->virtual_scr, 0, sizeof(m->virtual_scr));
+			m->virtual_scr.edge_thickness = 2;
+			m->virtual_scr.last_edge_thickness = 2;
 
 			TAILQ_INSERT_TAIL(&screen_info_q, m->si, entry);
 			TAILQ_INSERT_TAIL(&monitor_q, m, entry);

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -117,6 +117,9 @@ struct monitor {
                 int Vx;
                 int Vy;
 
+		int edge_thickness;
+		int last_edge_thickness;
+
                 int EdgeScrollX;
                 int EdgeScrollY;
 
@@ -135,6 +138,7 @@ struct monitor {
 	PanFrame PanFrameLeft;
 	PanFrame PanFrameRight;
 	PanFrame PanFrameBottom;
+	bool pan_frames_mapped;
 
 	TAILQ_ENTRY(monitor) entry;
 };


### PR DESCRIPTION
Bring the EdgeScroll command inline with other command, such as
EwmhBaseStruts whereby the dimensions can be specified per-monitor, such
as:

    EdgeScroll 0 0
    EdgeScroll screen DP-1 100 100
