### PR TITLE
dist: exclude FvwmPrompt binary

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -26,6 +26,9 @@ config_DATA = fvwm-menu-desktop-config.fpl
 
 EXTRA_DIST = fvwm-menu-desktop-config.fpl $(man_MANS) FvwmPrompt
 
+dist-hook:
+	rm -f $(distdir)/FvwmPrompt/FvwmPrompt
+
 ## The long generation for *.1 is to make both pod2man and 'make -j' happy.
 
 _fvwm-menu-xlock.1: fvwm-menu-xlock


### PR DESCRIPTION
Don't include the FvwmPrompt binary in the dist tarball.
