### PR TITLE
Varrious fixes for errors found in fvwm3-output.log

### DIFF
--- a/bin/fvwm-menu-desktop.in
+++ b/bin/fvwm-menu-desktop.in
@@ -715,9 +715,10 @@ def printmenu(name, icon, command):
     iconfile = ''
     if IconScaleTool.enable_icon:
         iconfile = geticonfile(icon) or getdefaulticonfile(command) or icon
-        if not (iconfile == '' or iconfile == None):
+        if not (iconfile == '' or iconfile == None) and os.path.isfile(iconfile):
             iconfile = '%'+iconfile+'%'
         else:
+            iconfile = ''
             sys.stderr.write("%s icon or default icon not found!\n")
     printtext('+ "%s%s" %s' % (escapemenutext(name), iconfile, command))
 

--- a/bin/fvwm-menu-desktop.in
+++ b/bin/fvwm-menu-desktop.in
@@ -480,7 +480,7 @@ Standard output is a series Fvwm commands."""
             if not style_id:
                 style_id = ent.getIcon()
             if style_id and ent.getIcon():
-                sys.stdout.write('Style {} MiniIcon "{}"\n'.format(style_id, geticonfile(ent.getIcon())))
+                sys.stdout.write('Style "{}" MiniIcon "{}"\n'.format(style_id, geticonfile(ent.getIcon())))
 
     sys.stdout.flush()
     vprint("\nProcess took " + str(time.time()-timestamp) + " seconds")

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2886,34 +2886,6 @@ void CMD_ModuleTimeout(F_CMD_ARGS)
 	return;
 }
 
-void CMD_HilightColor(F_CMD_ARGS)
-{
-	char *fore;
-	char *back;
-
-	if (Scr.cur_decor && Scr.cur_decor != &Scr.DefaultDecor)
-	{
-		fvwm_debug(__func__,
-			   "Decors do not support the HilightColor command"
-			   " anymore. Please use"
-			   " 'Style <stylename> HilightFore <forecolor>' and"
-			   " 'Style <stylename> HilightBack <backcolor>' instead."
-			   " Sorry for the inconvenience.");
-		return;
-	}
-	action = GetNextToken(action, &fore);
-	GetNextToken(action, &back);
-	if (fore && back)
-	{
-		xasprintf(&action, "* HilightFore %s, HilightBack %s", fore, back);
-		CMD_Style(F_PASS_ARGS);
-	}
-	free(fore);
-	free(back);
-
-	return;
-}
-
 void CMD_HilightColorset(F_CMD_ARGS)
 {
 	char *newaction;

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -270,7 +270,6 @@ void CMD_GotoDesk(F_CMD_ARGS);
 void CMD_GotoDeskAndPage(F_CMD_ARGS);
 void CMD_GotoPage(F_CMD_ARGS);
 void CMD_HideGeometryWindow(F_CMD_ARGS);
-void CMD_HilightColor(F_CMD_ARGS);
 void CMD_HilightColorset(F_CMD_ARGS);
 void CMD_IconFont(F_CMD_ARGS);
 void CMD_Iconify(F_CMD_ARGS);

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2338,8 +2338,6 @@ void HandleEnterNotify(const evh_args_t *ea)
 			int p = HandlePaging(
 				&e, edge_scroll, &junk, &delta,
 				True, True, False, Scr.ScrollDelay);
-			fvwm_debug(__func__, "handled paging for %s (%d)",
-				m->si->name, p);
 			return;
 		}
 	}

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -291,9 +291,6 @@ const func_t func_table[] =
 		F_HIDEGEOMWINDOW, 0, 0),
 	/* - (obsolete, use GeometryWindow Hide instead) */
 
-	CMD_ENT("hilightcolor", CMD_HilightColor, F_HICOLOR, 0, 0),
-	/* - (obsolete, use Style * HighlightFore/Back) */
-
 	CMD_ENT("hilightcolorset", CMD_HilightColorset, F_HICOLORSET, 0, 0),
 	/* - (obsolete, use Style * HighlightColorset) */
 

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1321,8 +1321,6 @@ static void SetRCDefaults(void)
 		{ "DefaultFont", "", "" },
 		{ DEFAULT_MENU_STYLE, "", "" },
 		{ "TitleStyle Centered -- Raised", "", "" },
-		{ "Style * Color lightgrey/dimgrey", "", "" },
-		{ "Style * HilightFore black, HilightBack grey", "", "" },
 		{ "AddToFunc LoadDefaultConfig", "", "" },
 		{ "+ I Read "FVWM_DATADIR"/default-config/config", "", "" },
 		{ "+ I StartFunction", "", "" },

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -733,11 +733,8 @@ int HandlePaging(
 	int mwidth, mheight;
 	int edge_thickness = m->virtual_scr.edge_thickness;
 
-	fvwm_debug(__func__, "ET (%s) is: %d", m->si->name, edge_thickness);
-
 	mwidth = monitor_get_all_widths();
 	mheight = monitor_get_all_heights();
-
 
 	delta->x = 0;
 	delta->y = 0;
@@ -1317,7 +1314,6 @@ void initPanFrames(struct monitor *ref)
 	}
 
 	/* Free panframes here for all monitors. */
-	fvwm_debug(__func__, "freeing panframes");
 	TAILQ_FOREACH(m, &monitor_q, entry) {
 		if (ref != NULL && m != ref)
 			continue;
@@ -1362,7 +1358,6 @@ void initPanFrames(struct monitor *ref)
 		checkPanFrames(m);
 	}
 	ref->virtual_scr.edge_thickness = saved_thickness;
-	fvwm_debug(__func__, "finished setting up per-monitor panframes");
 }
 
 Bool is_pan_frame(Window w)


### PR DESCRIPTION
In order to clean up the error log file I found that:

+ There were some instances of still using now removed color options. Removed them.
+ fvwm-menu-desktop was creating various errors in its menu output. Fixed them.
+ Removed pan_frame debugging, it is no longer needed and was filling up the log.