### PR TITLE
expand: fix $[monitor.0.XX] case

### DIFF
--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -563,7 +563,7 @@ static signed int expand_vars_extended(
 			/* Try parsing the name as a number.  If that fails,
 			 * then treat it as a valid name.
 			 */
-			pos = strtonum(m_name, 1, INT_MAX, &errstr);
+			pos = strtonum(m_name, 0, INT_MAX, &errstr);
 			if (errstr != NULL)
 				pos = -1;
 


### PR DESCRIPTION
Ensure we allow the number 0 to be an allowed value, so that the
ordering is consistent.
