### PR TITLE
Add Style CornerLength

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -5005,10 +5005,11 @@ style.
 _options_ is a comma separated list containing one or more of the
 following keywords. Each group of style names is separated by slashes
 ('/'). The last style in these groups is the default. _BorderWidth_,
-_HandleWidth_, _!Icon_ / _Icon_, _MiniIcon_, _IconBox_, _IconGrid_,
-_IconFill_, _IconSize_, _!Title_ / _Title_, _TitleAtBottom_ /
-_TitleAtLeft_ / _TitleAtRight_ / _TitleAtTop_, _LeftTitleRotatedCW_ /
-_LeftTitleRotatedCCW_, _RightTitleRotatedCCW_ / _RightTitleRotatedCW_,
+_HandleWidth_, _CornerLength_, _!Icon_ / _Icon_, _MiniIcon_,
+_IconBox_, _IconGrid_, _IconFill_, _IconSize_, _!Title_ / _Title_,
+_TitleAtBottom_ / _TitleAtLeft_ / _TitleAtRight_ /
+_TitleAtTop_, _LeftTitleRotatedCW_ / _LeftTitleRotatedCCW_,
+_RightTitleRotatedCCW_ / _RightTitleRotatedCW_,
 _TopTitleRotated_ / _TopTitleNotRotated_, _BottomTitleRotated_ /
 _BottomTitleNotRotated_, _!UseTitleDecorRotation_ /
 _UseTitleDecorRotation_, _StippledTitle_ / _!StippledTitle_,
@@ -5489,12 +5490,16 @@ but is deprecated.
 +
 _HandleWidth_ takes a numeric argument which is the width of the
 border to place the window if it does have resize-handles. Using
-HandleWidth without an argument restores the default.
+_HandleWidth_ without an argument restores the default.
++
+_CornerLength_ takes a single numeric argument which is the length,
+in pixels, of the corner handles. The default is the title height.
+Using _CornerLength_ without an argument restores the default.
 +
 _BorderWidth_ takes a numeric argument which is the width of the
 border to place the window if it does not have resize-handles. It is
 used only if the _!Handles_ style is specified too. Using
-BorderWidth without an argument restores the default.
+_BorderWidth_ without an argument restores the default.
 +
 _DepressableBorder_ makes the border parts of the window decoration
 look sunken in when a button is pressed over them. This can be

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -1659,6 +1659,7 @@ void setup_title_geometry(
 {
 	int width;
 	int offset;
+	style_flags *sflags = &(pstyle->flags);
 
 	get_title_font_size_and_offset(
 		fw, S_TITLE_DIR(SCF(*pstyle)),
@@ -1669,7 +1670,12 @@ void setup_title_geometry(
 		&width, &offset);
 	fw->title_thickness = width;
 	fw->title_text_offset = offset;
-	fw->corner_width = fw->title_thickness + fw->boundary_width;
+	fw->corner_length = fw->title_thickness + fw->boundary_width;
+	if (SHAS_CORNER_LENGTH(sflags))
+	{
+		fw->corner_length =
+			SGET_CORNER_LENGTH(*pstyle) + fw->boundary_width;
+	}
 	if (!HAS_TITLE(fw))
 	{
 		fw->title_thickness = 0;

--- a/fvwm/borders.c
+++ b/fvwm/borders.c
@@ -1789,11 +1789,11 @@ static void border_draw_one_border_part(
 			break;
 		case PART_BORDER_NE:
 		case PART_BORDER_SE:
-			bg.pixmap.g.x = frame_g->width - fw->corner_width;
+			bg.pixmap.g.x = frame_g->width - fw->corner_length;
 			break;
 		case PART_BORDER_N:
 		case PART_BORDER_S:
-			bg.pixmap.g.x = fw->corner_width;
+			bg.pixmap.g.x = fw->corner_length;
 			break;
 		default:
 			bg.pixmap.g.x = 0;
@@ -1806,11 +1806,11 @@ static void border_draw_one_border_part(
 			break;
 		case PART_BORDER_SW:
 		case PART_BORDER_SE:
-			bg.pixmap.g.y = frame_g->height - fw->corner_width;
+			bg.pixmap.g.y = frame_g->height - fw->corner_length;
 			break;
 		case PART_BORDER_W:
 		case PART_BORDER_E:
-			bg.pixmap.g.y = fw->corner_width;
+			bg.pixmap.g.y = fw->corner_length;
 			break;
 		default:
 			bg.pixmap.g.y = 0;

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2335,7 +2335,7 @@ void HandleEnterNotify(const evh_args_t *ea)
 			/* this was in the HandleMotionNotify before, HEDU */
 			Scr.flags.is_pointer_on_this_screen = 1;
 			e = *te;
-			int p = HandlePaging(
+			HandlePaging(
 				&e, edge_scroll, &junk, &delta,
 				True, True, False, Scr.ScrollDelay);
 			return;

--- a/fvwm/frame.c
+++ b/fvwm/frame.c
@@ -1535,7 +1535,7 @@ void frame_get_sidebar_geometry(
 	FvwmWindow *fw, DecorFaceStyle *borderstyle, rectangle *frame_g,
 	rectangle *ret_g, Bool *ret_has_x_marks, Bool *ret_has_y_marks)
 {
-	int min_w;
+	int min_l;
 	size_borders b;
 
 	ret_g->x = 0;
@@ -1570,16 +1570,16 @@ void frame_get_sidebar_geometry(
 		*ret_has_x_marks = True;
 		*ret_has_y_marks = True;
 	}
-	ret_g->x = fw->corner_width;
-	ret_g->y = fw->corner_width;
-	min_w = 2 * fw->corner_width + 4;
+	ret_g->x = fw->corner_length;
+	ret_g->y = fw->corner_length;
+	min_l = 2 * fw->corner_length + 4;
 	/* limit by available space, remove handle marks if necessary */
-	if (frame_g->width < min_w)
+	if (frame_g->width < min_l)
 	{
 		ret_g->x = frame_g->width / 3;
 		*ret_has_y_marks = False;
 	}
-	if (frame_g->height < min_w)
+	if (frame_g->height < min_l)
 	{
 		ret_g->y = frame_g->height / 3;
 		*ret_has_x_marks = False;

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -513,6 +513,7 @@ typedef struct style_flags
 	unsigned has_edge_resistance_move : 1;
 	unsigned has_edge_resistance_screen_move : 1;
 	unsigned has_handle_width : 1;
+	unsigned has_corner_length : 1;
 	unsigned has_icon : 1;
 	unsigned has_icon_boxes : 1;
 	unsigned has_icon_size_limits : 1;
@@ -637,6 +638,7 @@ typedef struct window_style
 	short border_width;
 	/* resize handle width */
 	short handle_width;
+	short corner_length;
 	int layer;
 	int start_desk;
 	int start_page_x;
@@ -764,8 +766,7 @@ typedef struct FvwmWindow
 	 * CONFIGARGSNEW macro in module_interface.c, libs/vpacket.h too! */
 	short boundary_width;
 	short unshaped_boundary_width;
-	short corner_width;
-	short visual_corner_width;
+	short corner_length;
 
 	/* title font */
 	FlocaleFont *title_font;

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -470,6 +470,11 @@ static void merge_styles(
 		SSET_HANDLE_WIDTH(
 			*merged_style, SGET_HANDLE_WIDTH(*add_style));
 	}
+	if (add_style->flags.has_corner_length)
+	{
+		SSET_CORNER_LENGTH(
+			*merged_style, SGET_CORNER_LENGTH(*add_style));
+	}
 	if (add_style->flags.has_icon_size_limits)
 	{
 		SSET_MIN_ICON_WIDTH(
@@ -2348,6 +2353,22 @@ static Bool style_parse_one_style_option(
 			S_SET_IS_UNCLOSABLE(SCF(*ps), !on);
 			S_SET_IS_UNCLOSABLE(SCM(*ps), 1);
 			S_SET_IS_UNCLOSABLE(SCC(*ps), 1);
+		}
+		else if (StrEquals(token, "CornerLength"))
+		{
+			GetIntegerArguments(rest, &rest, val, 1);
+
+			if (*val > 0)
+			{
+				SSET_CORNER_LENGTH(*ps, (short)*val);
+				ps->flags.has_corner_length = 1;
+			}
+			else
+			{
+				ps->flags.has_corner_length = 0;
+			}
+			ps->flag_mask.has_corner_length = 1;
+			ps->change_mask.has_corner_length = 1;
 		}
 		else
 		{
@@ -4986,6 +5007,12 @@ void check_window_style_change(
 		flags->do_redecorate = 1;
 		flags->do_update_ewmh_allowed_actions = 1;
 		flags->do_update_modules_flags = 1;
+	}
+
+	/* has_corner_length */
+	if (ret_style->change_mask.has_corner_length)
+	{
+		flags->do_redecorate = 1;
 	}
 
 	if (ret_style->change_mask.do_save_under ||

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -20,6 +20,8 @@
 	((sf)->has_border_width)
 #define SHAS_HANDLE_WIDTH(sf) \
 	((sf)->has_handle_width)
+#define SHAS_CORNER_LENGTH(sf) \
+	((sf)->has_corner_length)
 #define SHAS_ICON(sf) \
 	((sf)->has_icon)
 #define SHAS_ICON_BOXES(sf) \
@@ -468,6 +470,10 @@
 	((s).handle_width)
 #define SSET_HANDLE_WIDTH(s,x) \
 	((s).handle_width = (x))
+#define SGET_CORNER_LENGTH(s) \
+	((s).corner_length)
+#define SSET_CORNER_LENGTH(s,x) \
+	((s).corner_length = (x))
 #define SGET_LAYER(s) \
 	((s).layer)
 #define SSET_LAYER(s,x) \


### PR DESCRIPTION
Renames the window setting variable corner_width as corner_length, since length is more descriptive of what does, and make this configurable (currently it is computed using the title height and border thickness). The corner_length of a window can be configured using the new CornerLength style, which takes a single numerical argument as the length in pixels. If no argument (or an invalid argument) is provided, the default is used, which is the title height.

This is a rework of #771 that only allows pixel settings (since there were some issues with the % setting option).
