### PR TITLE
Don't use google fonts when building html doc.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -58,6 +58,6 @@ $(html_MANS): $(SECTION_FILES)
 	"$(ASCIIDOC)" -b manpage -a "$(patsubst %.1,%,$@)" "$<" -o "$@"
 
 %.html: %.adoc
-	"$(ASCIIDOC)" -b html5 -a toc -a "$(patsubst %.html,%,$@)" "$<" -o "$@"
+	"$(ASCIIDOC)" -b html5 -a toc -a webfonts! -a "$(patsubst %.html,%,$@)" "$<" -o "$@"
 
 endif


### PR DESCRIPTION
Asciidoctor uses google fonts in its html documentation, which makes the html files not fully usable offline. This triggered a warning in lintian which would prefer all docs are fully ofline and don't download stuff automatically.

This disables the webfonts from the html generation, so the html files are viewed the same offline and no longer automatically download google's webfonts.