### PR TITLE
Add index page for html manpages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,7 @@ config.status
 configure
 contrib/xsession/fvwm3.desktop
 core
-doc/footer.html
-doc/fvwm.ent
-doc/fvwm3.ent
+doc/index.adoc
 etc/
 fvwm/fvwm
 fvwm/fvwm3

--- a/doc/FvwmCommand.adoc
+++ b/doc/FvwmCommand.adoc
@@ -1,4 +1,4 @@
-= FvwmConsole(1)
+= FvwmCommand(1)
 
 :doctype: manpage
 :mantitle: FvwmCommand

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -10,11 +10,13 @@ MODULE_ADOC_SRCS = \
 	$(wildcard fvwm-*.adoc)
 
 # If building FvwmPrompt, don't generate the manpage for FvwmConsole as that
-# won't ever be installed.
+# won't ever be installed, otherwise don't generate FvwmPrompt manpage.
 if FVWM_BUILD_GOLANG
 MODULE_ADOC = $(filter-out FvwmConsole.adoc, $(MODULE_ADOC_SRCS))
+REMOVE_LINK = FvwmConsole.adoc
 else
-MODULE_ADOC = $(MODULE_ADOC_SRCS)
+MODULE_ADOC = $(filter-out FvwmPrompt.adoc, $(MODULE_ADOC_SRCS))
+REMOVE_LINK = FvwmPrompt.adoc
 endif
 
 EXTRA_DIST = $(MODULE_ADOC_SRCS)
@@ -22,7 +24,7 @@ EXTRA_DIST = $(MODULE_ADOC_SRCS)
 nothing:
 
 clean:
-	rm -f *.1 *.ad *.html
+	rm -f *.1 *.ad *.html index.adoc
 
 distclean-local: clean
 
@@ -32,8 +34,8 @@ if FVWM_BUILD_MANDOC
 man1_MANS = $(patsubst %.adoc,%.1, $(M1M))
 endif
 if FVWM_BUILD_HTMLDOC
-html_MANS = $(patsubst %.adoc,%.html, $(M1M))
-doc_DATA = $(patsubst %.adoc,%.html, $(M1M))
+html_MANS = index.html $(patsubst %.adoc,%.html, $(M1M))
+doc_DATA = $(html_MANS)
 endif
 
 EXTRACT_SECTIONS = \
@@ -56,6 +58,10 @@ $(html_MANS): $(SECTION_FILES)
 
 %.1: %.adoc
 	"$(ASCIIDOC)" -b manpage -a "$(patsubst %.1,%,$@)" "$<" -o "$@"
+
+index.html:
+	"$(SED)" '/$(REMOVE_LINK)/d' index.adoc.in > index.adoc; \
+	"$(ASCIIDOC)" -b html5 -a toc -a webfonts! -a index index.adoc -o index.html
 
 %.html: %.adoc
 	"$(ASCIIDOC)" -b html5 -a toc -a webfonts! -a "$(patsubst %.html,%,$@)" "$<" -o "$@"

--- a/doc/index.adoc.in
+++ b/doc/index.adoc.in
@@ -1,0 +1,38 @@
+= Fvwm3 Manual Pages
+
+== Fvwm3
+
+* xref:fvwm3.adoc[Fvwm 3]
+* xref:fvwm3menus.adoc[Fvwm 3 Menus]
+* xref:fvwm3commands.adoc[Fvwm 3 Commands]
+* xref:fvwm3styles.adoc[Fvwm 3 Styles]
+* xref:fvwm3all.adoc[Single Fvwm3 Manual Page]
+
+== Fvwm3 Helper Binaries
+
+* xref:FvwmPrompt.adoc[FvwmPrompt]
+* xref:FvwmCommand.adoc[FvwmCommand]
+* xref:fvwm-menu-desktop.adoc[fvwm-menu-desktop]
+* xref:fvwm-menu-directory.adoc[fvwm-menu-directory]
+* xref:fvwm-menu-xlock.adoc[fvwm-menu-xlock]
+* xref:fvwm-perllib.adoc[fvwm-perllib]
+* xref:fvwm-root.adoc[fvwm-root]
+* xref:fvwm-convert-2.6.adoc[fvwm-convert-2.6]
+
+== Fvwm3 Modules
+
+* xref:FvwmAnimate.adoc[FvwmAnimate]
+* xref:FvwmAuto.adoc[FvwmAuto]
+* xref:FvwmBacker.adoc[FvwmBacker]
+* xref:FvwmButtons.adoc[FvwmButtons]
+* xref:FvwmConsole.adoc[FvwmConsole]
+* xref:FvwmEvent.adoc[FvwmEvent]
+* xref:FvwmForm.adoc[FvwmForm]
+* xref:FvwmIconMan.adoc[FvwmIconMan]
+* xref:FvwmIdent.adoc[FvwmIdent]
+* xref:FvwmMFL.adoc[FvwmMFL]
+* xref:FvwmPager.adoc[FvwmPager]
+* xref:FvwmPerl.adoc[FvwmPerl]
+* xref:FvwmPrompt.adoc[FvwmPrompt]
+* xref:FvwmRearrange.adoc[FvwmRearrange]
+* xref:FvwmScript.adoc[FvwmScript]


### PR DESCRIPTION
This will now generate fvwm3-index.html if building html docs. This is done using an fvwm3-index.adoc.in template, in which the FvwmConsole or FvwmPrompt manpage is removed (depending on if FvwmPrompt is built or not).  This means that if helper binaries or modules are added/removed, the template will have to be manually updated.

This also makes it so the FvwmPrompt manpage is not build if FvwmPrompt is not being built.
