### PR TITLE
build: correct next version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ fi
 # Silence warning: ar: 'u' modifier ignored since 'D' is the default
 AC_SUBST(AR_FLAGS, [cr])
 
-AC_INIT([fvwm3], 1.0.10, [fvwm-workers@fvwm.org])
+AC_INIT([fvwm3], 1.1.0, [fvwm-workers@fvwm.org])
 AC_CONFIG_AUX_DIR(etc)
 AC_CONFIG_LIBOBJ_DIR(libs)
 AM_INIT_AUTOMAKE([foreign subdir-objects])


### PR DESCRIPTION
Go from 1.0.10 -> 1.1.0, otherwise it'll be ages before we reach a sensible version.