### PR TITLE
Add DesktopNames to xdg desktop file.

### DIFF
--- a/contrib/xsession/fvwm3.desktop.in
+++ b/contrib/xsession/fvwm3.desktop.in
@@ -4,4 +4,5 @@ Keywords=Fvwm3 Window Manager
 Comment=F? Virtual Window Manager
 Icon=@datadir@/fvwm3/default-config/images/fvwm-logo-small.png
 Type=Application
+DesktopNames=FVWM3;FVWM;
 Exec=@bindir@/fvwm3


### PR DESCRIPTION
This is used with xdg-desktop-portal, and will allow downstream distros/users to create fvwm3-portals.conf or fvwm-portals.conf to configure xdg-desktop-portal for fvwm3.

This only makes it so users who login via the desktop file set the environment variable `XDG_CURRENT_DESKTOP=Fvwm3:Fvwm`, which is then used for xdg-desktop-portal.