### PR TITLE
FvwmPrompt: accept commands on stdin

### DIFF
--- a/bin/FvwmPrompt/FvwmPrompt.go
+++ b/bin/FvwmPrompt/FvwmPrompt.go
@@ -152,7 +152,7 @@ func main() {
 	go connectToFMD(shell, readFromFMD, writeToFMD)
 
 	if isInteractive {
-		shell.Process(os.Args[1:]...)
+		handleInput(nil, strings.Join(os.Args[1:], " "), writeToFMD);
 	} else {
 		red := color.New(color.FgRed).SprintFunc()
 		shell.Actions.SetPrompt(red(*cmdLineArgs.promptText))


### PR DESCRIPTION
It was meant to be possible to use FvwmPrompt as FvwmCommand, as in:

    FvwmPrompt Exec exec xterm

This seemingly never worked.