### PR TITLE
RandR: handle monitor {dis,}connection better

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ if test ! x"$with_golang" = xno; then
 		sed -e 's/ .*$//')
 	    AC_MSG_CHECKING([whether go version is >= 1.14.x ($go_version)])
 	    case "$go_version" in
-	     1.14*|1.15*|1.16*|1.17*|1.18*|1.19*|1.20*|1.21*)
+	     1.14*|1.15*|1.16*|1.17*|1.18*|1.19*|1.20*|1.21*|1.22*|1.23*)
 	      AC_MSG_RESULT([yes - version is: $go_version])
 	      with_golang="yes"
 	      GO=

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -165,6 +165,9 @@ status_send(void)
 		if ((desk_doc[d_count] = cJSON_CreateObject()) == NULL)
 			goto out;
 
+		if (m->Desktops == NULL)
+			goto out;
+
 		this_desktop = cJSON_AddObjectToObject(desk_doc[d_count],
 		    "desktops");
 

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2295,6 +2295,12 @@ void HandleEnterNotify(const evh_args_t *ea)
 		pfm = monitor_resolve_name(prev_focused_monitor);
 		this_m = monitor_get_current();
 
+		/* Don't toggle the previous monitor if there isn't one, or
+		 * the two monitors are the same.
+		 */
+		if ((pfm == NULL) || (pfm == this_m))
+			return;
+
 		/* Send MX_MONITOR_FOCUS event. */
 		toggle_prev_monitor_state(this_m, pfm, NULL);
 

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -145,14 +145,18 @@ struct monitor {
 	bool pan_frames_mapped;
 
 	RB_ENTRY(monitor) entry;
+	TAILQ_ENTRY(monitor) oentry;
 };
 RB_HEAD(monitors, monitor);
+TAILQ_HEAD(monitorsold, monitor);
 
 extern struct monitors  monitors;
 extern struct monitors	monitor_q;
+extern struct monitorsold  monitorsold_q;
 int			monitor_compare(struct monitor *, struct monitor *);
 RB_PROTOTYPE(monitors, monitor, entry, monitor_compare);
 
+int		 changed_monitor_count(void);
 struct monitor	*monitor_resolve_name(const char *);
 struct monitor	*monitor_by_xy(int, int);
 struct monitor  *monitor_by_output(int);


### PR DESCRIPTION
When monitors are connected and disconnected, the monitor is deleted and reinserted into the RB_TREE.  This has to happen as the key has changed and a monitor could have changed position.

In doing so, ensure the windows which were on the existing monitors are properly updated.  This means keeping a separate list of monitors which have been altered, and reassigning windows on the old monitor to the new one.  This is done using monitor names, which seems consistent if one undocks a laptop from a docking station and then reattaches, for example.

Without this change, windows would lose which desk they were previously on.