### PR TITLE
logging: minor tweaks

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1036,10 +1036,6 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 
 	if (Scr.bo.do_debug_randr)
 	{
-		fvwm_debug(
-			__func__, "monitor '%s': {l: %d, r: %d, t: %d, b: %d} "
-			"{x: %d, y: %d, w: %d, h: %d}\n", m->si->name,
-			left, right, top, bottom, x, y, width, height);
 	}
 
 	if (
@@ -1055,7 +1051,10 @@ void ewmh_ComputeAndSetWorkArea(struct monitor *m)
 
 		if (Scr.bo.do_debug_randr)
 		{
-			fvwm_debug(__func__, "differ, so setting work area\n");
+			fvwm_debug(__func__, "monitor '%s': "
+			    "{l: %d, r: %d, t: %d, b: %d} "
+			    "{x: %d, y: %d, w: %d, h: %d}\n", m->si->name,
+			    left, right, top, bottom, x, y, width, height);
 		}
 	}
 
@@ -1129,16 +1128,6 @@ void EWMH_GetWorkAreaIntersection(
 	int area_h = m->Desktops->ewmh_working_area.height;
 	Bool is_dynamic = False;
 
-	if (Scr.bo.do_debug_randr)
-	{
-		fvwm_debug(
-			__func__, "mon: %s {ax: %d, ay: %d, aw: %d, ah: %d\n",
-			m->si->name, area_x, area_y, area_w, area_h);
-		fvwm_debug(
-			__func__, "mon: %s {x: %d, y: %d, w: %d, h: %d\n",
-			m->si->name, *x, *y, *w, *h);
-	}
-
 	switch(type)
 	{
 	case EWMH_IGNORE_WORKING_AREA:
@@ -1168,10 +1157,9 @@ void EWMH_GetWorkAreaIntersection(
 	*w = nw;
 	*h = nh;
 
-	if (Scr.bo.do_debug_randr)
-	{
-		fvwm_debug(
-			__func__,
+	if (Scr.bo.do_debug_randr &&
+	    (*x != area_x || *y != area_y || *w != area_w || *h != area_h)) {
+		fvwm_debug(__func__,
 			"mon: %s finalising: {x: %d, y: %d, w: %d, h: %d}\n",
 			m->si->name, *x, *y, *w, *h);
 	}

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -172,8 +172,6 @@ void CMD_EwmhBaseStruts(F_CMD_ARGS)
 	}
 
 	RB_FOREACH(m, monitors, &monitor_q) {
-		fvwm_debug(__func__, "mon: %s {l: %d, r: %d, t: %d, b: %d}\n",
-			m->si->name, val[0], val[1], val[2], val[3]);
 		set_ewmhc_strut_values(m, val);
 	}
 }

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -2422,8 +2422,6 @@ Bool setup_window_placement(
 		e = expand_vars(sc, NULL, False, True, NULL, exc);
 
 	start_style.screen = (e != NULL) ? fxstrdup(e) : fxstrdup("");
-	fvwm_debug(__func__, "Expanding screen from '%s' -> '%s'",
-			sc ? sc : "null", start_style.screen);
 	rc = _place_window(
 		exc, pstyle, attr_g, start_style, mode, win_opts, &reason);
 

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -705,6 +705,11 @@ monitor_dump_state(struct monitor *m)
 			"\t\tCurrentDesk: %d\n"
 			"\t\tCurrentPage: {x: %d, y: %d}\n"
 			"\t\tMyDisplayWidth: %d, MyDisplayHeight: %d\n\t}\n"
+			"\tEWMH: {\n"
+			"\t\tBaseStrut Top:    %d\n"
+			"\t\tBaseStrut Bottom: %d\n"
+			"\t\tBaseStrut Left:   %d\n"
+			"\t\tBaseStrut Right:  %d\n\t}\n"
 			"\tDesktops:\t%s\n"
 			"\tFlags:%s\n\n",
 			m2->number,
@@ -724,6 +729,10 @@ monitor_dump_state(struct monitor *m)
 			(int)(m2->virtual_scr.Vy / monitor_get_all_heights()),
 			monitor_get_all_widths(),
 			monitor_get_all_heights(),
+			m2->ewmhc.BaseStrut.top,
+			m2->ewmhc.BaseStrut.bottom,
+			m2->ewmhc.BaseStrut.left,
+			m2->ewmhc.BaseStrut.right,
 			m2->Desktops ? "yes" : "no",
 			monitor_mode == MONITOR_TRACKING_G ? "global" :
 			monitor_mode == MONITOR_TRACKING_M ? "per-monitor" :


### PR DESCRIPTION
Change some of the logging logic to reduce the same information being
printed out when it's not needed.  This mostly applies to when
DebugRandR is turned on.  Additionally, augment the DebugRandR output to
print out EWMHBaseStruts values.