### PR TITLE
build: fix Xft/Freetype/Fontconfig check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -643,6 +643,11 @@ AH_TEMPLATE([HAVE_XFT_UTF8],[Define if Xft library can handle utf8 encoding])
 AC_SUBST(Xft_LIBS)
 AC_SUBST(Xft_CFLAGS)
 
+if test x"$with_xft" = "no" || test x"$with_fontconfig" = "xno" || \
+  test x"$have_freetype" = "xno"; then
+  AC_MSG_ERROR(["*** XFT/Fontconfig/Freetype not found. ***])
+fi
+
 # ********* xpm
 problem_xpm=": Xpm library or header not found"
 

--- a/dev-docs/INSTALL.md
+++ b/dev-docs/INSTALL.md
@@ -23,17 +23,18 @@ system in use.
 ## Core dependencies
 
 * libevent-dev (>= 2.0)
+* libfontconfig-dev
+* libfreetype6-dev
 * libx11-dev
+* libxext-dev
+* libxft-dev
 * libxrandr-dev (>= 1.5)
 * libxrender-dev
 * libxt-dev
-* libxft-dev
 
 ## Optional dependencies
 
 * asciidoctor
-* libfontconfig-dev
-* libfreetype6-dev
 * libfribidi-dev
 * libncurses5-dev
 * libpng-dev
@@ -41,7 +42,6 @@ system in use.
 * librsvg-dev
 * libsm-dev
 * libxcursor-dev
-* libxext-dev
 * libxi-dev
 * libxpm-dev
 * sharutils


### PR DESCRIPTION
Now that XFT2 has been made mandatory, ensure we bail out of any
./configure checks if this is not found, rather than trying to compile
without xft.

Additionally, update the INSTALL.md instructions with those mandatory
packages.

Fixes #667
