### PR TITLE
FvwmPager: honour screen focus rules

### DIFF
--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -679,6 +679,7 @@ Bool update_fvwm_monitor(FvwmWindow *fw)
 	EWMH_SetCurrentDesktop(fw->m);
 	desk_add_fw(fw);
 	BroadcastConfig(M_CONFIGURE_WINDOW, fw);
+	BroadcastMonitorList(NULL);
 
 	return True;
 }

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2563,7 +2563,21 @@ void CMD_GotoDesk(F_CMD_ARGS)
 	struct monitor  *m, *m_loop;
 	char		*next, *token;
 	int		 new_desk;
+	int		 val[2];
 
+	/* We've received something like:
+	 *
+	 * GotoDesk 0 0
+	 *
+	 * But no monitor token.  Use the current monitor.
+	 */
+	if (GetIntegerArguments(action, NULL, val, 2) == 2) {
+		xasprintf(&action, "%s %d %d",
+			monitor_get_current()->si->name, val[0], val[1]);
+
+		val[0] = -1;
+		val[1] = -1;
+	}
 	token = PeekToken(action, &next);
 	m = monitor_resolve_name(token);
 	if (m != NULL)
@@ -2635,6 +2649,19 @@ void CMD_GotoDeskAndPage(F_CMD_ARGS)
 	char *token;
 	struct monitor  *m;
 
+	/* We've received something like:
+	 *
+	 * GotoDeskAndPage 0 0
+	 *
+	 * But no monitor token.  Use the current monitor.
+	 */
+	if (GetIntegerArguments(action, NULL, val, 2) == 2) {
+		xasprintf(&action, "%s %d %d",
+			monitor_get_current()->si->name, val[0], val[1]);
+
+		val[0] = -1;
+		val[1] = -1;
+	}
 	token = PeekToken(action, &next);
 	m = monitor_resolve_name(token);
 	if (m != NULL)

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -1555,20 +1555,15 @@ void list_config_info(unsigned long *body)
 		DrawGrid(val, True, None, NULL);
 	} else if (StrEquals(token, "Monitor")) {
 		char	*mname;
-		int		 updated = 0;
 
 		tline = GetNextToken(tline, &mname);
 
 		TAILQ_FOREACH(m2, &fp_monitor_q, entry) {
-			updated = 0;
 			if (strcmp(m2->name, mname) == 0) {
 				extract_monitor_config(m2,tline);
-				updated = 1;
+				return;
 			}
 		}
-
-		if (updated)
-			return;
 
 		m = fxcalloc(1, sizeof(*m));
 
@@ -1863,20 +1858,15 @@ ImagePath = NULL;
     }
     else if (StrEquals(token, "Monitor")) {
 	    char	*mname;
-	    int		 updated = 0;
 
 	    next = GetNextToken(next, &mname);
 
 	    TAILQ_FOREACH(m2, &fp_monitor_q, entry) {
-		    updated = 0;
 		    if (strcmp(m2->name, mname) == 0) {
 			    extract_monitor_config(m2, next);
-			    updated = 1;
+			    return;
 		    }
 	    }
-
-	    if (updated)
-		    continue;
 
 	    m = fxcalloc(1, sizeof(*m));
 

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1898,8 +1898,7 @@ void SwitchToDesk(int Desk)
 	struct fpmonitor *m = fpmonitor_this();
 
 	snprintf(command, sizeof(command),
-		"GotoDesk %s 0 %d", monitor_to_track ? m->name : "",
-		Desk + desk1);
+		"GotoDesk %s 0 %d", m->name, Desk + desk1);
 	SendText(fd,command,0);
 }
 


### PR DESCRIPTION
When FvwmPager is configured without the `Monitor` module config line,
*and*, `DesktopConfiguration per-monitor` is set, FvwmPager wasn't
tracking which monitor should be used to invoke the `GotoDesk` command
when clicking on the pager desk label.

This meant desktops had the effect of not switching.

This change won't affect `DesktopConfiguration global`, and will work
when FvwmPager has a `Monitor` configuration line.

Fixes #957
