### PR TITLE
Improve RandR Detection

### DIFF
--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -73,6 +73,7 @@
 #include "ewmh.h"
 #include "ewmh_intern.h"
 #include "geometry.h"
+#include "virtual.h"
 #include "window_flags.h"
 
 #define EWMH_DEBUG 0
@@ -1944,6 +1945,17 @@ void EWMH_Init(struct monitor *m)
 
 	clean_up();
 
+	if (m->Desktops == NULL) {
+		m->Desktops = fxcalloc(1, sizeof *m->Desktops);
+		m->Desktops->name = NULL;
+		m->Desktops->next = NULL;
+		m->Desktops->desk = 0;
+
+		/* XXX: mempcy virtual_scr??? */
+
+		apply_desktops_monitor(m);
+	}
+
 	EWMH_SetDesktopNames(m);
 	EWMH_SetCurrentDesktop(m);
 	EWMH_SetNumberOfDesktops(m);
@@ -1952,7 +1964,7 @@ void EWMH_Init(struct monitor *m)
 	EWMH_SetClientList(m);
 	EWMH_SetClientListStacking(m);
 
-	return;
+	m->flags &= ~MONITOR_NEW;
 }
 
 /*

--- a/libs/FScreen.h
+++ b/libs/FScreen.h
@@ -9,6 +9,7 @@
 #include "queue.h"
 #include "tree.h"
 
+#include <X11/extensions/Xrandr.h>
 #include <stdbool.h>
 
 typedef struct
@@ -73,8 +74,8 @@ struct screen_info	*screen_info_by_name(const char *);
 #define MONITOR_DISABLED 0x2
 #define MONITOR_ENABLED 0x4
 #define MONITOR_PRIMARY 0x8
-#define MONITOR_CHANGED 0x10
-#define MONITOR_ALL (MONITOR_DISABLED|MONITOR_ENABLED|MONITOR_CHANGED)
+#define MONITOR_CHANGED 0x100
+#define MONITOR_FOUND 0x200
 
 #define MONITOR_OUTSIDE_EDGE 0
 #define MONITOR_INSIDE_EDGE 1
@@ -171,7 +172,6 @@ void		 monitor_dump_state(struct monitor *);
 void		 monitor_output_change(Display *, XRRScreenChangeNotifyEvent *);
 int		 monitor_get_all_widths(void);
 int		 monitor_get_all_heights(void);
-void		 monitor_add_new(void);
 void		 monitor_assign_virtual(struct monitor *);
 void		 checkPanFrames(struct monitor *);
 


### PR DESCRIPTION
Rather than use output detection, just use RandR 1.5's XRRGetMonitors()
call and flag monitors up as being connected or disconnected.

This should help make the disabled status of monitors more robust,
whilst making changes to monitors easier to track.