### PR TITLE
FvwmPager: remove list_focus handling

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -851,26 +851,6 @@ void list_destroy(unsigned long *body)
 void list_monitor_focus(unsigned long *body)
 {
 	return;
-#if 0
-	struct fpmonitor	*m, *mcur, *mthis;
-	char	*mon_name = (char *)(&body[3]);
-
-	mcur = fpmonitor_get_current();
-
-	if (mcur == NULL || mon_name == NULL)
-		return;
-
-	mthis = fpmonitor_by_name(mon_name);
-
-	if (mcur == mthis)
-		return;
-
-	mcur->is_current = 0;
-	TAILQ_FOREACH(m, &fp_monitor_q, entry) {
-		if (m == mthis)
-			m->is_current = 1;
-	}
-#endif
 }
 
 /*


### PR DESCRIPTION
This was only ever used internally by FvwmPager to keep track of which
monitor is currently focused.  This is no longer required now that this
information is used directly from libfvwm3.
