### PR TITLE
GotoDesk: fallback to current monitor if not given

### DIFF
--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2563,7 +2563,6 @@ void CMD_GotoDesk(F_CMD_ARGS)
 	struct monitor  *m, *m_loop;
 	char		*next, *token;
 	int		 new_desk;
-	int		 val[2];
 
 	/* We've received something like:
 	 *
@@ -2571,25 +2570,14 @@ void CMD_GotoDesk(F_CMD_ARGS)
 	 *
 	 * But no monitor token.  Use the current monitor.
 	 */
-	if (GetIntegerArguments(action, NULL, val, 2) == 2) {
-		xasprintf(&action, "%s %d %d",
-			monitor_get_current()->si->name, val[0], val[1]);
-
-		val[0] = -1;
-		val[1] = -1;
-	}
 	token = PeekToken(action, &next);
 	m = monitor_resolve_name(token);
-	if (m != NULL)
-	{
-		action = next;
-	}
-	else
-	{
+	if (m == NULL) {
 		m = monitor_get_current();
+		next = action;
 	}
 
-	new_desk = GetDeskNumber(m, action, m->virtual_scr.CurrentDesk);
+	new_desk = GetDeskNumber(m, next, m->virtual_scr.CurrentDesk);
 
 	if (is_tracking_shared) {
 		/* Check to see if this monitor is requesting a desktop which


### PR DESCRIPTION
When parsing GotoDesk, don't assume n -> m arguments, as there's
validity for this command to have different combinations.

Instead, always assume the first argument is a potential monitor, and
look that up.  If it isn't found as a monitor, treat the rest of the
command as desk coordinates to lookup.  Otherwise, skip over the valid
monitor name, and perform the desk lookup.
