### PR TITLE
RandR: don't unset a new monitor's enabled state

### DIFF
--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -610,7 +610,7 @@ out:
 		 * active or not.  Clearing the MONITOR_FOUND flag is
 		 * important here so that the monitor is reconsidered again.
 		 */
-		if (!(m->flags & MONITOR_FOUND)) {
+		if (!(m->flags & (MONITOR_FOUND|MONITOR_NEW))) {
 			m->flags |= MONITOR_DISABLED;
 			m->emit |= MONITOR_DISABLED;
 		} else if (m->flags & (MONITOR_FOUND|MONITOR_DISABLED)) {


### PR DESCRIPTION
When setting up new monitors, don't clobber the new state by then
setting it to disabled.
