### PR TITLE
Stop fvwm-menu-desktop from informing users it cannot find icon %s.

### DIFF
--- a/bin/fvwm-menu-desktop.in
+++ b/bin/fvwm-menu-desktop.in
@@ -726,8 +726,8 @@ def printmenu(name, icon, command):
         if not (iconfile == '' or iconfile == None) and os.path.isfile(iconfile):
             iconfile = '%'+iconfile+'%'
         else:
+            vprint(f"{iconfile} icon or default icon not found!")
             iconfile = ''
-            sys.stderr.write("%s icon or default icon not found!\n")
     printtext('+ "%s%s" %s' % (escapemenutext(name), iconfile, command))
 
 def parsemenus(menulist, desktop, desktop_entries=[]):


### PR DESCRIPTION
The error was a literal `%s`, and it should only be output in verbose mode.