### PR TITLE
FvwmPager: Allow for some dynamic config loading

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -371,6 +371,27 @@ done about this - except not using SloppyFocus in the pager.
   is especially meaningful when the _DesktopConfiguration_ command is
   set to _shared_.
 
+== SENDING COMMANDS
+
+Using the _SendToModule_ command, _FvwmPager_ can be sent the following
+list of commands: *Monitor*, *DeskLabels*, *NoDeskLabels*, *MonitorLabels*,
+and *NoMonitorLabels*. Each command functions identically to its
+configuration option, changing the configuration of the running pager.
+
+**Note**: these commands work only on the running instance only, to make
+any changes permanent, update the relevant config file.
+
+For example, you can tell a running instance of _FvwmPager_ to track a
+specific monitor by sending it the following command:
+
+....
+SendToModule FvwmPager Monitor RANDRNAME
+....
+
+This will either change which monitor is being shown or tell the pager to
+only show a specific monitor. Note that the special value of *none* will
+show all windows on all monitors.
+
 == AUTHOR
 
 Robert Nation +

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -295,6 +295,7 @@ void initialise_common_pager_fragments(void);
 void initialize_pager(void);
 void initialize_fpmonitor_windows(struct fpmonitor *);
 void initialize_viz_pager(void);
+void set_desk_size(bool);
 Pixel GetColor(char *name);
 void DispatchEvent(XEvent *Event);
 void ReConfigure(void);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -73,7 +73,6 @@ static struct fpmonitor *fpmonitor_from_xy(int x, int y);
 static struct fpmonitor *fpmonitor_from_n(int n);
 static struct fpmonitor *fpmonitor_from_desk(int desk);
 static int fpmonitor_count(void);
-static void set_desk_size(bool);
 static void fvwmrec_to_pager(rectangle *, bool, struct fpmonitor *);
 static void pagerrec_to_fvwm(rectangle *, bool, struct fpmonitor *);
 static char *GetBalloonLabel(const PagerWindow *pw,const char *fmt);


### PR DESCRIPTION
This makes FvwmPager listen to 'SendToModule' commands such that the
following options can be configured on a running FvwmPager instance:
    
* DeskLabels
* NoDeskLabels
* Monitor RANDRNAME
* MonitorLabels
* NoMonitorLabels
    
For example:
    
   SendToModule FvwmPager Monitor $[monitor.1.name]
    
Will force an already-running FvwmPager instance to only track that monitor.