### PR TITLE
shared mode: fix internal commands

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2093,7 +2093,7 @@ static void _move_window(F_CMD_ARGS, Bool do_animate, int mode)
 		}
 		/* It's possible that we've received a command such as:
 		 *
-		 * MoveToPage HDMI2 0 1
+		 * MoveToPage screen HDMI2 0 1
 		 *
 		 * In which case, move the window to the selected monitor,
 		 * first.

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -78,7 +78,7 @@
 		char	*cmd;						    \
 		xasprintf(&cmd,						    \
 		    "All (!Screen %s, Desk %d, CurrentPage, !CirculateHit) "\
-		    "MoveToPage %s $[w.pagex] $[w.pagey]",		    \
+		    "MoveToPage screen %s $[w.pagex] $[w.pagey]",	    \
 		    (m)->si->name, (d), (m)->si->name);			    \
 		execute_function_override_window(			    \
 			NULL, NULL, cmd, NULL, 0, NULL);		    \
@@ -626,7 +626,7 @@ static void MapDesk(struct monitor *m, int desk, Bool grab)
 					    m->virtual_scr.CurrentDesk);
 
 					xasprintf(&cmd,
-					    "MoveToPage %s $[w.pagex] $[w.pagey]",
+					    "MoveToPage screen %s $[w.pagex] $[w.pagey]",
 					    m->si->name);
 
 					/* execute_function_override_window()
@@ -2764,7 +2764,7 @@ void CMD_MoveToDesk(F_CMD_ARGS)
 		RB_FOREACH(m, monitors, &monitor_q) {
 			if (m->virtual_scr.CurrentDesk == desk) {
 				xasprintf(&cmd,
-				    "MoveToPage %s $[w.pagex] $[w.pagey]",
+				    "MoveToPage screen %s $[w.pagex] $[w.pagey]",
 				    m->si->name);
 				execute_function_override_window(
 					NULL, NULL, cmd, NULL, 0, fw);


### PR DESCRIPTION
Since `DesktopConfiguration shared` uses internal fvwm commands, these
need updating to make use of changed syntax.
