### PR TITLE
Remove single screen support, -s.

### DIFF
--- a/dev-docs/COMMANDS
+++ b/dev-docs/COMMANDS
@@ -117,7 +117,6 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   PrintInfo             - Print information about the state of fvwm
   PropertyChange        - Internal, used for inter-module communication
   Quit                  - Exit fvwm
-  QuitScreen            - Stop managing the specified screen
   QuitSession           - Ask session manager to shut down itself and fvwm
   Raise                 - Raise a window in a layer
   RaiseLower            - Alternately raise or lower a window in a layer

--- a/dev-docs/PARSING.md
+++ b/dev-docs/PARSING.md
@@ -1252,9 +1252,6 @@ PRINTINFOKEYWORD =/ "Infostore"
 CMD_QUIT = "Quit"
 ```
 ```
-CMD_QUITSCREEN = "QuitScreen"
-```
-```
 CMD_READ = "Read" FILENAME ["quiet"]
 ```
 ```

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -5,7 +5,6 @@
 [*-d* _displayname_]
 [*-f* _config-file_]
 [*-o* _logfile_]
-[*-s* [_screen_num_]]
 [*-v*]
 [other options]
 
@@ -90,14 +89,6 @@ the other wm is ICCCM2 2.0 compliant.
 
 This option is used when fvwm is started by a session manager. Should
 not be used by a user.
-
-*-s* | *--single-screen* [_screen_num_]::
-
-On a multi-screen display, run fvwm only on the screen named in the
-_$DISPLAY_ environment variable or provided through the *-d* option. The
-optional argument _screen_num_ should be positive or null and override
-the screen number. Normally, fvwm attempts to start up on all screens of
-a multi-screen display.
 
 *-V* | *--version*::
 
@@ -395,27 +386,17 @@ or
 XTerm*Page: 3 2 1
 ....
 
-== USE ON MULTI-SCREEN DISPLAYS
+== RANDR MULTI-SCREEN SUPPORT
 
-If the *-s* command line argument is not given, fvwm automatically
-starts up on every screen on the specified display. After fvwm starts
-each screen is treated independently. Restarts of fvwm need to be
-performed separately on each screen. The use of
+Fvwm best supports multiple screens using the RandR X11 protocol. If
+fvwm isn't built with the RandR protocol then the multi screen support
+is very limited, and it is suggested to rebuild with RandR. It is also
+recommended to use 'EdgeScroll 0 0' on multi-screen displays to avoid
+changing pages when moving the mouse between screens.
 
-....
-EdgeScroll 0 0
-....
-
-is strongly recommended for multi-screen displays. You may need to quit
-on each screen to quit from the X session completely. This is not to be
-confused with RandR support.
-
-== RANDR SUPPORT
-
-Fvwm supports the RandR X11 protocol. If Fvwm has been compiled with
-RandR support then it tracks the outputs (displays) which it finds.
-These outputs are stored by name, which can be found by running using
-the xrand(1) command.
+If Fvwm has been compiled with RandR support then it tracks the outputs
+(displays) which it finds. These outputs are stored by name, which can be
+found by running using the xrandr(1) command.
 
 When Fvwm detects monitors, it adds them to a tree with a defined order, and
 each monitor is assigned a number.  That order is top-down, left-to-right, so
@@ -455,7 +436,7 @@ AddToFunc   RandRFunc
 Because Fvwm has the capability to track outputs, Fvwm can be told how
 to handle those. This is controlled via the *DesktopConfiguration*
 command. By default, Fvwm treats all outputs it finds as one large
-screen, although Fvwm can be told to treat screens indepedantly of each
+screen, although Fvwm can be told to treat screens independently of each
 other.
 
 == INITIALIZATION
@@ -1260,25 +1241,6 @@ menus. If you change any of these resources during a session (e.g. by
 issuing *Style* commands or by using various modules), these changes are
 lost after saving and restarting the session. To become permanent, such
 changes have to be added to the configuration file.
-
-Note further that the current implementation has the following anomaly
-when used on a multi-screen display: Starting fvwm for the first time,
-fvwm manages all screens by forking a copy of itself for each screen.
-Every copy knows its parent and issuing a *Quit* command to any instance
-of fvwm kills the master and thus all copies of fvwm. When you save and
-restart the session, the session manager brings up a copy of fvwm on
-each screen, but this time they are started as individual instances
-managing one screen only. Thus a *Quit* kills only the copy it was sent
-to. This is probably not a very serious problem, since with session
-management, you are supposed to quit a session through the session
-manager anyway. If it is really needed,
-
-....
-Exec exec killall fvwm
-....
-
-still kills all copies of fvwm. Your system must have the *killall*
-command though.
 
 == BOOLEAN ARGUMENTS
 
@@ -2453,7 +2415,6 @@ AddToMenu Quit-Verify
  + "Really Quit Fvwm?" Title
  + "Yes, Really Quit"  Quit
  + "Restart Fvwm"      Restart
- + "Restart Fvwm 1.xx" Restart fvwm1 -s
  + ""                  Nop
  + "No, Don't Quit"    Nop
 
@@ -4418,11 +4379,11 @@ AddToFunc SelectWindow
 	reversed. This command works also with windows that are not managed by
 	fvwm. In this case fvwm does not bring the window onto the screen if
 	it is not visible. For example it is possible to warp the pointer to
-	the center of the root window on screen 1:
+	the center of the root window:
 +
 
 ....
-WindowId root 1 WarpToWindow 50 50
+WindowId root WarpToWindow 50 50
 ....
 
 
@@ -8366,16 +8327,14 @@ This command implies the conditions _CirculateHit_,
 _CirculateHitIcon_ and _CirculateHitShaded_. They can be turned off
 by specifying "!CirculateHit" etc. explicitly.
 +
-*WindowId* [_id_] [(_conditions_)] | [root [_screen_]] _command_:::
+*WindowId* [_id_] [(_conditions_)] | [root] _command_:::
 	The *WindowId* command looks for a specific window _id_ and runs the
 	specified _command_ on it. The second form of syntax retrieves the
-	window id of the root window of the given _screen_. If no _screen_
-	is given, the current screen is assumed. The window indicated by
-	_id_ may belong to a window not managed by fvwm or even a window on
-	a different screen. Although most commands can not operate on such
-	windows, there are some exceptions, for example the *WarpToWindow*
-	command. Returns -1 if no window with the given id exists. See
-	*Conditions* section for a list of conditions.
+	window id of the root window. The window indicated by
+	_id_ may belong to a window not managed by fvwm. Although most
+	commands can not operate on such windows, there are some exceptions,
+	for example the *WarpToWindow* command. Returns -1 if no window with
+	the given id exists. See *Conditions* section for a list of conditions.
 +
 This command implies the conditions _CirculateHit_,
 _CirculateHitIcon_ and _CirculateHitShaded_. They can be turned off
@@ -8832,10 +8791,6 @@ sequence
 *Quit*::
 	Exits fvwm, generally causing X to exit too.
 
-*QuitScreen*::
-	Causes fvwm to stop managing the screen on which the command was
-	issued.
-
 *Restart* [_window_manager_ [_params_]]::
 	Causes fvwm to restart itself if _window_manager_ is left blank, or to
 	switch to an alternate window manager (or other fvwm version) if
@@ -8851,9 +8806,8 @@ variables _$VAR_ or _$\{VAR}_. Here are several examples:
 
 ....
 Key F1 R N Restart
-Key F1 R N Restart fvwm -s
-Key F1 R N Restart fvwm1 -s -f .fvwmrc
-Key F1 R N Restart xterm -n '"X console"' -T \"X\ console\" -e fvwm -s
+Key F1 R N Restart fvwm1 -f .fvwmrc
+Key F1 R N Restart xterm -n '"X console"' -T \"X\ console\" -e fvwm
 ....
 
 +

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -547,7 +547,6 @@ static void adjust_fvwm_internal_windows(FvwmWindow *fw)
 	{
 		Scr.Hilite = NULL;
 	}
-	update_last_screen_focus_window(fw);
 	restore_focus_after_unmap(fw, False);
 	frame_destroyed_frame(FW_W(fw));
 	if (fw == Scr.StolenFocusFvwmWin)

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2250,12 +2250,8 @@ void CMD_CursorMove(F_CMD_ARGS)
 		fvwm_debug(__func__, "CursorMove needs 2 arguments");
 		return;
 	}
-	if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
-			  &x, &y, &JunkX, &JunkY, &JunkMask) == False)
-	{
-		/* pointer is on a different screen */
-		return;
-	}
+	FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
+			  &x, &y, &JunkX, &JunkY, &JunkMask);
 
 	m = monitor_get_current();
 
@@ -3808,14 +3804,9 @@ static void _fake_event(F_CMD_ARGS, FakeEventType type)
 				 depth++)
 			{
 				w = child_w;
-				if (FQueryPointer(
+				FQueryPointer(
 						dpy, w, &root, &child_w,
-						&rx, &ry, &x, &y,
-						&JunkMask) == False)
-				{
-					/* pointer is on a different
-					 * screen - that's okay here */
-				}
+						&rx, &ry, &x, &y, &JunkMask);
 			}
 
 			if (type == FakeMouseEvent)
@@ -3900,14 +3891,9 @@ static void _fake_event(F_CMD_ARGS, FakeEventType type)
 			}
 
 			usleep(1000 * val);
-			if (FQueryPointer(
-					dpy, Scr.Root, &root, &JunkRoot,
-					&JunkX, &JunkY, &JunkX, &JunkY,
-					&mask) == False)
-			{
-				/* pointer is on a different screen -
-				 * that's okay here */
-			}
+			FQueryPointer(
+				dpy, Scr.Root, &root, &JunkRoot,
+				&JunkX, &JunkY, &JunkX, &JunkY, &mask);
 			break;
 		case 6:
 		case 7:

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2709,17 +2709,6 @@ void CMD_Wait(F_CMD_ARGS)
 
 void CMD_Quit(F_CMD_ARGS)
 {
-	if (master_pid != getpid())
-	{
-		kill(master_pid, SIGTERM);
-	}
-	Done(0,NULL);
-
-	return;
-}
-
-void CMD_QuitScreen(F_CMD_ARGS)
-{
 	Done(0,NULL);
 
 	return;

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -107,7 +107,6 @@ enum
 	F_PRINTINFO,
 	F_QUIT,
 	F_QUIT_SESSION,
-	F_QUIT_SCREEN,
 	F_READ,
 	F_REFRESH,
 	F_RESTART,
@@ -315,7 +314,6 @@ void CMD_Prev(F_CMD_ARGS);
 void CMD_PrintInfo(F_CMD_ARGS);
 void CMD_PropertyChange(F_CMD_ARGS);
 void CMD_Quit(F_CMD_ARGS);
-void CMD_QuitScreen(F_CMD_ARGS);
 void CMD_QuitSession(F_CMD_ARGS);
 void CMD_Raise(F_CMD_ARGS);
 void CMD_RaiseLower(F_CMD_ARGS);

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -1272,14 +1272,9 @@ static void direction_cmd(F_CMD_ARGS, Bool is_scan)
 	}
 	else
 	{
-		if (FQueryPointer(
+		FQueryPointer(
 			    dpy, Scr.Root, &JunkRoot, &JunkChild, &my_g.x,
-			    &my_g.y, &JunkX, &JunkY, &JunkMask) == False)
-		{
-			/* pointer is on a different screen */
-			my_g.x = 0;
-			my_g.y = 0;
-		}
+			    &my_g.y, &JunkX, &JunkY, &JunkMask);
 		my_g.width = 1;
 		my_g.height = 1;
 		my_cx = my_g.x;
@@ -2249,15 +2244,10 @@ void CMD_Test(F_CMD_ARGS)
 
 			if (!error)
 			{
-				if (FQueryPointer(
+				FQueryPointer(
 					dpy, Scr.Root, &JunkRoot, &win,
-					&JunkX, &JunkY,	&x, &y, &JunkMask)
- 					== False)
-				{
-					/* pointer is on a different screen */
-					match = 0;
-				}
-				else if (is_pan_frame(win))
+					&JunkX, &JunkY,	&x, &y, &JunkMask);
+				if (is_pan_frame(win))
 				{
 					if (dir == DIR_NONE ||
 					    (dir == DIR_N &&

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -1703,7 +1703,6 @@ void CMD_WindowId(F_CMD_ARGS)
 {
 	FvwmWindow *t;
 	char *token;
-	char *naction;
 	unsigned long win;
 	Bool use_condition = False;
 	Bool use_screenroot = False;
@@ -1715,24 +1714,9 @@ void CMD_WindowId(F_CMD_ARGS)
 
 	if (token && StrEquals(token, "root"))
 	{
-		int screen = Scr.screen;
-
 		free(token);
-		token = PeekToken(action, &naction);
-		if (!token || GetIntegerArguments(token, NULL, &screen, 1) != 1)
-		{
-			screen = Scr.screen;
-		}
-		else
-		{
-			action = naction;
-		}
 		use_screenroot = True;
-		if (screen < 0 || screen >= Scr.NumberOfScreens)
-		{
-			screen = 0;
-		}
-		win = XRootWindow(dpy, screen);
+		win = XRootWindow(dpy, Scr.screen);
 		if (win == None)
 		{
 			if (cond_rc != NULL)

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1372,18 +1372,18 @@ static Bool _test_for_motion(int x0, int y0)
 	/* However, some special mouse (e.g., a touchpad with the
 	 * synaptic driver) may handle a double click in a special way
 	 * (for dragging through short touching and holding down the
-	 * finger on the touchpad). Bascially, when you execute a
+	 * finger on the touchpad). Basically, when you execute a
 	 * double click the first button release is queued after the
-	 * second _physical_ mouse release happen. It seems that
-	 * FQueryPointer may not work as expected: it does not see
-	 * that the button is released on a double click.  So, we need
-	 * to check for a button press in the future to avoid a fvwm
+	 * second _physical_ mouse release happen. So, we need to
+	 * check for a button press in the future to avoid a fvwm
 	 * lockup! (olicha 2004-01-31) */
 
-	for (x = x0, y = y0; FQueryPointer(
-		     dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX, &JunkY,
-		     &x, &y, &mask) == True; usleep(20000))
+	for (x = x0, y = y0; True; usleep(20000))
 	{
+		FQueryPointer(
+		     dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX, &JunkY,
+		     &x, &y, &mask);
+
 		if ((mask & DEFAULT_ALL_BUTTONS_MASK) == 0)
 		{
 			/* all buttons are released */
@@ -1408,7 +1408,7 @@ static Bool _test_for_motion(int x0, int y0)
 		}
 	}
 
-	/* pointer has moved off screen */
+	/* This won't happen */
 	return True;
 }
 
@@ -4591,17 +4591,16 @@ void CoerceEnterNotifyOnCurrentWindow(void)
 {
 	Window child;
 	Window root;
-	Bool f;
 	evh_args_t ea;
 	exec_context_changes_t ecc;
 	XEvent e;
 	FvwmWindow *fw;
 
-	f = FQueryPointer(
+	FQueryPointer(
 		dpy, Scr.Root, &root, &child, &e.xcrossing.x_root,
 		&e.xcrossing.y_root, &e.xcrossing.x, &e.xcrossing.y,
 		&JunkMask);
-	if (f == False || child == None)
+	if (child == None)
 	{
 		return;
 	}
@@ -4691,11 +4690,8 @@ void WaitForButtonsUp(Bool do_handle_expose)
 	int use_wait_cursor;
 	XEvent e;
 
-	if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX, &JunkY,
-			  &JunkX, &JunkY, &mask) == False)
-	{
-		/* pointer is on a different screen - that's okay here */
-	}
+	FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX, &JunkY,
+			  &JunkX, &JunkY, &mask);
 	mask &= DEFAULT_ALL_BUTTONS_MASK;
 	if (mask == 0)
 	{
@@ -4732,14 +4728,9 @@ void WaitForButtonsUp(Bool do_handle_expose)
 		}
 		else
 		{
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild,
-				    &JunkX, &JunkY, &JunkX, &JunkY, &mask) ==
-			    False)
-			{
-				/* pointer is on a different screen - that's
-				 * okay here */
-			}
+				    &JunkX, &JunkY, &JunkX, &JunkY, &mask);
 			mask &= DEFAULT_ALL_BUTTONS_MASK;
 			usleep(1);
 		}

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2257,28 +2257,7 @@ void HandleEnterNotify(const evh_args_t *ea)
 
 	if (ewp->window == Scr.Root)
 	{
-		FvwmWindow *lf = get_last_screen_focus_window();
-
-		if (!Scr.flags.is_pointer_on_this_screen)
-		{
-			Scr.flags.is_pointer_on_this_screen = 1;
-			if (lf && lf != &Scr.FvwmRoot &&
-			    !FP_DO_UNFOCUS_LEAVE(FW_FOCUS_POLICY(lf)))
-			{
-				SetFocusWindow(lf, True, FOCUS_SET_FORCE);
-			}
-			else if (lf != &Scr.FvwmRoot)
-			{
-				ForceDeleteFocus();
-			}
-			else
-			{
-				/* This was the first EnterNotify event for the
-				 * root window - ignore */
-			}
-			set_last_screen_focus_window(NULL);
-		}
-		else if (!(sf = get_focus_window()) ||
+		if (!(sf = get_focus_window()) ||
 			 FP_DO_UNFOCUS_LEAVE(FW_FOCUS_POLICY(sf)))
 		{
 			DeleteFocus(True);
@@ -2293,7 +2272,6 @@ void HandleEnterNotify(const evh_args_t *ea)
 		{
 			InstallWindowColormaps(NULL);
 		}
-		focus_grab_buttons(lf);
 
 		struct monitor *pfm, *this_m;
 		pfm = monitor_resolve_name(prev_focused_monitor);
@@ -2309,10 +2287,6 @@ void HandleEnterNotify(const evh_args_t *ea)
 		toggle_prev_monitor_state(this_m, pfm, NULL);
 
 		return;
-	}
-	else
-	{
-		Scr.flags.is_pointer_on_this_screen = 1;
 	}
 
 	/* An EnterEvent in one of the PanFrameWindows activates the Paging or
@@ -2372,7 +2346,6 @@ void HandleEnterNotify(const evh_args_t *ea)
 				m = fw->m;
 
 			/* this was in the HandleMotionNotify before, HEDU */
-			Scr.flags.is_pointer_on_this_screen = 1;
 			e = *te;
 			HandlePaging(
 				&e, edge_scroll, &junk, &delta,
@@ -2920,42 +2893,8 @@ void HandleLeaveNotify(const evh_args_t *ea)
 	}
 
 
-	/* If we leave the root window, then we're really moving
-	 * another screen on a multiple screen display, and we
-	 * need to de-focus and unhighlight to make sure that we
-	 * don't end up with more than one highlighted window at a time */
-	if (lwp->window == Scr.Root &&
-	   /* domivogt (16-May-2000): added this test because somehow fvwm
-	    * sometimes gets a LeaveNotify on the root window although it is
-	    * single screen. */
-	    Scr.NumberOfScreens > 1)
-	{
-		if (lwp->mode == NotifyNormal)
-		{
-			if (lwp->detail != NotifyInferior)
-			{
-				FvwmWindow *sf = get_focus_window();
-
-				Scr.flags.is_pointer_on_this_screen = 0;
-				set_last_screen_focus_window(sf);
-				if (sf != NULL)
-				{
-					DeleteFocus(True);
-				}
-				if (Scr.Hilite != NULL)
-				{
-					border_draw_decorations(
-						Scr.Hilite, PART_ALL, False,
-						True, CLEAR_ALL, NULL, NULL);
-				}
-			}
-		}
-	}
-	else
-	{
-		/* handle a subwindow cmap */
-		LeaveSubWindowColormap(te->xany.window);
-	}
+	/* handle a subwindow cmap */
+	LeaveSubWindowColormap(te->xany.window);
 	if (fw != NULL &&
 	    (lwp->window == FW_W_FRAME(fw) ||
 	     lwp->window == FW_W_ICON_TITLE(fw) ||

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -1164,12 +1164,8 @@ static signed int expand_vars_extended(
 		case VAR_POINTER_CX:
 			is_x = True;
 		}
-		if (FQueryPointer(dpy, context_w, &JunkRoot, &JunkChild,
-				  &JunkX, &JunkY, &x, &y, &JunkMask) == False)
-		{
-			/* pointer is on a different screen, don't expand */
-			return -1;
-		}
+		FQueryPointer(dpy, context_w, &JunkRoot, &JunkChild,
+				  &JunkX, &JunkY, &x, &y, &JunkMask);
 		val = (is_x) ? x : y;
 		break;
 	case VAR_POINTER_SCREEN:

--- a/fvwm/externs.h
+++ b/fvwm/externs.h
@@ -40,7 +40,6 @@ extern char NoClass[];
 extern char NoResource[];
 extern XGCValues Globalgcv;
 extern unsigned long Globalgcm;
-extern int master_pid;
 extern Display *dpy;
 extern int x_fd;
 extern XContext FvwmContext;

--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -1041,13 +1041,9 @@ void focus_grab_buttons_on_pointer_window(void)
 	Window w;
 	FvwmWindow *fw;
 
-	if (!FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &w, &JunkX, &JunkY, &JunkX,
-		    &JunkY, &JunkMask))
-	{
-		/* pointer is not on this screen */
-		return;
-	}
+		    &JunkY, &JunkMask);
 	if (XFindContext(dpy, w, FvwmContext, (caddr_t *) &fw) == XCNOENT)
 	{
 		/* pointer is not over a window */

--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -71,8 +71,6 @@ static Bool lastFocusType;
 /* Last window which Fvwm gave the focus to NOT the window that really has the
  * focus */
 static FvwmWindow *ScreenFocus = NULL;
-/* Window which had focus before the pointer moved to a different screen. */
-static FvwmWindow *LastScreenFocus = NULL;
 
 /* ---------------------------- exported variables (globals) --------------- */
 
@@ -253,27 +251,6 @@ static void _update_windowlist(
 	return;
 }
 
-static Bool _try_other_screen_focus(const FvwmWindow *fw)
-{
-	if (fw == NULL && !Scr.flags.is_pointer_on_this_screen)
-	{
-		FvwmWindow *sf;
-
-		sf = get_focus_window();
-		set_focus_window(NULL);
-		if (sf != NULL)
-		{
-			focus_grab_buttons(sf);
-		}
-		/* DV (25-Nov-2000): Don't give the Scr.NoFocusWin the focus
-		 * here. This would steal the focus from the other screen's
-		 * root window again. */
-		return True;
-	}
-
-	return False;
-}
-
 /*
  * Sets the input focus to the indicated window.
  */
@@ -293,10 +270,6 @@ static void _set_focus_to_fwin(
 		return;
 	}
 	_update_windowlist(fw, args->set_by, args->is_focus_by_flip_focus_cmd);
-	if (_try_other_screen_focus(fw) == True)
-	{
-		return;
-	}
 
 	if (fw && !args->do_forbid_warp)
 	{
@@ -1085,7 +1058,7 @@ void focus_grab_buttons_on_pointer_window(void)
 	return;
 }
 
-/* functions to access ScreenFocus, LastScreenFocus and PreviousFocus */
+/* functions to access ScreenFocus and PreviousFocus */
 FvwmWindow *get_focus_window(void)
 {
 	return ScreenFocus;
@@ -1094,28 +1067,6 @@ FvwmWindow *get_focus_window(void)
 void set_focus_window(FvwmWindow *fw)
 {
 	ScreenFocus = fw;
-
-	return;
-}
-
-FvwmWindow *get_last_screen_focus_window(void)
-{
-	return LastScreenFocus;
-}
-
-void set_last_screen_focus_window(FvwmWindow *fw)
-{
-	LastScreenFocus = fw;
-
-	return;
-}
-
-void update_last_screen_focus_window(FvwmWindow *fw)
-{
-	if (fw == LastScreenFocus)
-	{
-		LastScreenFocus = NULL;
-	}
 
 	return;
 }

--- a/fvwm/focus.h
+++ b/fvwm/focus.h
@@ -71,9 +71,6 @@ FvwmWindow *focus_get_transientfor_fwin(const FvwmWindow *fw);
 
 FvwmWindow *get_focus_window(void);
 void set_focus_window(FvwmWindow *fw);
-FvwmWindow *get_last_screen_focus_window(void);
-void set_last_screen_focus_window(FvwmWindow *fw);
-void update_last_screen_focus_window(FvwmWindow *fw);
 void set_focus_model(FvwmWindow *fw);
 void focus_force_refresh_focus(const FvwmWindow *fw);
 void refresh_focus(const FvwmWindow *fw);

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -438,9 +438,6 @@ const func_t func_table[] =
 	CMD_ENT("quit", CMD_Quit, F_QUIT, 0, 0),
 	/* - Exit fvwm */
 
-	CMD_ENT("quitscreen", CMD_QuitScreen, F_QUIT_SCREEN, 0, 0),
-	/* - Stop managing the specified screen */
-
 	CMD_ENT("quitsession", CMD_QuitSession, F_QUIT_SESSION, 0, 0),
 	/* - Ask session manager to shut down itself and fvwm */
 

--- a/fvwm/functions.c
+++ b/fvwm/functions.c
@@ -1120,14 +1120,9 @@ static void execute_complex_function(
 		FCheckMaskEvent(dpy, ButtonPressMask, &d);
 		break;
 	default:
-		if (FQueryPointer(
+		FQueryPointer(
 			    dpy, Scr.Root, &JunkRoot, &JunkChild, &x, &y,
-			    &JunkX, &JunkY, &JunkMask) == False)
-		{
-			/* pointer is on a different screen */
-			x = 0;
-			y = 0;
-		}
+			    &JunkX, &JunkY, &JunkMask);
 		button = 0;
 		break;
 	}

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -133,8 +133,6 @@ static const char *init_function_names[4] =
 
 /* ---------------------------- exported variables (globals) --------------- */
 
-int master_pid;                 /* process number of 1st fvwm process */
-
 ScreenInfo Scr;                 /* structures for the screen */
 Display *dpy = NULL;            /* which display are we talking to */
 
@@ -490,33 +488,6 @@ static int parse_command_args(
 	}
 
 	return error_code ? error_code : argc;
-}
-
-/*
- *
- */
-static
-char *get_display_name(char *disp_name, int screen_num)
-{
-	char *msg;
-	char *new_dn;
-	char *cp;
-
-	CopyString(&msg, disp_name);
-	cp = strchr(msg, ':');
-	if (cp != NULL)
-	{
-		cp = strchr(cp, '.');
-		if (cp != NULL)
-		{
-			/* truncate at display part */
-			*cp = '\0';
-		}
-	}
-	xasprintf(&new_dn, "%s.%d", msg, screen_num);
-	free(msg);
-
-	return new_dn;
 }
 
 /*
@@ -1175,10 +1146,6 @@ static void InitVariables(void)
 	/* Not the right place for this, should only be called once
 	 * somewhere .. */
 
-	Scr.flags.is_pointer_on_this_screen = !!FQueryPointer(
-		dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX, &JunkY, &JunkX,
-		&JunkY, &JunkMask);
-
 	/* make sure colorset 0 exists */
 	alloc_colorset(0);
 
@@ -1192,7 +1159,6 @@ static void usage(int is_verbose)
 		   " [-d display]"
 		   " [-f cfgfile]"
 		   " [-c cmd]"
-		   " [-s [screen_num]]"
 		   " [-I vis-id | -C vis-class]"
 		   " [-l colors"
 		   " [-L|A|S|P] ...]"
@@ -1222,7 +1188,6 @@ static void usage(int is_verbose)
                    " -o logfile:   output file or '-' for stderr\n"
 		   " -P:           visual palette\n"
 		   " -r:           replace running window manager\n"
-		   " -s [screen]:  manage a single screen\n"
 		   " -S:           static palette\n"
 		   " -v:           verbose log output\n"
 		   " -V:           print version information\n"
@@ -1704,8 +1669,6 @@ int main(int argc, char **argv)
 	XSetWindowAttributes attributes;
 	int i;
 	char *display_string;
-	Bool do_force_single_screen = False;
-	int single_screen_num = -1;
 	Bool replace_wm = False;
 	int visualClass = -1;
 	int visualId = -1;
@@ -1810,22 +1773,6 @@ int main(int argc, char **argv)
 				exit(1);
 			}
 			state_filename = argv[i];
-		}
-		else if (strcmp(argv[i], "-s") == 0 ||
-			 strcmp(argv[i], "-single-screen") == 0 ||
-			 strcmp(argv[i], "--single-screen") == 0)
-		{
-			do_force_single_screen = True;
-			if (i+1 < argc && argv[i+1][0] != '-')
-			{
-				i++;
-				if (sscanf(argv[i], "%d", &single_screen_num) ==
-				    0)
-				{
-					usage(0);
-					exit(1);
-				}
-			}
 		}
 		else if (strcmp(argv[i], "-d") == 0 ||
 			 strcmp(argv[i], "-display") == 0 ||
@@ -2043,106 +1990,15 @@ int main(int argc, char **argv)
 
 	InstallSignals();
 
-	if (single_screen_num >= 0)
+	if(!(Pdpy = dpy = XOpenDisplay(display_name)))
 	{
-		char *dn = NULL;
-
-		if (display_name)
-		{
-			dn = display_name;
-		}
-		if (!dn)
-		{
-			dn = getenv("DISPLAY");
-		}
-		if (!dn)
-		{
-			/* should never happen ? */
-			if (!(dpy = XOpenDisplay(dn)))
-			{
-				fvwm_debug(__func__, "can't open display %s"
-					   "to get the default display",
-					   XDisplayName(dn));
-			}
-			else
-			{
-				dn = XDisplayString(dpy);
-			}
-		}
-		if (dn == NULL)
-		{
-			fvwm_debug(__func__,
-				   "couldn't find default display (%s)",
-				   XDisplayName(dn));
-		}
-		else
-		{
-			char *new_dn;
-
-			new_dn = get_display_name(dn, single_screen_num);
-			if (dpy && strcmp(new_dn, dn) == 0)
-			{
-				/* allready opened */
-				Pdpy = dpy;
-			}
-			else if (dpy)
-			{
-				XCloseDisplay(dpy);
-				dpy = NULL;
-			}
-			if (!dpy && !(Pdpy = dpy = XOpenDisplay(new_dn)))
-			{
-				fvwm_debug(__func__,
-					   "can't open display %s, single screen "
-					   "number %d maybe not correct",
-					   new_dn, single_screen_num);
-			}
-			Scr.screen = single_screen_num;
-			Scr.NumberOfScreens = ScreenCount(dpy);
-			free(new_dn);
-		}
+		fvwm_debug(__func__, "can't open display %s",
+			   XDisplayName(display_name));
+		exit (1);
 	}
-
-	if (!dpy)
-	{
-		if(!(Pdpy = dpy = XOpenDisplay(display_name)))
-		{
-			fvwm_debug(__func__, "can't open display %s",
-				   XDisplayName(display_name));
-			exit (1);
-		}
-		Scr.screen= DefaultScreen(dpy);
-		Scr.NumberOfScreens = ScreenCount(dpy);
-	}
+	Scr.screen= DefaultScreen(dpy);
 
 	atexit(catch_exit);
-	master_pid = getpid();
-
-	if (!do_force_single_screen)
-	{
-		int myscreen = 0;
-		char *new_dn;
-		char *dn;
-
-		dn = XDisplayString(dpy);
-		for (i=0;i<Scr.NumberOfScreens;i++)
-		{
-			if (i != Scr.screen && fork() == 0)
-			{
-				myscreen = i;
-				new_dn = get_display_name(dn, myscreen);
-				Pdpy = dpy = XOpenDisplay(new_dn);
-				Scr.screen = myscreen;
-				Scr.NumberOfScreens = ScreenCount(dpy);
-				free(new_dn);
-
-				break;
-			}
-		}
-
-		g_argv[argc++] = "-s";
-		g_argv[argc] = NULL;
-	}
 
 	monitor_mode = MONITOR_TRACKING_G;
 	FScreenInit(dpy);
@@ -2387,7 +2243,6 @@ int main(int argc, char **argv)
 			if (prop != NULL)
 			{
 				Restarting = True;
-				/* do_force_single_screen = True; */
 			}
 		}
 	}

--- a/fvwm/menubindings.c
+++ b/fvwm/menubindings.c
@@ -530,17 +530,10 @@ void menu_shortcuts(
 				&menu_height, &JunkBW, &JunkDepth))
 		{
 			is_geometry_known = 1;
-			if (
-				FQueryPointer(
+			FQueryPointer(
 					dpy, Scr.Root, &JunkRoot, &JunkChild,
-					&mx, &my, &JunkX, &JunkY, &JunkMask) ==
-				0)
-			{
-				/* pointer is on a different screen */
-				mx = 0;
-				my = 0;
-			}
-			else if (
+					&mx, &my, &JunkX, &JunkY, &JunkMask);
+			if (
 				mx >= menu_x && mx < menu_x + menu_width &&
 				my >= menu_y && my < menu_y + menu_height)
 			{
@@ -1024,16 +1017,9 @@ void menu_shortcuts(
 			pmret->rc = MENU_NEWITEM;
 			/* Have to work with relative positions or tear off
 			 * menus will be hard to reposition */
-			if (
-				FQueryPointer(
-					dpy, MR_WINDOW(mr), &JunkRoot,
-					&JunkChild, &JunkX, &JunkY, &mx, &my,
-					&JunkMask) ==  0)
-			{
-				/* This should not happen */
-			    	mx = 0;
-				my = 0;
-			}
+			FQueryPointer(
+				dpy, MR_WINDOW(mr), &JunkRoot,
+				&JunkChild, &JunkX, &JunkY, &mx, &my, &JunkMask);
 
 			if (MST_MOUSE_WHEEL(mr) == MMW_POINTER)
 			{

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -573,13 +573,9 @@ static MenuItem *find_entry(
 	/* get the pointer position */
 	if (p_rx < 0)
 	{
-		if (!FQueryPointer(
+		FQueryPointer(
 			    dpy, Scr.Root, &JunkRoot, &Child,
-			    &root_x, &root_y, &JunkX, &JunkY, &JunkMask))
-		{
-			/* pointer is on a different screen */
-			return NULL;
-		}
+			    &root_x, &root_y, &JunkX, &JunkY, &JunkMask);
 	}
 	else
 	{
@@ -2951,16 +2947,12 @@ static int pop_menu_up(
 			{
 				/* use current cx/cy */
 			}
-			else if (FQueryPointer(
-					 dpy, Scr.Root, &JunkRoot, &JunkChild,
-					 &cx, &cy, &JunkX, &JunkY, &JunkMask))
-			{
-				/* use pointer's position */
-			}
 			else
 			{
-				cx = -1;
-				cy = -1;
+				/* use pointer's position */
+				FQueryPointer(
+					 dpy, Scr.Root, &JunkRoot, &JunkChild,
+					 &cx, &cy, &JunkX, &JunkY, &JunkMask);
 			}
 			pops->pos_hints.screen_origin_x = cx;
 			pops->pos_hints.screen_origin_y = cy;
@@ -3553,14 +3545,9 @@ static void _mloop_init(
 	pmret->rc = MENU_NOP;
 	memset(pops, 0, sizeof(*pops));
 	/* remember where the pointer was so we can tell if it has moved */
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &JunkChild, &(msi->x_init),
-		    &(msi->y_init), &JunkX, &JunkY, &JunkMask) == False)
-	{
-		/* pointer is on a different screen */
-		msi->x_init = 0;
-		msi->y_init = 0;
-	}
+		    &(msi->y_init), &JunkX, &JunkY, &JunkMask);
 	/* get the event mask right */
 	msi->event_mask = (pmp->tear_off_root_menu_window == NULL) ?
 		XEVMASK_MENU : XEVMASK_TEAR_OFF_MENU;
@@ -3703,15 +3690,10 @@ static mloop_ret_code_t _mloop_get_event(
 		{
 			/* since the pointer has been warped since the key was
 			 * pressed, fake a different key press position */
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild,
 				    &e.xkey.x_root, &e.xkey.y_root,
-				    &JunkX, &JunkY, &e.xkey.state) == False)
-			{
-				/* pointer is on a different screen */
-				e.xkey.x_root = 0;
-				e.xkey.y_root = 0;
-			}
+				    &JunkX, &JunkY, &e.xkey.state);
 			fev_fake_event(&e);
 			med->mi = MR_SELECTED_ITEM(pmp->menu);
 		}
@@ -4109,14 +4091,9 @@ static mloop_ret_code_t _mloop_handle_event(
 
 		if (in->mif.has_mouse_moved == False)
 		{
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &p_child, &p_rx,
-				    &p_ry, &JunkX, &JunkY, &JunkMask) == False)
-			{
-				/* pointer is on a different screen */
-				p_rx = 0;
-				p_ry = 0;
-			}
+				    &p_ry, &JunkX, &JunkY, &JunkMask);
 			if (p_rx - msi->x_init > Scr.MoveThreshold ||
 			    msi->x_init - p_rx > Scr.MoveThreshold ||
 			    p_ry - msi->y_init > Scr.MoveThreshold ||
@@ -4827,13 +4804,8 @@ static mloop_ret_code_t _mloop_handle_action_without_mi(
 		int x, y, mx, my;
 		int mw, mh;
 
-		if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
-				  &x, &y, &JunkX, &JunkY, &JunkMask) == False)
-		{
-			/* pointer is on a different screen */
-			x = 0;
-			y = 0;
-		}
+		FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
+				  &x, &y, &JunkX, &JunkY, &JunkMask);
 		if (menu_get_geometry(
 			    pmp->menu, &JunkRoot, &mx, &my, &mw, &mh, &JunkBW,
 			    &JunkDepth) &&
@@ -5547,13 +5519,8 @@ void do_menu(MenuParameters *pmp, MenuReturn *pmret)
 
 	/* Try to pick a root-relative optimal x,y to
 	 * put the mouse right on the title w/o warping */
-	if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
-			  &x, &y, &JunkX, &JunkY, &JunkMask) == False)
-	{
-		/* pointer is on a different screen */
-		x = 0;
-		y = 0;
-	}
+	FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
+			  &x, &y, &JunkX, &JunkY, &JunkMask);
 	/* Save these - we want to warp back here if this is a top level
 	 * menu brought up by a keystroke */
 	if (!pmp->flags.is_submenu)
@@ -7065,15 +7032,9 @@ char *get_menu_options(
 				  &JunkChild)))
 		{
 			/* no window or could not get geometry */
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy,Scr.Root, &JunkRoot, &JunkChild, &x,
-				    &y, &JunkX, &JunkY, &JunkMask) == False)
-			{
-				/* pointer is on a different screen - that's
-				 * okay here */
-				x = 0;
-				y = 0;
-			}
+				    &y, &JunkX, &JunkY, &JunkMask);
 			width = height = 1;
 			if (!pops->pos_hints.has_screen_origin)
 			{

--- a/fvwm/misc.c
+++ b/fvwm/misc.c
@@ -449,13 +449,9 @@ FvwmWindow *get_pointer_fvwm_window(void)
 	Window ancestor;
 	FvwmWindow *t;
 
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &win, &JunkX, &JunkY,
-		    &x, &y, &JunkMask) == False)
-	{
-		/* pointer is on a different screen */
-		return NULL;
-	}
+		    &x, &y, &JunkMask);
 	for (t = NULL ; win != Scr.Root && win != None; win = ancestor)
 	{
 		Window root = None;

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -707,21 +707,10 @@ void module_input_execute(struct fmodule_input *input)
 	 * This is OK now that the Pager uses "Move pointer"
 	 * A real fix would be for the modules to pass the button press coords
 	 */
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX,&JunkY,
-		    &e.xbutton.x_root, &e.xbutton.y_root, &e.xbutton.state) ==
-	    False)
-	{
-		/* pointer is not on this screen */
-		/* If a module does XUngrabPointer(), it can now get proper
-		 * Popups */
-		e.xbutton.window = Scr.Root;
-		ecc.w.fw = NULL;
-	}
-	else
-	{
-		e.xbutton.window = input->window;
-	}
+		    &e.xbutton.x_root, &e.xbutton.y_root, &e.xbutton.state);
+	e.xbutton.window = input->window;
 	e.xbutton.subwindow = None;
 	e.xbutton.button = 1;
 	/* If a module does XUngrabPointer(), it can now get proper Popups */

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -581,22 +581,13 @@ static int GetOnePositionArgument(
 	case 'm':
 	case 'M':
 	{
-	        int x;
+		int x;
 		int y;
 
-		if (
-			FQueryPointer(
+		FQueryPointer(
 			    dpy, Scr.Root, &JunkRoot, &JunkChild, &JunkX,
-			    &JunkY, &x, &y, &JunkMask) == False)
-		{
-			/* pointer is on a different screen - that's okay here
-			 */
-			final_pos = 0;
-		}
-		else
-		{
-			final_pos = (is_x) ? x : y;
-		}
+			    &JunkY, &x, &y, &JunkMask);
+		final_pos = (is_x) ? x : y;
 		s1++;
 		break;
 	}
@@ -1528,14 +1519,9 @@ static void InteractiveMove(
 
 	if (do_start_at_pointer)
 	{
-		if (FQueryPointer(
+		FQueryPointer(
 			    dpy, Scr.Root, &JunkRoot, &JunkChild, &drag.x,
-			    &drag.y, &JunkX, &JunkY, &JunkMask) == False)
-		{
-			/* pointer is on a different screen */
-			drag.x = 0;
-			drag.y = 0;
-		}
+			    &drag.y, &JunkX, &JunkY, &JunkMask);
 	}
 	else
 	{
@@ -1746,19 +1732,12 @@ static void AnimatedMoveAnyWindow(
 		}
 		if (fWarpPointerToo == True)
 		{
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild,
 				    &JunkX, &JunkY, &pointer.x, &pointer.y,
-				    &JunkMask) == False)
-			{
-				/* pointer is on a different screen */
-				pointer = current;
-			}
-			else
-			{
-				pointer.x += current.x - last.x;
-				pointer.y += current.y - last.y;
-			}
+				    &JunkMask);
+			pointer.x += current.x - last.x;
+			pointer.y += current.y - last.y;
 			FWarpPointer(
 				dpy, None, Scr.Root, 0, 0, 0, 0, pointer.x,
 				pointer.y);
@@ -2694,19 +2673,11 @@ Bool move_loop(
 	/* prevent flicker when paging */
 	SET_WINDOW_BEING_MOVED_OPAQUE(fw, do_move_opaque);
 
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &JunkChild, &p.x, &p.y,
-		    &JunkX, &JunkY, &button_mask) == False)
-	{
-		/* pointer is on a different screen */
-		p.x = 0;
-		p.y = 0;
-	}
-	else
-	{
-		p.x += offset.x;
-		p.y += offset.y;
-	}
+		    &JunkX, &JunkY, &button_mask);
+	p.x += offset.x;
+	p.y += offset.y;
 	button_mask &= DEFAULT_ALL_BUTTONS_MASK;
 	orig = p;
 
@@ -2783,19 +2754,11 @@ Bool move_loop(
 			fev_make_null_event(&e, dpy);
 			e.type = MotionNotify;
 			e.xmotion.time = fev_get_evtime();
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild, &p2.x,
-				    &p2.y, &JunkX, &JunkY, &JunkMask) == True)
-			{
-				e.xmotion.x_root = p2.x;
-				e.xmotion.y_root = p2.y;
-			}
-			else
-			{
-				/* pointer is on a different screen */
-				e.xmotion.x_root = 0;
-				e.xmotion.y_root = 0;
-			}
+				    &p2.y, &JunkX, &JunkY, &JunkMask);
+			e.xmotion.x_root = p2.x;
+			e.xmotion.y_root = p2.y;
 			e.xmotion.state = JunkMask;
 			e.xmotion.same_screen = True;
 			break;
@@ -2842,25 +2805,18 @@ Bool move_loop(
 
 			/* Query the pointer to catch the latest information.
 			 * This *is* necessary. */
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild, &x,
-				    &y, &JunkX, &JunkY, &JunkMask) == True)
-			{
-				fev_make_null_event(&e2, dpy);
-				e2.type = MotionNotify;
-				e2.xmotion.time = fev_get_evtime();
-				e2.xmotion.x_root = x;
-				e2.xmotion.y_root = y;
-				e2.xmotion.state = JunkMask;
-				e2.xmotion.same_screen = True;
-				e = e2;
-				fev_fake_event(&e);
-			}
-			else
-			{
-				/* pointer is on a different screen,
-				 * ignore event */
-			}
+				    &y, &JunkX, &JunkY, &JunkMask);
+			fev_make_null_event(&e2, dpy);
+			e2.type = MotionNotify;
+			e2.xmotion.time = fev_get_evtime();
+			e2.xmotion.x_root = x;
+			e2.xmotion.y_root = y;
+			e2.xmotion.state = JunkMask;
+			e2.xmotion.same_screen = True;
+			e = e2;
+			fev_fake_event(&e);
 		}
 		is_fake_event = False;
 		/* Handle a limited number of key press events to allow
@@ -4380,14 +4336,9 @@ static Bool _resize_window(F_CMD_ARGS)
 	{
 		position toff = { 0, 0 };
 
-		if (FQueryPointer(
+		FQueryPointer(
 			    dpy, Scr.Root, &JunkRoot, &JunkChild, &stashed.x,
-			    &stashed.y, &JunkX, &JunkY, &JunkMask) == False)
-		{
-			/* pointer is on a different screen */
-			stashed.x = 0;
-			stashed.y = 0;
-		}
+			    &stashed.y, &JunkX, &JunkY, &JunkMask);
 		_resize_step(
 			exc, stashed, &toff, drag, orig,
 			&motion, do_resize_opaque, True);
@@ -4462,27 +4413,19 @@ static Bool _resize_window(F_CMD_ARGS)
 
 			/* Query the pointer to catch the latest information.
 			 * This *is* necessary. */
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild, &x,
-				    &y, &JunkX, &JunkY, &JunkMask) == True)
-			{
-				/* Must NOT use button_mask here, or resize
-				 * will not work with num lock */
-				fev_make_null_event(&e2, dpy);
-				e2.type = MotionNotify;
-				e2.xmotion.time = fev_get_evtime();
-				e2.xmotion.x_root = x;
-				e2.xmotion.y_root = y;
-				e2.xmotion.state = JunkMask;
-				e2.xmotion.same_screen = True;
-				ev = e2;
-				fev_fake_event(&ev);
-			}
-			else
-			{
-				/* pointer is on a different screen,
-				 * ignore event */
-			}
+				    &y, &JunkX, &JunkY, &JunkMask);
+			
+			fev_make_null_event(&e2, dpy);
+			e2.type = MotionNotify;
+			e2.xmotion.time = fev_get_evtime();
+			e2.xmotion.x_root = x;
+			e2.xmotion.y_root = y;
+			e2.xmotion.state = JunkMask;
+			e2.xmotion.same_screen = True;
+			ev = e2;
+			fev_fake_event(&ev);
 		}
 
 		is_done = False;

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -301,8 +301,6 @@ typedef struct ScreenInfo
 {
 	unsigned long screen;
 	Screen *pscreen;
-	/* number of screens on display */
-	int NumberOfScreens;
 	/* the head of the fvwm window list */
 	FvwmWindow FvwmRoot;
 	/* the root window */
@@ -470,8 +468,6 @@ typedef struct ScreenInfo
 		unsigned is_executing_complex_function : 1;
 		unsigned is_executing_menu_function : 1;
 		unsigned is_map_desk_in_progress : 1;
-		unsigned is_pointer_on_this_screen : 1;
-		unsigned is_single_screen : 1;
 		unsigned is_window_scheduled_for_destroy : 1;
 		unsigned is_wire_frame_displayed : 1;
 	} flags;

--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -1054,10 +1054,6 @@ callback_die(FSmcConn sm_conn, FSmPointer client_data)
 	}
 	sm_fd = -1;
 
-	if (master_pid != getpid())
-	{
-		kill(master_pid, SIGTERM);
-	}
 	Done(0, NULL);
 }
 

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -149,15 +149,9 @@ static void _drag_viewport(const exec_context_t *exc, int scroll_speed)
 		return;
 	}
 
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &JunkChild, &x, &y,
-		    &JunkX, &JunkY, &button_mask) == False)
-	{
-		/* pointer is on a different screen */
-		/* Is this the best thing to do? */
-		UngrabEm(GRAB_NORMAL);
-		return;
-	}
+		    &JunkX, &JunkY, &button_mask);
 	MyXGrabKeyboard(dpy);
 	button_mask &= DEFAULT_ALL_BUTTONS_MASK;
 	memset(&e, 0, sizeof(e));
@@ -200,25 +194,18 @@ static void _drag_viewport(const exec_context_t *exc, int scroll_speed)
 
 			/* Query the pointer to catch the latest information.
 			 * This *is* necessary. */
-			if (FQueryPointer(
+			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild, &px,
-				    &py, &JunkX, &JunkY, &JunkMask) == True)
-			{
-				fev_make_null_event(&e2, dpy);
-				e2.type = MotionNotify;
-				e2.xmotion.time = fev_get_evtime();
-				e2.xmotion.x_root = px;
-				e2.xmotion.y_root = py;
-				e2.xmotion.state = JunkMask;
-				e2.xmotion.same_screen = True;
-				e = e2;
-				fev_fake_event(&e);
-			}
-			else
-			{
-				/* pointer is on a different screen,
-				 * ignore event */
-			}
+				    &py, &JunkX, &JunkY, &JunkMask);
+			fev_make_null_event(&e2, dpy);
+			e2.type = MotionNotify;
+			e2.xmotion.time = fev_get_evtime();
+			e2.xmotion.x_root = px;
+			e2.xmotion.y_root = py;
+			e2.xmotion.state = JunkMask;
+			e2.xmotion.same_screen = True;
+			e = e2;
+			fev_fake_event(&e);
 		}
 		/* Handle a limited number of key press events to allow
 		 * mouseless operation */
@@ -786,7 +773,6 @@ int HandlePaging(
 
 	do
 	{
-		int rc;
 		Window JunkW;
 		int JunkC;
 		unsigned int JunkM;
@@ -798,31 +784,10 @@ int HandlePaging(
 			return 0;
 		}
 		/* get pointer location */
-		rc = FQueryPointer(
+		FQueryPointer(
 			dpy, Scr.Root, &JunkW, &JunkW, &x, &y, &JunkC, &JunkC,
 			&JunkM);
-		if (rc == False)
-		{
-			/* pointer is on a different screen */
-			x = 0;
-			y = 0;
-		}
 
-#if 0
-		/* check actual pointer location since PanFrames can get buried
-		 * under window being moved or resized - mab */
-		if (x >= edge_thickness &&
-		    x < mwidth - edge_thickness &&
-		    x <= (m->si->w) - edge_thickness &&
-		    y >= edge_thickness &&
-		    y < mheight - edge_thickness &&
-		    y >= (m->si->h) - edge_thickness)
-		{
-			is_timestamp_valid = False;
-			add_time = 0;
-			return 0;
-		}
-#endif
 		if (!fLoop && is_last_position_valid &&
 		    (x - last_x > MAX_PAGING_MOVE_DISTANCE ||
 		     x - last_x < -MAX_PAGING_MOVE_DISTANCE ||
@@ -854,17 +819,14 @@ int HandlePaging(
 
 	/* Get the latest pointer position.  This is necessary as XFree 4.1.0.1
 	 * sometimes does not report mouse movement when it should. */
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &JunkChild, &x, &y, &JunkX,
-		    &JunkY, &JunkMask) == False)
-	{
-		/* pointer is on a different screen - ignore */
-	}
+		    &JunkY, &JunkMask);
+
 	/* Move the viewport */
 	/* and/or move the cursor back to the approximate correct location */
 	/* that is, the same place on the virtual desktop that it */
 	/* started at */
-
 	if (x <= (m->si->x + edge_thickness))
 	{
 		delta->x = -warp_size.x;
@@ -1001,14 +963,9 @@ int HandlePaging(
 	FWarpPointer(dpy,None,Scr.Root,0,0,0,0,p->x,p->y);
 	MoveViewport(m, m->virtual_scr.Vx + delta->x,
 			m->virtual_scr.Vy + delta->y,False);
-	if (FQueryPointer(
+	FQueryPointer(
 		    dpy, Scr.Root, &JunkRoot, &JunkChild, &(p->x), &(p->y),
-		    &JunkX, &JunkY, &JunkMask) == False)
-	{
-		/* pointer is on a different screen */
-		p->x = 0;
-		p->y = 0;
-	}
+		    &JunkX, &JunkY, &JunkMask);
 	if (Grab)
 	{
 		MyXUngrabServer(dpy);

--- a/libs/FEvent.c
+++ b/libs/FEvent.c
@@ -252,7 +252,6 @@ Bool fev_get_evpos_or_query(
 	Window JunkW;
 	int JunkC;
 	unsigned int JunkM;
-	Bool rc;
 	int type;
 
 	type = (e != NULL) ? e->type : -1;
@@ -287,16 +286,10 @@ Bool fev_get_evpos_or_query(
 		}
 		return True;
 	default:
-		rc = FQueryPointer(
+		FQueryPointer(
 			dpy, w, &JunkW, &JunkW, ret_x, ret_y, &JunkC, &JunkC,
 			&JunkM);
-		if (rc == False)
-		{
-			/* pointer is on a different screen */
-			*ret_x = 0;
-			*ret_y = 0;
-		}
-		return rc;
+		return True;
 	}
 }
 
@@ -844,18 +837,16 @@ int FQLength(
 	return rc;
 }
 
-Bool FQueryPointer(
+void FQueryPointer(
 	Display *display, Window w, Window *root_return, Window *child_return,
 	int *root_x_return, int *root_y_return, int *win_x_return,
 	int *win_y_return, unsigned int *mask_return)
 {
-	Bool rc;
-
-	rc = XQueryPointer(
+	XQueryPointer(
 		display, w, root_return, child_return, root_x_return,
 		root_y_return, win_x_return, win_y_return, mask_return);
 
-	return rc;
+	return;
 }
 
 Status FSendEvent(

--- a/libs/FEvent.h
+++ b/libs/FEvent.h
@@ -183,7 +183,7 @@ int FPutBackEvent(
 	Display *display, XEvent *event);
 int FQLength(
 	Display *display);
-Bool FQueryPointer(
+void FQueryPointer(
 	Display *display, Window w, Window *root_return, Window *child_return,
 	int *root_x_return, int *root_y_return, int *win_x_return,
 	int *win_y_return, unsigned int *mask_return);

--- a/libs/Target.c
+++ b/libs/Target.c
@@ -133,14 +133,10 @@ void fvwmlib_keyboard_shortcuts(
 		int x_def_new = 0;
 		int y_def_new = 0;
 
-		if (FQueryPointer(
+		FQueryPointer(
 			    dpy, RootWindow(dpy, screen), &JunkRoot,
 			    &Event->xany.window, &x_root, &y_root, &x, &y,
-			    &JunkMask) == False)
-		{
-			/* pointer is on a different screen - do nothing */
-			return;
-		}
+			    &JunkMask);
 		if (x + x_move < 0)
 		{
 			x_def_new = x + x_move;

--- a/modules/FvwmIconMan/x.c
+++ b/modules/FvwmIconMan/x.c
@@ -800,14 +800,9 @@ void X_init_manager (int man_id)
     unsigned int ujunk;
     fscreen_scr_arg fscr;
 
-    if (FQueryPointer(
+    FQueryPointer(
 	  theDisplay, theRoot, &dummyroot, &dummychild, &man->geometry.x,
-	  &man->geometry.y, &junk, &junk, &ujunk) == False)
-    {
-      /* pointer is on a different screen - that's okay here */
-      man->geometry.y = 0;
-      man->geometry.x = 0;
-    }
+	  &man->geometry.y, &junk, &junk, &ujunk);
     fscr.xypos.x = man->geometry.x;
     fscr.xypos.y = man->geometry.y;
     FScreenGetScrRect(

--- a/modules/FvwmIdent/FvwmIdent.c
+++ b/modules/FvwmIdent/FvwmIdent.c
@@ -790,14 +790,9 @@ void list_end(void)
 		unsigned int JunkM;
 		fscreen_scr_arg fscr;
 
-		if (!FQueryPointer(
+		FQueryPointer(
 			dpy, Root, &JunkW, &JunkW, &x, &y, &JunkC, &JunkC,
-			&JunkM))
-		{
-			/* pointer is on a different screen */
-			x = 0;
-			y = 0;
-		}
+			&JunkM);
 
 		fscr.xypos.x = x;
 		fscr.xypos.y = y;

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -425,14 +425,9 @@ int main(int argc, char **argv)
   ParseOptions();
   if (is_transient)
   {
-    if (FQueryPointer(
+    FQueryPointer(
 	  dpy, Scr.Root, &JunkRoot, &JunkChild, &pwindow.x, &pwindow.y, &JunkX,
-	  &JunkY, &JunkMask) == False)
-    {
-      /* pointer is on a different screen */
-      pwindow.x = 0;
-      pwindow.y = 0;
-    }
+	  &JunkY, &JunkMask);
     usposition = 1;
     xneg = 0;
     yneg = 0;

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1304,21 +1304,15 @@ void DispatchEvent(XEvent *Event)
       {
 	if(Event->xany.window == Desks[i].w)
 	{
-	  if (FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
-			    &JunkX, &JunkY,&x, &y, &JunkMask) == False)
-	  {
-	    /* pointer is on a different screen - that's okay here */
-	  }
+	  FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
+			    &JunkX, &JunkY,&x, &y, &JunkMask);
 	  Scroll(x, y, i, False);
 	}
       }
       if(Event->xany.window == icon_win)
       {
-	if (FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
-			  &JunkX, &JunkY,&x, &y, &JunkMask) == False)
-	{
-	  /* pointer is on a different screen - that's okay here */
-	}
+	FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
+		  &JunkX, &JunkY,&x, &y, &JunkMask);
 	Scroll(x, y, -1, True);
       }
       /* Flush any pending scroll operations */
@@ -1398,8 +1392,8 @@ void DispatchEvent(XEvent *Event)
       {
 	if(Event->xany.window == Desks[i].w)
 	{
-	  if (FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
-			    &JunkX, &JunkY,&x, &y, &JunkMask) == False)
+	  FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
+			    &JunkX, &JunkY,&x, &y, &JunkMask);
 	  {
 	    /* pointer is on a different screen - that's okay here */
 	  }
@@ -1426,8 +1420,8 @@ void DispatchEvent(XEvent *Event)
       }
       if(Event->xany.window == icon_win)
       {
-	if (FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
-			  &JunkX, &JunkY,&x, &y, &JunkMask) == False)
+	FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
+			  &JunkX, &JunkY,&x, &y, &JunkMask);
 	{
 	  /* pointer is on a different screen - that's okay here */
 	}
@@ -1464,21 +1458,15 @@ void DispatchEvent(XEvent *Event)
       {
 	if(Event->xany.window == Desks[i].w)
 	{
-	  if (FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
-			    &JunkX, &JunkY,&x, &y, &JunkMask) == False)
-	  {
-	    /* pointer is on a different screen - that's okay here */
-	  }
+	  FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
+			    &JunkX, &JunkY,&x, &y, &JunkMask);
 	  Scroll(x, y, i, False);
 	}
       }
       if(Event->xany.window == icon_win)
       {
-	if (FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
-			  &JunkX, &JunkY,&x, &y, &JunkMask) == False)
-	{
-	  /* pointer is on a different screen - that's okay here */
-	}
+	FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
+			  &JunkX, &JunkY,&x, &y, &JunkMask);
 	Scroll(x, y, -1, True);
       }
 
@@ -2865,12 +2853,8 @@ void MoveWindow(XEvent *Event)
 			XDestroyWindow(dpy, t->PagerView);
 			t->PagerView = None;
 		}
-		if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
-				  &x, &y, &JunkX, &JunkY, &JunkMask) == False) {
-			/* pointer is on a different screen */
-			x = 0;
-			y = 0;
-		}
+		FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
+				  &x, &y, &JunkX, &JunkY, &JunkMask);
 		XUngrabPointer(dpy,CurrentTime);
 		XSync(dpy,0);
 
@@ -3300,13 +3284,9 @@ void IconMoveWindow(XEvent *Event, PagerWindow *t)
 	if (moved && (abs(x - xi) < MoveThreshold && abs(y - yi) < MoveThreshold))
 			moved = 0;
 
-	if (KeepMoving)	{
-		if (FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
-				  &x, &y, &JunkX, &JunkY, &JunkMask) == False) {
-			/* pointer is on a different screen */
-			x = 0;
-			y = 0;
-		}
+	if (KeepMoving) {
+		FQueryPointer(dpy, Scr.Root, &JunkRoot, &JunkChild,
+				  &x, &y, &JunkX, &JunkY, &JunkMask);
 		XUngrabPointer(dpy, CurrentTime);
 		XSync(dpy, 0);
 		SendText(fd, "Silent Raise", t->w);

--- a/perllib/FVWM/Commands.pm
+++ b/perllib/FVWM/Commands.pm
@@ -723,12 +723,6 @@ $TIME = 1410306754;
 		descr => q{Exit fvwm},
 	},
 	{
-		name => 'QuitScreen',
-		cursor => '',
-		window => 0,
-		descr => q{Stop managing the specified screen},
-	},
-	{
 		name => 'QuitSession',
 		cursor => '',
 		window => 0,


### PR DESCRIPTION
Fvwm no longer needs to run separate instances on each screen to manage screens independently. With RandR support and `DesktopConfiguration per-monitor`, each screen can be managed independently, with the advantage that all windows are managed by a single instance of fvwm, so windows can be moved between screens and controlled by a single instance. This removes the old single screen support from fvwm.

Note, users of the old `-s` option should switch to `DesktopConfiguration per-monitor` and run a single instance of fvwm. If there are features that `per-monitor` is missing, report issues so they are known and can be addressed. In general `per-monitor` should provide the same functionality and more than running separate instances on each Xinemera screen.