### PR TITLE
A few FvwmPager fixes

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -2515,5 +2515,7 @@ void ExitPager(void)
     XSync(dpy,0);
   }
   XUngrabKeyboard(dpy, CurrentTime);
+  free(monitor_to_track);
+  free(preferred_monitor);
   exit(0);
 }

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -305,7 +305,7 @@ static struct fpmonitor *fpmonitor_from_xy(int x, int y)
 static rectangle CalcGeom(PagerWindow *t, bool is_icon)
 {
 	/* Place initial rectangle off screen. */
-	rectangle rec = {-32768, -32768, 0, 0};
+	rectangle rec = {-32768, -32768, MinSize, MinSize};
 	struct fpmonitor *fp = fpmonitor_this(NULL);
 
 	/* If the monitor we expect to find is disabled, then


### PR DESCRIPTION
* Use {Min,Max}Size for the default rectangle, so that windows do not have zero size.
* Track disabled monitors if monitor_to_track was previously set.
* Free malloc()d variables on exiting the pager.