### PR TITLE
FvwmMFL: add DISPLAY to FVWMML_SOCKET

### DIFF
--- a/bin/FvwmPrompt/FvwmPrompt.go
+++ b/bin/FvwmPrompt/FvwmPrompt.go
@@ -16,7 +16,8 @@ import (
 )
 
 var (
-	fmdSocket = os.Getenv("FVWMMFL_SOCKET")
+	fmdDisplay = os.Getenv("DISPLAY");
+	fmdSocket = os.Getenv("FVWMMFL_SOCKET_" + fmdDisplay)
 )
 
 // getopt parsing


### PR DESCRIPTION
This adds the DISPLAY information to the given FVWMML_SOCKET, and
updates FVWM's environment with that new information.  This is a hackish
way to make FVWMMFL sockets unique per-display.

This needs a rethink.
