### PR TITLE
BroadcastMonitorList: send DesktopSize once

### DIFF
--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -397,7 +397,13 @@ void CMD_Send_ConfigInfo(F_CMD_ARGS)
 	int match_len = 0;
 	fmodule *mod = exc->m.module;
 
-	send_monitor_list(mod);
+	/* Don't send the monitor list when a module asks for its
+	 * configuration... in this case, fvwm -> module could get in an
+	 * infinite loop, continually telling that module the same
+	 * information over and over.
+	 *
+	 * send_monitor_list(mod);
+	 */
 	send_desktop_geometry(mod);
 	/* send ImagePath and ColorLimit first */
 	send_image_path(mod);

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -492,24 +492,22 @@ void BroadcastMonitorList(fmodule *this)
 			monitor_mode, is_tracking_shared);
 		SendName(module, M_CONFIG_INFO, 0, 0, 0, name);
 		free(name);
-
-		/* Reissue the DesktopSize command here, rather than sending
-		 * down the DesktopSize -- we want FvwmPager in particular to
-		 * react to a M_NEW_PAGE event, which DesktopSize will do; and
-		 * this avoids duplication in FvwmPager as a result.
-		 */
-		char action[256];
-
-		/* Every monitor will have the same dx/dy values, so just take
-		 * the fist entry in our list.
-		 */
-		struct monitor *m = RB_MIN(monitors, &monitor_q);
-
-		snprintf(action, sizeof(action), "DesktopSize %dx%d",
-			m->dx, m->dy);
-		execute_function_override_window(NULL, NULL, action, NULL, 0,
-			NULL);
 	}
+
+	/* Reissue the DesktopSize command here, rather than sending
+	 * down the DesktopSize -- we want FvwmPager in particular to
+	 * react to a M_NEW_PAGE event, which DesktopSize will do; and
+	 * this avoids duplication in FvwmPager as a result.
+	 */
+	char action[256];
+
+	/* Every monitor will have the same dx/dy values, so just take
+	 * the fist entry in our list.
+	 */
+	m = RB_MIN(monitors, &monitor_q);
+
+	snprintf(action, sizeof(action), "DesktopSize %dx%d", m->dx, m->dy);
+	execute_function_override_window(NULL, NULL, action, NULL, 0, NULL);
 }
 
 void BroadcastWindowIconNames(FvwmWindow *fw, Bool window, Bool icon)


### PR DESCRIPTION
When updating modules about changes to monitors, etc., only send the
DesktopSize command once, as this is proliferated for every module for
all pages, which is redundant.

Fixes #997
