### PR TITLE
Multiple FvwmPager Fixes

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -3905,7 +3905,7 @@ Move shuffle Up Left
 *Move* can be used to moved a window to a specified position:
 +
 
-> *Move* [screen _S_] \[w | m | v]_x_[p | w] \[w | m | v]_y_[p | w] [Warp] [ewmhiwa]
+> *Move* [screen _S_] [desk _N_] \[w | m | v]_x_[p | w] \[w | m | v]_y_[p | w] [Warp] [ewmhiwa]
 
 +
 This will move the window to the _x_ and _y_ position (see below).
@@ -3919,6 +3919,13 @@ specified, the coordinates are interpreted as relative to the given
 screen. The width and height of the screen are used for the
 calculations instead of the display dimensions. The _screen_ is
 interpreted as in the *MoveToScreen* command.
++
+If the literal option _desk_ followed by a desk number _N_ is specified,
+place the window on the specified desk after it has been moved. This can
+serve two purposes, first you can move a window's position and desk in a
+single command. Second when a window is moved between monitors, its desk
+is updated to be the same as the new monitor. This option can override
+that behavior by specifying which desk the window should end up on.
 +
 The positional arguments _x_ and _y_ can specify an absolute or relative
 position from either the left/top or right/bottom of the screen. By default,

--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2435,6 +2435,7 @@ FvwmWindow *AddWindow(
 	setup_key_and_button_grabs(fw);
 
 	/****** inform modules of new window ******/
+	fw->UpdateDesk = -1; /* Initialize to ensure desk update. */
 	update_fvwm_monitor(fw);
 	BroadcastConfig(M_ADD_WINDOW,fw);
 	BroadcastWindowIconNames(fw, True, False);

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -831,6 +831,8 @@ typedef struct FvwmWindow
 	int FocusDesk;
 	/* Desk to deiconify to, for StubbornIcons */
 	int DeIconifyDesk;
+	/* If not negative, this is the desk update_fvwm_monitor will use. */
+	int UpdateDesk;
 
 	char *mini_pixmap_file;
 	FvwmPicture *mini_icon;

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -750,6 +750,16 @@ int GetMoveArguments(FvwmWindow *fw,
 			&scr_w, &scr_h);
 		action = GetNextToken(action, &s1);
 	}
+	if (s1 && StrEquals(s1, "desk"))
+	{
+		int desk;
+
+		free(s1);
+		token = PeekToken(action, &action);
+		if (sscanf(token, "%d", &desk) && desk >= 0)
+			fw->UpdateDesk = desk;
+		action = GetNextToken(action, &s1);
+	}
 	action = GetNextToken(action, &s2);
 	while (!global_flag_parsed)
 	{

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -397,7 +397,7 @@ static int GetDeskNumber(struct monitor *mon, char *action, int current_desk)
  * Unmaps a window on transition to a new desktop
  *
  */
-static void unmap_window(FvwmWindow *t)
+void unmap_window(FvwmWindow *t)
 {
 	XWindowAttributes winattrs;
 	unsigned long eventMask = 0;
@@ -453,7 +453,7 @@ static void unmap_window(FvwmWindow *t)
  * Maps a window on transition to a new desktop
  *
  */
-static void map_window(FvwmWindow *t)
+void map_window(FvwmWindow *t)
 {
 	XWindowAttributes winattrs;
 	unsigned long eventMask = 0;

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -16,6 +16,8 @@ Bool is_pan_frame(Window w);
 void MoveViewport(struct monitor *, int newx, int newy,Bool);
 void goto_desk(int desk, struct monitor *);
 void do_move_window_to_desk(FvwmWindow *fw, int desk);
+void unmap_window(FvwmWindow *t);
+void map_window(FvwmWindow *t);
 Bool get_page_arguments(FvwmWindow *, char *action, int *page_x, int *page_y,
     struct monitor **);
 char *GetDesktopName(struct monitor *, int desk);

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -815,13 +815,8 @@ void list_configure(unsigned long *body)
   is_new_desk = (t->desk != cfgpacket->desk);
   handle_config_win_package(t, cfgpacket);
   if (is_new_desk)
-  {
     ChangeDeskForWindow(t, cfgpacket->desk);
-  }
-  else
-  {
-    MoveResizePagerView(t, false);
-  }
+  MoveResizePagerView(t, true);
 }
 
 /*

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -146,9 +146,11 @@ PagerWindow	*Start = NULL;
 PagerWindow	*FocusWin = NULL;
 
 /* Monitors */
+bool			fp_is_tracking_shared = false;
 char			*monitor_to_track = NULL;
 char			*preferred_monitor = NULL;
 struct fpmonitors	fp_monitor_q;
+enum monitor_tracking	fp_monitor_mode = MONITOR_TRACKING_G;
 
 static int x_fd;
 static fd_set_size_t fd_width;
@@ -994,7 +996,7 @@ void list_new_desk(unsigned long *body)
       (strcmp(fp->m->si->name, monitor_to_track) != 0))
 	  return;
 
-  if (monitor_mode == MONITOR_TRACKING_G)
+  if (fp_monitor_mode == MONITOR_TRACKING_G)
     monitor_assign_virtual(fp->m);
 
   if (fAlwaysCurrentDesk && oldDesk != fp->m->virtual_scr.CurrentDesk)
@@ -1632,7 +1634,8 @@ void list_config_info(unsigned long *body)
 		sscanf(tline, "%d %d", &mmode, &is_shared);
 
 		if (mmode > 0)
-			monitor_mode = mmode;
+			fp_monitor_mode = mmode;
+		fp_is_tracking_shared = is_shared;
 	}
 }
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -91,6 +91,7 @@ FlocaleWinString	*FwinString;
 int		Rows = -1;
 int		desk1 = 0;
 int		desk2 = 0;
+int		desk_i = 0;
 int		ndesks = 0;
 int		Columns = -1;
 int		MoveThreshold = DEFAULT_PAGER_MOVE_THRESHOLD;
@@ -998,6 +999,9 @@ void list_new_desk(unsigned long *body)
   if (monitor_to_track != NULL &&
       (strcmp(fp->m->si->name, monitor_to_track) != 0))
 	  return;
+
+  /* Update the icon window to always track current desk. */
+  desk_i = fp->m->virtual_scr.CurrentDesk;
 
   if (fp_monitor_mode == MONITOR_TRACKING_G)
     monitor_assign_virtual(fp->m);

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -930,8 +930,8 @@ void list_new_page(unsigned long *body)
 	if ((fp = fpmonitor_this(m)) == NULL)
 		return;
 
-	fp->virtual_scr.Vx = body[0];
-	fp->virtual_scr.Vy = body[1];
+	fp->virtual_scr.Vx = fp->m->virtual_scr.Vx = body[0];
+	fp->virtual_scr.Vy = fp->m->virtual_scr.Vy = body[1];
 	if (fp->m->virtual_scr.CurrentDesk != body[2]) {
 		/* first handle the new desk */
 		body[0] = body[2];
@@ -990,7 +990,8 @@ void list_new_desk(unsigned long *body)
    * itself, then don't change the FvwmPager's desk.  Only do this if we're
    * tracking a specific monitor though.
    */
-  if (monitor_to_track != NULL && fp->m != mout)
+  if (monitor_to_track != NULL &&
+      (strcmp(fp->m->si->name, monitor_to_track) != 0))
 	  return;
 
   if (monitor_mode == MONITOR_TRACKING_G)

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -196,6 +196,7 @@ extern FlocaleWinString	*FwinString;
 extern int		Rows;
 extern int		desk1;
 extern int		desk2;
+extern int		desk_i;
 extern int		ndesks;
 extern int		Columns;
 extern int		MoveThreshold;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -237,6 +237,8 @@ extern bool	do_focus_on_enter;
 extern bool	fAlwaysCurrentDesk;
 extern bool	use_dashed_separators;
 extern bool	do_ignore_next_button_release;
+extern bool	fp_is_tracking_shared;
+extern enum monitor_tracking fp_monitor_mode;
 
 /* Screen / Windows */
 extern int		fd[2];

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1335,9 +1335,6 @@ void DispatchEvent(XEvent *Event)
 	{
 	  FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
 			    &JunkX, &JunkY,&x, &y, &JunkMask);
-	  {
-	    /* pointer is on a different screen - that's okay here */
-	  }
 	  if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
 		fp = fpmonitor_from_desk(i + desk1);
 	  else
@@ -1363,9 +1360,6 @@ void DispatchEvent(XEvent *Event)
       {
 	FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
 			  &JunkX, &JunkY,&x, &y, &JunkMask);
-	{
-	  /* pointer is on a different screen - that's okay here */
-	}
 	struct fpmonitor *fp2 = fpmonitor_this(NULL);
 	if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
 		fp = fp2;
@@ -2058,7 +2052,7 @@ void DrawIconGrid(int erase)
 	if (HilightDesks) {
 		TAILQ_FOREACH(fp, &fp_monitor_q, entry) {
 			if (fp->disabled ||
-			   fp->m->virtual_scr.CurrentDesk != tmp ||
+			   fp->m->virtual_scr.CurrentDesk != tmp + desk1 ||
 			   (monitor_to_track != NULL &&
 			   strcmp(fp->m->si->name, monitor_to_track) != 0))
 				continue;
@@ -2287,7 +2281,7 @@ void ChangeDeskForWindow(PagerWindow *t, long newdesk)
 		int desk = newdesk - desk1;
 		XReparentWindow(dpy, t->PagerView, Desks[desk].w,
 			t->pager_view.x, t->pager_view.y);
-		MoveResizeWindow(t, true, false);
+		MoveResizeWindow(t, true, true);
 	}
 
 	return;
@@ -2303,13 +2297,12 @@ void MoveResizePagerView(PagerWindow *t, bool do_force_redraw)
 		return;
 	}
 
-	if (t->m->virtual_scr.CurrentDesk < desk1 ||
-	    t->m->virtual_scr.CurrentDesk > desk2)
+	if (t->desk < desk1 || t->desk > desk2)
 		HideWindow(t, t->PagerView);
 	else
 		MoveResizeWindow(t, do_force_redraw, false);
 
-	if (fp->m->virtual_scr.CurrentDesk == t->desk)
+	if (t->desk == desk1)
 		MoveResizeWindow(t, do_force_redraw, true);
 	else
 		HideWindow(t, t->IconView);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -2012,7 +2012,7 @@ void DrawIconGrid(int erase)
 	if (fp == NULL)
 		return;
 
-	int i, tmp = (fp->m->virtual_scr.CurrentDesk - desk1);
+	int i, tmp = (fp->m->virtual_scr.CurrentDesk - desk_i);
 
 	if (tmp < 0 || tmp >= ndesks)
 		tmp = 0;
@@ -2052,7 +2052,7 @@ void DrawIconGrid(int erase)
 	if (HilightDesks) {
 		TAILQ_FOREACH(fp, &fp_monitor_q, entry) {
 			if (fp->disabled ||
-			   fp->m->virtual_scr.CurrentDesk != tmp + desk1 ||
+			   fp->m->virtual_scr.CurrentDesk != tmp + desk_i ||
 			   (monitor_to_track != NULL &&
 			   strcmp(fp->m->si->name, monitor_to_track) != 0))
 				continue;
@@ -2302,7 +2302,7 @@ void MoveResizePagerView(PagerWindow *t, bool do_force_redraw)
 	else
 		MoveResizeWindow(t, do_force_redraw, false);
 
-	if (t->desk == desk1)
+	if (t->desk == desk_i)
 		MoveResizeWindow(t, do_force_redraw, true);
 	else
 		HideWindow(t, t->IconView);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -224,7 +224,7 @@ static struct fpmonitor *fpmonitor_from_xy(int x, int y)
 {
 	struct fpmonitor *fp;
 
-	if (monitor_to_track == NULL && monitor_mode != MONITOR_TRACKING_G) {
+	if (monitor_to_track == NULL && fp_monitor_mode != MONITOR_TRACKING_G) {
 		x %= fpmonitor_get_all_widths();
 		y %= fpmonitor_get_all_heights();
 
@@ -1298,7 +1298,7 @@ void DispatchEvent(XEvent *Event)
 	 * use.
 	 */
 	else if(Event->xany.window == Desks[i].title_w &&
-		((monitor_mode == MONITOR_TRACKING_G && !is_tracking_shared) ||
+		((fp_monitor_mode == MONITOR_TRACKING_G && !fp_is_tracking_shared) ||
 		 (monitor_to_track != NULL) || (m_count == 1)))
 	{
 		SwitchToDesk(i, NULL);
@@ -1335,7 +1335,7 @@ void DispatchEvent(XEvent *Event)
 	{
 	  FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
 			    &JunkX, &JunkY,&x, &y, &JunkMask);
-	  if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
+	  if (fp_monitor_mode == MONITOR_TRACKING_G && fp_is_tracking_shared)
 		fp = fpmonitor_from_desk(i + desk1);
 	  else
 		fp = fpmonitor_from_xy(x * fp->virtual_scr.VWidth / desk_w,
@@ -1361,7 +1361,7 @@ void DispatchEvent(XEvent *Event)
 	FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
 			  &JunkX, &JunkY,&x, &y, &JunkMask);
 	struct fpmonitor *fp2 = fpmonitor_this(NULL);
-	if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
+	if (fp_monitor_mode == MONITOR_TRACKING_G && fp_is_tracking_shared)
 		fp = fp2;
 	else {
 		fp = fpmonitor_from_xy(
@@ -2105,7 +2105,7 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
 	vy = (desk_h == 0) ? 0 :
 		Event->xbutton.y * fp->virtual_scr.VHeight / desk_h;
 
-	if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
+	if (fp_monitor_mode == MONITOR_TRACKING_G && fp_is_tracking_shared)
 		fp = fpmonitor_from_desk(Desk);
 	else
 		fp = fpmonitor_from_xy(vx, vy);
@@ -2427,7 +2427,7 @@ void Scroll(int x, int y, int Desk, bool do_scroll_icon)
 	}
 
 	/* center around mouse */
-	if (monitor_mode == MONITOR_TRACKING_G && !is_tracking_shared) {
+	if (fp_monitor_mode == MONITOR_TRACKING_G && !fp_is_tracking_shared) {
 		adjx = window_w / fp->virtual_scr.VxPages;
 		adjy = window_h / fp->virtual_scr.VyPages;
 	} else {


### PR DESCRIPTION
A collection of bugfixes I've been trying to hunt down, and things I noticed when trying to add new features. I have split the bugfixes out, before working on new features. This includes:

+ A patch with various small fixes bundled together.
+ Localize variables names to fvwm pager.
+ Add a new 'desk N' option to the move command so fvwm pager can correctly move windows to a specified location.
+ Fix the initial configuration parsing so it can deal with all the normal broadcast read during the initialization.
+ Fix an issue where the IconView pager only showed desk 0, this now always shows the current desk (or really the last
   desk any monitor switched to).
+ Refactored fix movement code. I think windows are now being correctly moved and positioned in fvwm and the pager.

