### PR TITLE
FvwmPager: CurrentDeskPerMonitor and two other features.

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -369,7 +369,17 @@ done about this - except not using SloppyFocus in the pager.
 *FvwmPager: Monitor RandRName::
   Tells FvwmPager to display windows only on _RandRName_ monitor. This
   is especially meaningful when the _DesktopConfiguration_ command is
-  set to _shared_.
+  set to _shared_. If _RandRName_ is *none*, the monitor is unset,
+  and the pager will show windows on all monitors.
+
+*FvwmPager: CurrentMonitor RandRName::
+  When always viewing the current desktop, either via the icon pager
+  or running *FvwmPager {asterisk}*, the current desktop is updated each
+  time any monitor changes desktops. This may not be preferable if using
+  _per-monitor_ or _shared_ mode. This option sets the current monitor
+  to _RandRName_, and the current desk is only updated when that monitor
+  changes desks, ignoring changes from any other monitor. If _RandRName_
+  is *none*, the current_monitor is unset, reverting to default behavior.
 
 == AUTHOR
 

--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -373,13 +373,27 @@ done about this - except not using SloppyFocus in the pager.
   and the pager will show windows on all monitors.
 
 *FvwmPager: CurrentMonitor RandRName::
-  When always viewing the current desktop, either via the icon pager
-  or running *FvwmPager {asterisk}*, the current desktop is updated each
+  When viewing only the current desktop, either via the icon pager or running
+  *FvwmPager {asterisk}*, the current desktop is updated each
   time any monitor changes desktops. This may not be preferable if using
   _per-monitor_ or _shared_ mode. This option sets the current monitor
   to _RandRName_, and the current desk is only updated when that monitor
   changes desks, ignoring changes from any other monitor. If _RandRName_
   is *none*, the current_monitor is unset, reverting to default behavior.
+
+*FvwmPager: CurrentDeskPerMonitor::
+  When viewing only the current desktop, either via the icon pager or running
+  *FvwmPager {asterisk}*, this option makes the pager show the windows on the
+  desktop each monitor is viewing independently. For example, the area of the
+  pager for monitor 0 would show its windows on desktop 2, while the area of
+  the pager for monitor 1 would show its windows on desktop 1, the desktop it
+  is currently viewing. When used with _DeskLabels_, there will be one desk
+  label per monitor stating the desk each monitor is viewing, and use
+  _MonitorLabels_ to get the monitor names associated with each desk.
+
+*FvwmPager: CurrentDeskGlobal::
+  This option cancels setting _CurrentDeskPerMonitor_, reverting to the
+  default.
 
 == AUTHOR
 

--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -276,6 +276,10 @@ does not get the input focus. This may happen if you drag the pointer
 over one of the mini windows in the pager. There is nothing that can be
 done about this - except not using SloppyFocus in the pager.
 
+*FvwmPager: FocusAfterMove::
+  After moving a window using the pager (using mouse button 2), give the
+  window focus if it is moved to the same desktop as the current monitor.
+
 *FvwmPager: SolidSeparators::
   By default the pages of the virtual desktop are separated by dashed
   lines in the pager window. This option causes FvwmPager to use solid

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -132,6 +132,7 @@ bool	use_monitor_label = false;
 bool	ShowPagerBalloons = false;
 bool	do_focus_on_enter = false;
 bool	fAlwaysCurrentDesk = false;
+bool	CurrentDeskPerMonitor = false;
 bool	use_dashed_separators = true;
 bool	do_ignore_next_button_release = false;
 
@@ -968,7 +969,7 @@ void list_new_desk(unsigned long *body)
   int change_highcs = -1;
   int mon_num = body[1];
   struct monitor *mout;
-  struct fpmonitor *fp, *tfp;
+  struct fpmonitor *fp;
 
   mout = monitor_by_output(mon_num);
   /* Don't allow monitor_by_output to fallback to RB_MIN. */
@@ -993,12 +994,12 @@ void list_new_desk(unsigned long *body)
    * If always showing the current desktop, the current_monitor is set, and
    * tracking is per-monitor, only change pager desk on the current_monitor.
    */
-  if ((monitor_to_track != NULL &&
+  if (!CurrentDeskPerMonitor && ((monitor_to_track != NULL &&
 		(strcmp(mout->si->name, monitor_to_track) != 0)) ||
 		(current_monitor != NULL &&
 		monitor_to_track == NULL &&
 		(monitor_mode == MONITOR_TRACKING_M || is_tracking_shared) &&
-		(strcmp(mout->si->name, current_monitor) != 0)))
+		(strcmp(mout->si->name, current_monitor) != 0))))
 	  return;
 
   /* Update the icon window to always track current desk. */
@@ -1139,8 +1140,8 @@ void list_new_desk(unsigned long *body)
   }
 
   MovePage(true);
-  DrawGrid(oldDesk - desk1, 1, None, NULL);
-  DrawGrid(fp->m->virtual_scr.CurrentDesk - desk1, 1, None, NULL);
+  DrawGrid(oldDesk - desk1, None, NULL);
+  DrawGrid(fp->m->virtual_scr.CurrentDesk - desk1, None, NULL);
   MoveStickyWindow(false, true);
 /*
   Hilight(FocusWin,false);
@@ -1540,7 +1541,7 @@ void list_config_info(unsigned long *body)
 		{
 			val = val - desk1;
 		}
-		DrawGrid(val, true, None, NULL);
+		DrawGrid(val, None, NULL);
 	} else if (StrEquals(token, "Monitor")) {
 		parse_monitor_line(tline);
 		ReConfigure();
@@ -2008,6 +2009,10 @@ ImagePath = NULL;
 	    use_monitor_label = true;
     } else if(StrEquals(resource, "NoMonitorLabels")) {
 	    use_monitor_label = false;
+    } else if(StrEquals(resource, "CurrentDeskPerMonitor")) {
+	    CurrentDeskPerMonitor = true;
+    } else if(StrEquals(resource, "CurrentDeskGlobal")) {
+	    CurrentDeskPerMonitor = false;
     }
     else if(StrEquals(resource,"Colorset"))
     {

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -147,11 +147,9 @@ PagerWindow	*Start = NULL;
 PagerWindow	*FocusWin = NULL;
 
 /* Monitors */
-bool			fp_is_tracking_shared = false;
 char			*monitor_to_track = NULL;
 char			*preferred_monitor = NULL;
 struct fpmonitors	fp_monitor_q;
-enum monitor_tracking	fp_monitor_mode = MONITOR_TRACKING_G;
 
 static int x_fd;
 static fd_set_size_t fd_width;
@@ -998,7 +996,7 @@ void list_new_desk(unsigned long *body)
   /* Update the icon window to always track current desk. */
   desk_i = fp->m->virtual_scr.CurrentDesk;
 
-  if (fp_monitor_mode == MONITOR_TRACKING_G)
+  if (monitor_mode == MONITOR_TRACKING_G)
     monitor_assign_virtual(fp->m);
 
   if (fAlwaysCurrentDesk && oldDesk != fp->m->virtual_scr.CurrentDesk)
@@ -1826,8 +1824,8 @@ void parse_desktop_configuration_line(char *tline)
 		sscanf(tline, "%d %d", &mmode, &is_shared);
 
 		if (mmode > 0) {
-			fp_monitor_mode = mmode;
-			fp_is_tracking_shared = is_shared;
+			monitor_mode = mmode;
+			is_tracking_shared = is_shared;
 		}
 }
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -122,6 +122,7 @@ bool	is_transient = false;
 bool	HilightDesks = true;
 bool	ShowBalloons = false;
 bool	error_occured = false;
+bool	FocusAfterMove = false;
 bool	use_desk_label = true;
 bool	win_hi_pix_set = false;
 bool	WindowBorders3d = false;
@@ -2381,6 +2382,10 @@ ImagePath = NULL;
     else if (StrEquals(resource, "SloppyFocus"))
     {
       do_focus_on_enter = true;
+    }
+    else if (StrEquals(resource, "FocusAfterMove"))
+    {
+      FocusAfterMove = true;
     }
     else if (StrEquals(resource, "SolidSeparators"))
     {

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -226,6 +226,7 @@ extern bool	is_transient;
 extern bool	HilightDesks;
 extern bool	ShowBalloons;
 extern bool	error_occured;
+extern bool	FocusAfterMove;
 extern bool	use_desk_label;
 extern bool	win_hi_pix_set;
 extern bool	WindowBorders3d;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -238,8 +238,6 @@ extern bool	do_focus_on_enter;
 extern bool	fAlwaysCurrentDesk;
 extern bool	use_dashed_separators;
 extern bool	do_ignore_next_button_release;
-extern bool	fp_is_tracking_shared;
-extern enum monitor_tracking fp_monitor_mode;
 
 /* Screen / Windows */
 extern int		fd[2];

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -251,6 +251,7 @@ extern PagerWindow	*Start;
 extern PagerWindow	*FocusWin;
 
 /* Monitors */
+extern char			*current_monitor;
 extern char			*monitor_to_track;
 extern char			*preferred_monitor;
 extern struct fpmonitors	fp_monitor_q;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -236,6 +236,7 @@ extern bool	use_monitor_label;
 extern bool	ShowPagerBalloons;
 extern bool	do_focus_on_enter;
 extern bool	fAlwaysCurrentDesk;
+extern bool	CurrentDeskPerMonitor;
 extern bool	use_dashed_separators;
 extern bool	do_ignore_next_button_release;
 
@@ -303,7 +304,7 @@ void ReConfigure(void);
 void ReConfigureAll(void);
 void update_pr_transparent_windows(void);
 void MovePage(bool is_new_desk);
-void DrawGrid(int desk,int erase,Window ew,XRectangle *r);
+void DrawGrid(int desk,Window ew,XRectangle *r);
 void DrawIconGrid(int erase);
 void SwitchToDesk(int Desk, struct fpmonitor *m);
 void SwitchToDeskAndPage(int Desk, XEvent *Event);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -2736,29 +2736,30 @@ void MoveWindow(XEvent *Event)
 	 * "ewmhiwa" disables clipping to monitor/ewmh boundaries.
 	 */
 	pagerrec_to_fvwm(&rec, false, fp);
-	if (CurrentDeskPerMonitor && fAlwaysCurrentDesk)
+	if (CurrentDeskPerMonitor && fAlwaysCurrentDesk) {
+		NewDesk = fp->m->virtual_scr.CurrentDesk;
 		/* Let fvwm handle any desk changes in this case. */
 		snprintf(buf, sizeof(buf), "Silent Move v+%dp v+%dp ewmhiwa",
 			 rec.x, rec.y);
-	else
+	} else {
+		NewDesk += desk1;
 		snprintf(buf, sizeof(buf),
 			 "Silent Move desk %d v+%dp v+%dp ewmhiwa",
-			 NewDesk + desk1, rec.x, rec.y);
+			 NewDesk, rec.x, rec.y);
+	}
 	SendText(fd, buf, t->w);
 	XSync(dpy,0);
 	SendText(fd, "Silent Raise", t->w);
 
-done_moving:
-#if 0
-	/* Disabling for now, unsure how useful this feature is. */
-	if (fp->m->virtual_scr.CurrentDesk == t->desk) {
+	if (FocusAfterMove && fp->m->virtual_scr.CurrentDesk == NewDesk) {
 		XSync(dpy,0);
 		usleep(5000);
 		XSync(dpy,0);
 
 		SendText(fd, "Silent FlipFocus NoWarp", t->w);
 	}
-#endif
+
+done_moving:
 	if (is_transient)
 		ExitPager(); /* does not return */
 }
@@ -3121,7 +3122,8 @@ void IconMoveWindow(XEvent *Event, PagerWindow *t)
 		SendText(fd, buf, t->w);
 		XSync(dpy, 0);
 		SendText(fd, "Silent Raise", t->w);
-		//SendText(fd, "Silent FlipFocus NoWarp", t->w);
+		if (FocusAfterMove)
+			SendText(fd, "Silent FlipFocus NoWarp", t->w);
 	} else {
 		MoveResizePagerView(t, true);
 	}

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -224,7 +224,7 @@ static struct fpmonitor *fpmonitor_from_xy(int x, int y)
 {
 	struct fpmonitor *fp;
 
-	if (monitor_to_track == NULL && fp_monitor_mode != MONITOR_TRACKING_G) {
+	if (monitor_to_track == NULL && monitor_mode != MONITOR_TRACKING_G) {
 		x %= fpmonitor_get_all_widths();
 		y %= fpmonitor_get_all_heights();
 
@@ -1298,7 +1298,7 @@ void DispatchEvent(XEvent *Event)
 	 * use.
 	 */
 	else if(Event->xany.window == Desks[i].title_w &&
-		((fp_monitor_mode == MONITOR_TRACKING_G && !fp_is_tracking_shared) ||
+		((monitor_mode == MONITOR_TRACKING_G && !is_tracking_shared) ||
 		 (monitor_to_track != NULL) || (m_count == 1)))
 	{
 		SwitchToDesk(i, NULL);
@@ -1335,7 +1335,7 @@ void DispatchEvent(XEvent *Event)
 	{
 	  FQueryPointer(dpy, Desks[i].w, &JunkRoot, &JunkChild,
 			    &JunkX, &JunkY,&x, &y, &JunkMask);
-	  if (fp_monitor_mode == MONITOR_TRACKING_G && fp_is_tracking_shared)
+	  if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
 		fp = fpmonitor_from_desk(i + desk1);
 	  else
 		fp = fpmonitor_from_xy(x * fp->virtual_scr.VWidth / desk_w,
@@ -1361,7 +1361,7 @@ void DispatchEvent(XEvent *Event)
 	FQueryPointer(dpy, icon_win, &JunkRoot, &JunkChild,
 			  &JunkX, &JunkY,&x, &y, &JunkMask);
 	struct fpmonitor *fp2 = fpmonitor_this(NULL);
-	if (fp_monitor_mode == MONITOR_TRACKING_G && fp_is_tracking_shared)
+	if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
 		fp = fp2;
 	else {
 		fp = fpmonitor_from_xy(
@@ -2105,7 +2105,7 @@ void SwitchToDeskAndPage(int Desk, XEvent *Event)
 	vy = (desk_h == 0) ? 0 :
 		Event->xbutton.y * fp->virtual_scr.VHeight / desk_h;
 
-	if (fp_monitor_mode == MONITOR_TRACKING_G && fp_is_tracking_shared)
+	if (monitor_mode == MONITOR_TRACKING_G && is_tracking_shared)
 		fp = fpmonitor_from_desk(Desk);
 	else
 		fp = fpmonitor_from_xy(vx, vy);
@@ -2434,7 +2434,7 @@ void Scroll(int x, int y, int Desk, bool do_scroll_icon)
 	}
 
 	/* center around mouse */
-	if (fp_monitor_mode == MONITOR_TRACKING_G && !fp_is_tracking_shared) {
+	if (monitor_mode == MONITOR_TRACKING_G && !is_tracking_shared) {
 		adjx = window_w / fp->virtual_scr.VxPages;
 		adjy = window_h / fp->virtual_scr.VyPages;
 	} else {


### PR DESCRIPTION
This adds the following features to FvwmPager. Two features are fairly minor (so grouping them here) and the third is a new way to view the pager.

+ Add option `CurrentDeskPerMonitor`. This option affects both the icon view of the pager and when the pager is tracking a current desk via `fAlwaysCurrentDesk` activated by running `Module FvwmPager *`. This option makes the pager show the windows on the current desktop of each monitor independently. Useful when using `per-monitor` and the monitors are on different desks, to ensure you always see the windows for each monitor. In addition if `DeskLabels` and `MonitorLabes` are enabled, the desk that each monitor is currently viewing is shown in the label.

+ Add option `FocusAfterMove`. This option will use `FlipFocus` on any window that is moved by the pager and dropped in the current desktop of the monitor viewing the window. This is an old feature that was in the code, but was always enabled. Not all use cases would want this feature, so instead I disabled it by default, and added this new option to turn it on.

+ Add option `CurrentMonitor RandRname`. This option configures a `current_monitor` that is used to determine when the current desktop should update. Without setting this option, the current desktop for icon view, or when using the pager in `fAlwaysCurrentDesk`, mode `Module FvwmPager *`, is updated each and every time any monitor changes desktops. This may not be ideal in `per-monitor` mode, so configuring this option will make the current desktop only update when the specified monitor changes desktops, and ignore all other monitors.