### PR TITLE
FvwmPager: New mode IsShared for DesktopConfiguration shared.

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -59,7 +59,8 @@ monitor label will move that monitor to the clicked desk. Clicks in which it
 cannot be clearly determined which monitor to move will be ignored, such as
 clicks on desk labels or dead space in 'per-monitor' mode, clicking on a desk
 not occupied by any monitor in 'shared' mode. It is suggested to use
-_MonitorLabels_ with 'shared' mode.
+_MonitorLabels_ with 'shared' mode. There is also a special mode _IsShared_
+to better view the shared desktops in 'shared' mode.
 
 When clicked with button 3, FvwmPager will move the current view port centered
 on the area clicked. Unlike a left click, which always places the monitor(s)
@@ -398,6 +399,16 @@ done about this - except not using SloppyFocus in the pager.
 *FvwmPager: CurrentDeskGlobal::
   This option cancels setting _CurrentDeskPerMonitor_, reverting to the
   default.
+
+*FvwmPager: IsShared::
+  Setting this option tells fvwm to use shared mode, which is designed to
+  work best with _DesktopConfiguration shared_. In this mode, each desktop
+  shows only the windows and area occupied by the last monitor to view that
+  desktop. Pair this with _MonitorLabels_ to change the desktop of each
+  monitor by clicking on their label.
+
+*FvwmPager: IsNotShared:
+  This setting turns off the previous, _IsShared_, setting.
 
 == AUTHOR
 

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -139,6 +139,7 @@ typedef struct desk_info
   GC rvGC;                      /* used for drawing hilighted desk title */
   unsigned long fp_mask;        /* used for the fpmonitor window */
   XSetWindowAttributes fp_attr; /* used for the fpmonitor window */
+  struct fpmonitor *fp;         /* most recent monitor viewing desk. */
 } DeskInfo;
 
 typedef struct pager_string_list
@@ -212,6 +213,7 @@ extern int	windowcolorset;
 extern int	activecolorset;
 extern bool	xneg;
 extern bool	yneg;
+extern bool	IsShared;
 extern bool	icon_xneg;
 extern bool	icon_yneg;
 extern bool	MiniIcons;
@@ -333,5 +335,6 @@ void DrawInBalloonWindow(int i);
 void HandleScrollDone(void);
 int fpmonitor_get_all_widths(void);
 int fpmonitor_get_all_heights(void);
+struct fpmonitor *fpmonitor_from_desk(int desk);
 
 #endif /* FVWMPAGER_H */

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -253,8 +253,8 @@ extern PagerWindow	*Start;
 extern PagerWindow	*FocusWin;
 
 /* Monitors */
-extern char			*current_monitor;
-extern char			*monitor_to_track;
+extern struct fpmonitor		*current_monitor;
+extern struct fpmonitor		*monitor_to_track;
 extern char			*preferred_monitor;
 extern struct fpmonitors	fp_monitor_q;
 

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -110,7 +110,7 @@ static void do_scroll(int sx, int sy, bool do_send_message,
 	{
 		if (monitor_to_track != NULL)
 			snprintf(screen, sizeof(screen), "screen %s",
-				 monitor_to_track);
+				 monitor_to_track->m->si->name);
 		else if (ScrollFp != NULL)
 			snprintf(screen, sizeof(screen), "screen %s",
 				 ScrollFp->m->si->name);
@@ -1592,8 +1592,7 @@ void ReConfigure(void)
 		m->m->virtual_scr.CurrentDesk : desk1;
 
 	    if (i == m->m->virtual_scr.CurrentDesk - desk &&
-		(monitor_to_track == NULL ||
-		strcmp(m->m->si->name, monitor_to_track) == 0))
+		(monitor_to_track == NULL || m == monitor_to_track))
 	    {
 	      XMoveResizeWindow(dpy, m->CPagerWin[i],
 				vp.x, vp.y, vp.width, vp.height);
@@ -1764,8 +1763,7 @@ void MovePage(bool is_new_desk)
 		m->m->virtual_scr.CurrentDesk : desk1;
 
 	if (!m->disabled && i == m->m->virtual_scr.CurrentDesk - desk &&
-		(monitor_to_track == NULL ||
-		strcmp(m->m->si->name, monitor_to_track) == 0))
+		(monitor_to_track == NULL || m == monitor_to_track))
 	{
 		vp = set_vp_size_and_loc(m, false);
 		XMoveResizeWindow(dpy, m->CPagerWin[i],
@@ -2074,7 +2072,7 @@ void DrawIconGrid(int erase)
 			if (fp->disabled ||
 			   fp->m->virtual_scr.CurrentDesk != tmp + desk ||
 			   (monitor_to_track != NULL &&
-			   strcmp(fp->m->si->name, monitor_to_track) != 0))
+			   fp != monitor_to_track))
 				continue;
 			rec = set_vp_size_and_loc(fp, true);
 			if (HilightPixmap) {
@@ -2392,8 +2390,7 @@ void Hilight(PagerWindow *t, int on)
 	if (!t)
 		return;
 
-	if (monitor_to_track != NULL &&
-	    strcmp(t->m->si->name, monitor_to_track) != 0)
+	if (monitor_to_track != NULL && t->m != monitor_to_track->m)
 		return;
 
 	if(Pdepth < 2)


### PR DESCRIPTION
First this cleans up FvwmPager's handling of `DesktopConfiguration shared`. It should now correctly show the location of all windows and monitors when using shared mode, along with limit what clicks do. Only clicks in a desktop that a monitor is currently occupied will move through the pages, of the monitor on that desk. To move different monitors between desks `MonitorLabels` should be used.

Here is a screenshot of the normal mode and `IsShared` mode when using `DesktopConfiguration shared` showing 4 desks in a 2x2 grid. Each desk is further split up into 2x2 pages.

![mpv-shot0001](https://github.com/fvwmorg/fvwm3/assets/18082412/2cc02a43-078a-4e34-8380-e0c6668c7696)

The pager on the left is what shared mode looks like in a regular pager. As you can see there is a lot of blank space for each desktop for the other monitor, and since only a single monitor can view the desktop at a time, the space won't be used. The pager on the right is using the shared mode, only showing a single monitor at a time. In this case the unused space is no longer shown and the `MonitorLabels` can be used to move monitors between the desks.

Note, this is built on top of #1002, so needs to be merged after.