### PR TITLE
Add a utils script to create manpage html output for www.fvwm.org

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -1569,8 +1569,7 @@ $[pointer.screen]::
 +
 This is deprecated; use $[monitor.current] instead.
 
-$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width],
-$[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.prev_primary], $[monitor.current], $[monitor.prev] $[monitor.output], $[monitor.number] $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
+$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width], $[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.prev_primary], $[monitor.current], $[monitor.prev] $[monitor.output], $[monitor.number] $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
 	Returns information about the selected monitor. These can be nested, for
 	example: $[monitor.$[monitor.primary].width]
 +

--- a/utils/fvwm_doc2web.sh
+++ b/utils/fvwm_doc2web.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# This script uses asciidoctor to build the html documents for www.fvwm.org.
+# This is done by first building the pages in --embedded (-e) mode with no
+# headers and footers, then placing a simple header for Jekyll on top.
+#
+# Use: Run utils/fvwm_doc2web.sh from the top level of the fvwm3 source.
+# The output will be located in doc/fvwmorg.github.io/
+CMD="asciidoctor -e -b html5 -a toc -a webfonts!"
+OUT_DIR="fvwmorg.github.io"
+FVWM_VER="1.1.0"
+FVWM_DOCS="fvwm3 fvwm3all fvwm3commands fvwm3menus fvwm3styles FvwmAnimate \
+	FvwmAuto FvwmBacker FvwmButtons FvwmCommand FvwmConsole FvwmEvent \
+	FvwmForm FvwmIconMan FvwmIdent FvwmMFL FvwmPager FvwmPerl FvwmPrompt \
+	FvwmRearrange FvwmScript fvwm-menu-desktop fvwm-menu-directory \
+	fvwm-menu-xlock fvwm-perllib fvwm-root fvwm-convert-2.6"
+
+if [ ! -d "fvwm" ] || [ ! -f "fvwm/fvwm3.c" ] || [ ! -d "doc" ]
+then
+	echo Run from root level of fvwm3 source using utils/fvwm_man2doc.sh
+	exit 1
+fi
+
+cd doc/
+if [ ! -d "${OUT_DIR}" ]
+then
+	mkdir ${OUT_DIR}
+fi
+
+# Build pages. Place them in their own directory like rest of site.
+for doc in ${FVWM_DOCS}
+do
+	FILE=${OUT_DIR}/${doc}.html
+	HEADER="---\ntitle: ${doc} manual page\nshowtitle: 1\n"
+	HEADER="${HEADER}permalink: /Man/${doc}/index.html\n---"
+	echo "Building HTML: ${doc}.html"
+	echo ${HEADER} > ${FILE}
+	${CMD} -a ${doc} ${doc}.adoc -o - >> ${FILE}
+	sed -i 's/literalblock/literalblock highlight/' ${FILE}
+	sed -i '/toctitle/d' ${FILE}
+	sed -i 's/id="toc" class="toc"/id="markdown-toc"/' ${FILE}
+done
+
+# Build index page.
+# A build will remove one of FvwmConsole or FvwmPrompt from the index.
+# That is not desirable here, so use the .in file instead.
+FILE=${OUT_DIR}/index.html
+HEADER="---\ntitle: Fvwm3 Manual Pages\nshowtitle: 1\n---\n"
+HEADER="${HEADER}The following are the manual pages for "
+HEADER="${HEADER}fvwm3 version <strong>${FVWM_VER}</strong>."
+echo "Building HTML: index.html"
+echo ${HEADER} > ${FILE}
+${CMD} -a index index.adoc.in -o - >> ${FILE}
+sed -i 's!.html"!/"!' ${FILE}
+sed -i '/toctitle/d' ${FILE}
+sed -i 's/id="toc" class="toc"/id="markdown-toc"/' ${FILE}
+sed -i 's/ class="sect1"//' ${FILE}
+# This should be one line.
+sed -i 's!<p>!!g' ${FILE}
+sed -i 's!</p>!!g' ${FILE}


### PR DESCRIPTION
This script when run in the top level of the fvwm3 source will create html output designed for www.fvwm.org. The majority is done using asciidoctor in embedded mode to no longer include headers/footers. There is some additional edits done with sed to make the website format better without messing with its css too much.

Also found a minor bug in the manual page generation when testing this out, throwing it in here.