### PR TITLE
clang: fix compiler warnings

### DIFF
--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -2036,7 +2036,7 @@ static int style_set_border_colorset(window_style *ps, char *rest, int type)
 		this_many = BP_SIZE;
 	}
 
-	if (this_many < 2 && this_many > 8)
+	if (this_many < 2 || this_many > 8)
 		return 1;
 
 	for (upto = 0; upto < this_many; upto++) {

--- a/libs/System.c
+++ b/libs/System.c
@@ -321,7 +321,7 @@ int fvwm_mkstemp (char *template)
 	gettimeofday (&tv, NULL);
 	value = ((unsigned long) tv.tv_usec << 16) ^ tv.tv_sec ^ getpid ();
 
-	for (count = 0; count < TMP_MAX; value = 7777, count)
+	for (count = 0; count < TMP_MAX; value = 7777)
 	{
 		unsigned long v = value;
 

--- a/modules/FvwmIconMan/FvwmIconMan.h
+++ b/modules/FvwmIconMan/FvwmIconMan.h
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "libs/ftime.h"
 
@@ -190,8 +191,8 @@ typedef struct win_data {
 	window_flags flags;
 	struct win_data *win_prev, *win_next;
 	struct win_manager *manager;
-	int app_id_set : 1;
-	int geometry_set : 1;
+	bool app_id_set;
+	bool geometry_set;
 	Uchar complete;
 
 	/* this data must be freed */

--- a/modules/FvwmScript/FvwmScript.c
+++ b/modules/FvwmScript/FvwmScript.c
@@ -339,7 +339,7 @@ void Xinit(int IsFather)
 
   if (IsFather)
   {
-    size_t len = strlen("FvwmScript") + 5;
+    size_t len = strlen("FvwmScript") + 10;
     name = fxcalloc(sizeof(char), len);
     do
     {


### PR DESCRIPTION
This keeps clang happy by fixing some of its suggestions.
