### PR TITLE
Remove second FvwmPrompt link from htmldoc index page.

### DIFF
--- a/doc/index.adoc.in
+++ b/doc/index.adoc.in
@@ -33,6 +33,5 @@
 * xref:FvwmMFL.adoc[FvwmMFL]
 * xref:FvwmPager.adoc[FvwmPager]
 * xref:FvwmPerl.adoc[FvwmPerl]
-* xref:FvwmPrompt.adoc[FvwmPrompt]
 * xref:FvwmRearrange.adoc[FvwmRearrange]
 * xref:FvwmScript.adoc[FvwmScript]


### PR DESCRIPTION
I meant to include this with the other man page tweaks, but forgot until this morning so here it is.