### PR TITLE
FvwmPager: Allow dynamic updates via SendToModule

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -563,6 +563,29 @@ is an alias for this option and works the same.
 *FvwmPager: NoSeparators::
   Turns off the lines separating the pages of the virtual desktop.
 
+== SENDING COMMANDS
+
+Using the _SendToModule_ command, _FvwmPager_ can be sent the following
+list of commands: *Monitor*, *CurrentMonitor*, *DeskLabels*, *NoDeskLabels*,
+*MonitorLabels*, *NoMonitorLabels*, *CurrentDeskPerMonitor*,
+*CurrentDeskGlobal*, *IsShared*, and *IsNotShared*. Each command functions
+identically to its configuration option, changing the configuration of the
+running pager.
+
+**Note**: these commands work only on the running instance only, to make
+any changes permanent, update the relevant config file.
+
+For example, you can tell a running instance of _FvwmPager_ to track a
+specific monitor by sending it the following command:
+
+....
+SendToModule FvwmPager Monitor RandRname
+....
+
+This will either change which monitor is being shown or tell the pager to
+only show a specific monitor. Note that the special value of *none* will
+show all windows on all monitors.
+
 == AUTHOR
 
 Robert Nation +

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -964,7 +964,12 @@ void list_new_desk(unsigned long *body)
 	    mout != current_monitor->m &&
 	    (monitor_mode == MONITOR_TRACKING_M ||
 	    is_tracking_shared))))
+	{
+		/* Still need to update monitor location of other monitors. */
+		if (current_monitor != NULL && oldDesk != newDesk)
+			goto update_grid;
 		return;
+	}
 
 	/* Update the current desk. */
 	desk_i = newDesk;
@@ -1003,6 +1008,8 @@ void list_new_desk(unsigned long *body)
 
 	XStoreName(dpy, Scr.pager_w, style->label);
 	XSetIconName(dpy, Scr.pager_w, style->label);
+
+update_grid:
 	MovePage();
 	draw_desk_grid(oldDesk - desk1);
 	draw_desk_grid(newDesk - desk1);

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -295,6 +295,7 @@ void initialize_pager(void);
 void initialize_fpmonitor_windows(struct fpmonitor *);
 void initialize_viz_pager(void);
 Pixel GetSimpleColor(char *name);
+void set_desk_size(bool);
 void DispatchEvent(XEvent *Event);
 void ReConfigure(void);
 void ReConfigureAll(void);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -73,7 +73,6 @@ static rectangle set_vp_size_and_loc(struct fpmonitor *, bool is_icon);
 static struct fpmonitor *fpmonitor_from_xy(int x, int y);
 static struct fpmonitor *fpmonitor_from_n(int n);
 static int fpmonitor_count(void);
-static void set_desk_size(bool);
 static void fvwmrec_to_pager(rectangle *, bool, struct fpmonitor *);
 static void pagerrec_to_fvwm(rectangle *, bool, struct fpmonitor *);
 static char *get_label(const PagerWindow *pw,const char *fmt);


### PR DESCRIPTION
This makes FvwmPager listen to 'SendToModule' commands such that the following options can be configured on a running FvwmPager instance:

* DeskLabels
* NoDeskLabels
* Monitor RANDRNAME
* MonitorLabels
* NoMonitorLabels
* CurrentMonitor RANDRNAME
* CurrentDeskPerMonitor
* CurrentDeskGlobal
* IsShared
* IsNotShared

For example:

   SendToModule FvwmPager Monitor $[monitor.1.name]

Will force an already-running FvwmPager instance to only track that monitor.

This also fixes a bug with `CurrentMonitor` where the desk grids and monitor location were not correctly drawn found during testing this.