### PR TITLE
FvwmPager - DeskStyles

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -214,11 +214,19 @@ size may be slightly different than the specified size.
 For backwards compatibility the option, '*FvwmPager: DeskColor [desk] color',
 is an alias for this option and works the same.
 
-*FvwmPager: Hilight [desk] color::
-  Sets the background color for both the location of any active monitors (if
-  _DeskHilight_ is set) and the current desk label and/or monitor label if
-  _DeskLabels_ or _MonitorLabels_ is set. If _desk_ is not present or is
-  equal to '*', the color is used for all desks.
+*FvwmPager: HiFore [desk] color::
+  Sets the foreground color the for text used in the highlighted _DeskLabels_
+  and _MonitorLabels_ if _DeskHilight_ is set. If _desk_ is not present or
+  is equal to '*' the color is used for all desks.
+
+*FvwmPager: HiBack [desk] color::
+  Sets the background color the for the highlighted labels when using
+  _DeskLabels_ or _MonitorLabels_ or for the location of any active monitors.
+  Has no effect if _DeskHilight_ is not on. If _desk_ is not present or equal
+  to '*' the color is used for all desks.
++
+For backwards compatibility the option, '*FvwmPager: Hilight [desk] color',
+is an alias for this option and works the same.
 
 *FvwmPager: Colorset [desk] colorset::
   Sets the _colorset_ number (see fvwm3commands(1)) used for both the

--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -198,20 +198,58 @@ size may be slightly different than the specified size.
   fairly useless for desktop scales of 32 or greater. If _font_name_ is
   "none" then no window names will be displayed.
 
-*FvwmPager: Fore color::
-  Specifies the color to use to write the desktop labels, and to draw
-  the page-grid lines.
+*FvwmPager: Fore [desk] color::
+  Sets the foreground color, which is used to write desktop labels and to
+  draw the page-grid lines.  The _color_ is any valid 'X11/rgb.txt' color
+  name and _desk_ is an optional parameter which states what desk to set
+  the foreground color for. If _desk_ is not present or is equal to '*',
+  the color is used for all desks.
 
-*FvwmPager: Back color::
-  Specifies the background color for the window.
+*FvwmPager: Back [desk] color::
+  Sets the background color, which is used for the background of each desk.
+  The _color_ is any valid 'X11/rgb.txt' color name and _desk_ is an optional
+  parameter which states what desk to set the foreground color for. If _desk_
+  is not present or is equal to '*', the color is used for all desks.
++
+For backwards compatibility the option, '*FvwmPager: DeskColor [desk] color',
+is an alias for this option and works the same.
 
-*FvwmPager: Hilight color::
-  The active page and desk label will be highlighted by using this
-  background pattern instead of the normal background.
+*FvwmPager: Hilight [desk] color::
+  Sets the background color for both the location of any active monitors (if
+  _DeskHilight_ is set) and the current desk label and/or monitor label if
+  _DeskLabels_ or _MonitorLabels_ is set. If _desk_ is not present or is
+  equal to '*', the color is used for all desks.
 
-*FvwmPager: HilightPixmap pixmap::
-  The active page will be highlighted by using this background pattern
-  instead of the normal background.
+*FvwmPager: Colorset [desk] colorset::
+  Sets the _colorset_ number (see fvwm3commands(1)) used for both the
+  foreground and background of the optional _desk_. If _desk_ is not provided
+  or equal to '*', the colorset is used for all desks.
+
+*FvwmPager: BalloonColorset [desk] colorset::
+  Sets the _colorset_ number (see fvwm3commands(1)) used for both the
+  foreground and background of the balloon windows on the optional _desk_.
+  If _desk_ is not provided or equal to '*', the colorset is used for all
+  desks.
+
+*FvwmPager: HilightColorset [desk] colorset::
+  Sets the _colorset_ number (see fvwm3commands(1)) used for both the
+  foreground and background of the highlighted areas, which includes the
+  location of active monitors, and the desk and monitor labels. If _desk_
+  is not provided or equal to '*', the colorset is used for all desks.
+
+*FvwmPager: Pixmap [desk] pixmap::
+  Sets the _pixmap_ to be used as the background image instead of the _Back_
+  color for the desktop _desk_. If _desk_ is not provided or equal to '*',
+  the pixmap is used for all desks.
++
+For backwards compatibility the option,
+'*FvwmPager: DeskPixmap [desk] pixmap',
+is an alias for this option and works the same.
+
+*FvwmPager: HilightPixmap [desk] pixmap::
+  Sets the _pixmap_ to be used as the background image of the active monitor
+  locations instead of 'Hilight' color for the desktop _desk_. If _desk_ is
+  not provided or equal to '*', the pixmap is used for all desks.
 
 *FvwmPager: DeskHilight::
   Hilight the area shown by all active monitors with the current hilight
@@ -230,21 +268,6 @@ size may be slightly different than the specified size.
   window. Possible flags are: %t, %i, %c, and %r for the window's title,
   icon title, class, or resource name, respectively. The default is
   "%i".
-
-*FvwmPager: DeskColor desk color::
-  Assigns the color _color_ to desk _desk_ (or the current desk if desk
-  is "*") in the pager window. This replaces the background color for
-  the particular _desk_. This only works when the pager is full sized.
-  When Iconified, the pager uses the color specified by *FvwmPager:
-  Back.
-
-*FvwmPager: Pixmap pixmap::
-  Use _pixmap_ as background for the pager.
-
-*FvwmPager: DeskPixmap desk pixmap::
-  Assigns the pixmap _color_ to desk _desk_ (or the current desk if desk
-  is "*") in the pager window. This replaces the background pixmap for
-  the particular _desk_.
 
 *FvwmPager: DeskTopScale number::
   If the geometry is not specified, then a desktop reduction factor is
@@ -328,20 +351,6 @@ done about this - except not using SloppyFocus in the pager.
 *FvwmPager: BalloonStringFormat format::
   The same as _*FvwmPager: WindowLabelFormat_, it just specifies the
   string to display in the balloons. The default is "%i".
-
-*FvwmPager: Colorset desk colorset::
-  Tells the module to use colorset _colorset_ for _desk_. If you use an
-  asterisk '*' in place of _desk_, the colorset is used on all desks.
-
-*FvwmPager: BalloonColorset desk colorset::
-  Tells the module to use colorset _colorset_ for balloons on _desk_. If
-  you use an asterisk '*' in place of _desk_, the colorset is used on
-  all desks.
-
-*FvwmPager: HilightColorset desk colorset::
-  Tells the module to use colorset _colorset_ for hilighting on _desk_.
-  If you use an asterisk '*' in place of _desk_, the colorset is used on
-  all desks.
 
 *FvwmPager: WindowColorsets colorset activecolorset::
   Uses colorsets in the same way as *FvwmPager: WindowColors. The shadow

--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -174,17 +174,18 @@ size may be slightly different than the specified size.
   canceling the effect of the _ShapeLabels_ option.
 
 *FvwmPager: DeskLabels::
-  Tells FvwmPager to display a label for each desk. This is the default
-  state, but this is useful for undoing _Font none_ or _NoDeskLabels_.
+  Tells FvwmPager to display a label for each desk. If _LabelHilight_ is
+  set, the active desk will be highlighted. This is the default state,
+  but this is useful for undoing _Font none_ or _NoDeskLabels_.
 
 *FvwmPager: NoDeskLabels::
   Tells FvwmPager to not display desk labels.
 
 *FvwmPager: MonitorLabels::
-  Tells FvwmPager to display a row of monitor labels. The monitor label
-  on the desktop the monitor is currently viewing will be highlighted using
-  the hilight color. Clicking on a monitor label will move that monitor to
-  the selected desktop. This option is best used with
+  Tells FvwmPager to display a row of monitor labels. If _LabelHilight_ is
+  set, the monitor label on the desktop the monitor is currently viewing will
+  be highlighted using the hilight color. Clicking on a monitor label will
+  move that monitor to the selected desktop. This option is goes well with
   'DesktopConfiguration shared' to be able to control which monitor is moved
   to a selected desktop.
 
@@ -204,11 +205,21 @@ size may be slightly different than the specified size.
   "none" then no window names will be displayed.
 
 *FvwmPager: DeskHilight::
-  Hilight the area shown by all active monitors with the current hilight
+  Highlight the area shown by all active monitors with the current highlight
   color/pixmap. Useful for canceling the effect of the _NoDeskHilight_ option.
 
 *FvwmPager: NoDeskHilight::
-  Don't hilight the active page.
+  Don't highlight the active page.
+
+*FvwmPager: LabelHilight::
+  Highlight the label of the current monitor and/or desk. What is highlighted
+  depends on a combination of what _DesktopConfiguration_ is used and which
+  labels are shown. This is the default state.
+
+*FvwmPager: NoLabelHilight::
+  Don't highlight the current labels. This is useful when using pixmaps or
+  transparent colorsets, to remove the filled rectangle on the highlighted
+  label.
 
 *FvwmPager: WindowColors fore back hiFore hiBack::
   Change the normal/highlight colors of the windows. _fore_ and _hiFore_
@@ -448,6 +459,13 @@ is an alias for this option and works the same.
 *FvwmPager: HilightPixmap [desk] pixmap::
   Sets the _pixmap_ to be used as the background image of the active monitor
   locations instead of 'Hilight' color for the desktop _desk_.
+
+*FvwmPager: LabelPixmap [desk] True|False::
+  By default pixmaps are drawn in the root window for each desk, which covers
+  the labels. Turning this option by using _False_, _F_, or _0_, will draw
+  pixmaps only over the virtual desktop window. This option can be turned
+  back on with _True_, _T_, or _1_. Note, disabling this will not work with
+  transparent colorsets.
 
 == AUTHOR
 

--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -13,17 +13,18 @@ FvwmPager is spawned by fvwm, so no command line invocation will work.
 FvwmPager displays a miniature view of the fvwm virtual desktop(s) showing
 all desk numbers between _first desk_ and _last desk_. If _last desk_ is
 omitted only the _first desk_ is shown. If both desk numbers are omitted,
-the current desk is used instead. If you use an asterisk '*' in place of
-_first desk_ the pager will always show the current desktop, even when you
-switch desks. If you iconify FvwmPager, its icon on the virtual desktop
-will be a functional version of the pager only showing the current desktop.
+the current desk is used instead. If you use an asterisk, *{asterisk}*, in
+place of _first desk_ the pager will always show the current desktop, even
+when you switch desks. If you iconify FvwmPager, its icon on the virtual
+desktop will be a functional version of the pager only showing the current
+desktop.
 
-FvwmPager is launched via the `Module FvwmPager` command from fvwm's config
+FvwmPager is launched via the *Module FvwmPager* command from fvwm's config
 file, and can be launched from functions, menus, key bindings, and so on. If
 the pager is started with the _-transient_ option, the next time a button is
 released the pager is closed. Note that this option only works if the window
-style of the pager window is 'Sticky' (see the fvwm man page). You should use
-the 'StaysOnTop' style too.
+style of the pager window is _Sticky_ (see the fvwm man page). You should use
+the _StaysOnTop_ style too.
 
 The following example shows how to launch two pagers from your config file
 when fvwm starts. The first is a pager which will show all desks from 0 to
@@ -36,7 +37,7 @@ AddToFunc StartFunction Module FvwmPager *
 
 FvwmPager is configured via an fvwm module configuration alias. If an _alias_
 is given, FvwmPager will use the _alias_ for the configuration and name of the
-window. If no _alias_ is given, the default 'FvwmPager' alias is used. See the
+window. If no _alias_ is given, the default "FvwmPager" alias is used. See the
 *CONFIGURATION* section below for a full list of configuration options.
 
 == DESCRIPTION
@@ -47,34 +48,34 @@ _DeskHilight_ is set, the location of each monitor within the
 desktop is also shown. The pager can be used as a quick reference of the
 location of windows and monitors, to change the current page/desk, and to
 focus or move windows. The behavior of FvwmPager depends on the current
-'DesktopConfiguration'.
+_DesktopConfiguration_.
 
 When clicked with button 1, FvwmPager will move the current desk/page to the
-location clicked. If using 'DesktopConfiguration global' all monitors will
-move to the location clicked, 'DesktopConfiguration per-monitor' moves the
+location clicked. If using _DesktopConfiguration_ global all monitors will
+move to the location clicked, _DesktopConfiguration_ per-monitor moves the
 only the monitor which occupies the area clicked, and last
-'DesktopConfiguration shared' only allows changing pages of a monitor which
+_DesktopConfiguration_ shared only allows changing pages of a monitor which
 occupies the clicked desk. If _MonitorLabels_ are showing, clicks on the
 monitor label will move that monitor to the clicked desk. Clicks in which it
 cannot be clearly determined which monitor to move will be ignored, such as
-clicks on desk labels or dead space in 'per-monitor' mode, clicking on a desk
-not occupied by any monitor in 'shared' mode. It is suggested to use
-_MonitorLabels_ with 'shared' mode. There is also a special mode _IsShared_
-to better view the shared desktops in 'shared' mode.
+clicks on desk labels or dead space in per-monitor mode, clicking on a desk
+not occupied by any monitor in shared mode. It is suggested to use
+_MonitorLabels_ with shared mode. There is also a special mode _IsShared_
+to better view the shared desktops in shared mode.
 
 When clicked with button 3, FvwmPager will move the current view port centered
 on the area clicked. Unlike a left click, which always places the monitor(s)
-inside a single page's boundaries, left click will 'Scroll' between multiple
+inside a single page's boundaries, left click will _Scroll_ between multiple
 pages. While right click is held down, moving the mouse will cause the view
-port to 'Scroll' to the mouse location. Note that 'Scroll' works best in
-'global' mode.
+port to _Scroll_ to the mouse location. Note that _Scroll_ works best in
+_global_ mode.
 
 When button 2 clicks a window in the pager, that window will gain focus.
-Setting the _*FvwmPager: SloppyFocus_ option will give focus to the window
-under the mouse without clicking. Holding down button 2 on a window in the
-pager can be used the move the window. The window can be placed at any
-location inside the pager, and when you move the window outside of the pager,
-the window will move to the current location, and can continued to be moved.
+Setting the _SloppyFocus_ option will give focus to the window under the
+mouse without clicking. Holding down button 2 on a window in the pager can
+be used the move the window. The window can be placed at any location inside
+the pager, and when you move the window outside of the pager, the window will
+move to the current location, and can continued to be moved.
 
 When iconified, FvwmPager's icon on the desktop is a fully functional pager
 that only shows the current desk. This icon pager responds to all the same
@@ -85,7 +86,7 @@ the current desk. Note that the FvwmPager icon must be visible via
 
 FvwmPager will compute its initial window size based on your monitor(s)
 configuration. By default it makes a pager 1/32 the size of your monitor(s)
-resolution (see _DeskTopScale_) and matches either the global
+resolution (see _DesktopScale_) and matches either the global
 aspect ratio or a single monitor if _Monitor_ is set. Both the size of
 the pager (see _Geometry_) and desktop layout (see _Cols_ and _Rows_)
 can be configured.
@@ -93,7 +94,7 @@ can be configured.
 == CONFIGURATION
 
 FvwmPager is configured via a module configuration alias in fvwm's
-configuration file. The default alias is 'FvwmPager' and can be configured
+configuration file. The default alias is "FvwmPager" and can be configured
 using lines of the form:
 
 ....
@@ -117,31 +118,47 @@ are listed below.
 
 == CONFIGURATION OPTIONS
 
-The configuration options are split into two groups. First is the
-collection of options that affect the overall look and behavior of
-the pager. Below these is a collection of options that can style each
-desk individually, allowing each desk to have its own unique look.
+The configuration options are split into two groups to help organize
+the large list of configuration options the pager has. Below you can
+find configuration options for the *GEOMETRY*, *LABELS*, *HILIGHTING*,
+*WINDOW LOOKS*, *BALLOON WINDOWS*, *MOUSE BEHAVIOUR*, *MONITOR AND
+DESKTOP CONFIGURATION*, *DESK STYLES*, and *MISCELLANEOUS*.
+
+=== GEOMETRY
+
+Configures the size of the pager along with how the desktops are arranged
+in a grid when viewing more than one desktop.
 
 *FvwmPager: Geometry geometry::
-  Completely or partially specifies the pager windows location and
-  geometry, in standard X11 notation. If both width and height are
-  set, FvwmPager will use that size and no longer preserve the
-  aspect ratio when resized. If you wish to maintain an undistorted
-  aspect ratio, you can set one dimension to zero. For example
-  '400x0' will make a 400 pixel wide window whose height matches
-  the aspect ratio and will also preserve aspect ratio when resized.
+  Completely or partially specifies the pager's window size and location
+  as a _geometry_ string, 'WIDTHxHEIGHT+X+Y'. If both width and height
+  are set, FvwmPager will use that size, and not respect the aspect
+  ratio of the monitors. To maintain an undistorted aspect ratio, set
+  one dimension to zero. For example 400x0 will make a 400 pixel wide
+  window whose height matches the monitors aspect ratio.
 +
-*Note*: FvwmPager's dimensions will be slightly adjusted to ensure
-every page shown has the exact same number of pixels. So the actual
-size may be slightly different than the specified size.
+If _X_ or _Y_ are included in the geometry string, the pager will open
+at the specified position. The sign specifies which edge to measure from:
+_+X_ from the left edge, _-X_ from right edge, _+Y_ from top edge, or
+_-Y_ from bottom edge.
+
+*FvwmPager: DesktopScale number::
+  If the _Geometry_ is not specified, then a desktop reduction factor is
+  used to calculate the pager's size. The pager will scale a single page
+  to be 1/_number_ of the actual size. The final size of the pager window
+  is then based off the number of pages and/or desks shown. For example,
+  A _number_ of 10 will make each page a tenth of the actual size.
+  A default of 32 is used to size the pager.
 
 *FvwmPager: Rows rows::
-  Tells fvwm how many rows of desks to use when laying out the pager
-  window.
+  FvwmPager can show multiple virtual desktops at once. The desktops
+  can be arranged in a horizontal line (one row, the default behavior),
+  a vertical line (one column), or in a grid with multiple rows
+  and columns. This configures the number of rows used.
 
 *FvwmPager: Columns columns::
-  Tells fvwm how many columns of desks to use when laying out the pager
-  window.
+  Tells FvwmPager how many columns of desks to use when laying out the
+  grid of desktops.
 
 *FvwmPager: IconGeometry geometry::
   Specifies a size (optional) and location (optional) for the pager's
@@ -151,12 +168,19 @@ size may be slightly different than the specified size.
   location specification (used to specify a location relative to the
   bottom instead of the top of the screen).
 
-*FvwmPager: StartIconic::
-  Causes the pager to start iconified.
+=== LABELS
 
-*FvwmPager: NoStartIconic::
-  Causes the pager to start normally. Useful for canceling the effect of
-  the _StartIconic_ option.
+FvwmPager can add labels to each virtual desktop shown. The labels can
+show the name of the desktops and/or the name of the monitors. Labels
+can be used as buttons to move monitors between virtual desktops. They
+can be positioned either above or below each desktop. If _ShapeLabels_
+is set, only the labels on the current desktop are shown.
+
+*FvwmPager: Font font-name::
+  Specified a font to use to label the desktops. If _font_name_ is
+  "None" then no desktop or monitor labels will be displayed. Note,
+  if _MonitorLabels_ or _DeskLabels_ is used after _Font none_,
+  the labels will be shown with a default font.
 
 *FvwmPager: LabelsBelow::
   Causes the pager to draw desk labels below the corresponding desk.
@@ -166,8 +190,7 @@ size may be slightly different than the specified size.
   Useful for canceling the effect of the _LabelsBelow_ option.
 
 *FvwmPager: ShapeLabels::
-  Causes the pager to hide the labels of all but the current desk. This
-  turns off label hilighting.
+  Causes the pager to hide the labels of all but the current desk.
 
 *FvwmPager: NoShapeLabels::
   Causes the pager to show the labels of all visible desks. Useful for
@@ -192,24 +215,19 @@ size may be slightly different than the specified size.
 *FvwmPager: NoMonitorLabels::
   Tells FvwmPager to not display monitor labels, the default state.
 
-*FvwmPager: Font font-name::
-  Specified a font to use to label the desktops. If _font_name_ is
-  "none" then no desktop or monitor labels will be displayed. Note,
-  if _MonitorLabels_ or _DeskLabels_ is used after _Font none_,
-  the labels will be shown with a default font.
+=== HILIGHTING
 
-*FvwmPager: SmallFont font-name::
-  Specified a font to use to label the window names in the pager. If not
-  specified, the window labels will be omitted. Window labels seem to be
-  fairly useless for desktop scales of 32 or greater. If _font_name_ is
-  "none" then no window names will be displayed.
+FvwmPager will highlight the current location of each monitor in the virtual
+desktop. This can highlight both the area inside the desk, and the desk labels.
+Which labels are highlighted is a combination of the _DesktopConfiguration_
+and the below options.
 
 *FvwmPager: DeskHilight::
   Highlight the area shown by all active monitors with the current highlight
-  color/pixmap. Useful for canceling the effect of the _NoDeskHilight_ option.
+  color/pixmap. The default behavior.
 
 *FvwmPager: NoDeskHilight::
-  Don't highlight the active page.
+  Don't highlight the active monitor location.
 
 *FvwmPager: LabelHilight::
   Highlight the label of the current monitor and/or desk. What is highlighted
@@ -221,10 +239,24 @@ size may be slightly different than the specified size.
   transparent colorsets, to remove the filled rectangle on the highlighted
   label.
 
-*FvwmPager: WindowColors fore back hiFore hiBack::
-  Change the normal/highlight colors of the windows. _fore_ and _hiFore_
-  specify the colors as used for the font inside the windows. _back_ and
-  _hiBack_ are used to fill the windows with.
+=== WINDOW LOOKS
+
+The following options can be used to specify the general look of the mini
+windows. This includes labels, borders, mini icons, and how to deal with
+small windows. By default windows use the foreground (border and labels)
+and background of the colorset used in fvwm. See 'DESK STYLES' below for
+options to configure custom colors.
+
+*FvwmPager: WindowFont font-name::
+  Specify a font to use to label the mini windows in the pager. If not
+  specified, or set to "None", the window labels will be omitted. Window
+  labels are often far bigger than the mini window has space for, due to
+  how tiny the mini windows are and how long window names are.
+  'BALLOON WINDOWS' below can be configured to have a popup label that
+  appears when the mouse hovers over the window.
++
+Note, for backwards compatibility the option _SmallFont_ is an alias
+for this option.
 
 *FvwmPager: WindowLabelFormat format::
   This specifies a printf() like format for the labels in the mini
@@ -232,14 +264,74 @@ size may be slightly different than the specified size.
   icon title, class, or resource name, respectively. The default is
   "%i".
 
-*FvwmPager: DeskTopScale number::
-  If the geometry is not specified, then a desktop reduction factor is
-  used to calculate the pager's size. Things in the pager window are
-  shown at 1/_number_ of the actual size.
+*FvwmPager: WindowBorderWidth n::
+  Specifies the width of the border drawn around the mini windows. This
+  also affects the minimum size of the mini windows, which will be
+  2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 1.
+
+*FvwmPager: Window3DBorders::
+  Specifies that the mini windows should have a 3D borders based on the
+  mini window background. This option only works when windows are configured
+  using colorsets. See both _WindowColorset_ and _FocusColorset_ under
+  'DESK STYLES' below.
 
 *FvwmPager: MiniIcons::
-  Allow the pager to display a window's mini icon in the pager, if it
-  has one, instead of showing the window's name.
+  Allow the pager to display a window's mini icon in the pager, if it has
+  one, instead of showing the window's label. Note, when setting custom
+  _MiniIcons_ in fvwm, you may need to add the 'EWMHMiniIconOverride' style
+  for applications that supply an icon.
+
+*FvwmPager: WindowMinSize n::
+  Specifies the minimum size as _n_ pixels of the mini windows. This does
+  not include the width of the border, so the actual minimum size is
+  2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 3.
+
+*FvwmPager: HideSmallWindows::
+  Tells FvwmPager to not show windows that are the minimum size. Useful
+  for tiny pagers where small windows will appear out of place.
+
+=== BALLOON WINDOWS
+
+Balloon windows provide popup labels for each window when the mouse hovers
+over it. The label, font, color, and position of these balloon windows can
+be configured below.
+
+*FvwmPager: Balloons [type]::
+  Show a balloon describing the window when the pointer is moved into a
+  window in the pager. The default format (the window's icon name) can
+  be changed using _BalloonStringFormat_. If _type_ is "Pager" balloons
+  are just shown for an un-iconified pager; if _type_ is "Icon" balloons
+  are just shown for an iconified pager. If _type_ is anything else (or
+  null) balloons are always shown.
+
+*FvwmPager: BalloonFont font-name::
+  Specifies a font to use for the balloon text. Defaults to _fixed_.
+
+*FvwmPager: BalloonStringFormat format::
+  The same as _WindowLabelFormat_, this specifies the string to display in
+  the balloons. Possible flags are: %t, %i, %c, and %r for the window's
+  title, icon title, class, or resource name, respectively. The default is
+  "%i".
+
+*FvwmPager: BalloonBorderWidth number::
+  Sets the width of the balloon window's border. Defaults to 1.
+
+*FvwmPager: BalloonYOffset number::
+  The balloon window is positioned to be horizontally centered against
+  the pager window it is describing. The vertical position may be set as
+  an offset. Negative offsets of _-n_ are placed _n_ pixels above the
+  pager window, positive offsets of _+n_ are placed _n_ pixels below.
+  Offsets of -1 and 1 represent the balloon window close to the original
+  window without a gap. Offsets of 0 are not permitted, as this would
+  permit direct transit from pager window to balloon window, causing an
+  event loop. Defaults to +3. The offset will change sign automatically,
+  as needed, to keep the balloon on the screen.
+
+=== MOUSE BEHAVIOUR
+
+The mouse can be used to focus and move windows. Mouse button 2 (middle)
+can be used to focus (click) or move (hold and drag) the windows. These
+options can modify this behavior a bit.
 
 *FvwmPager: MoveThreshold pixels::
   Defines the distance the pointer has to be moved before a window being
@@ -267,81 +359,11 @@ done about this - except not using SloppyFocus in the pager.
   After moving a window using the pager (using mouse button 2), give the
   window focus if it is moved to the same desktop as the current monitor.
 
-*FvwmPager: SolidSeparators::
-  By default the pages of the virtual desktop are separated by dashed
-  lines in the pager window. This option causes FvwmPager to use solid
-  lines instead.
+=== MONITOR AND DESKTOP CONFIGURATION
 
-*FvwmPager: NoSeparators::
-  Turns off the lines separating the pages of the virtual desktop.
-
-*FvwmPager: Balloons [type]::
-  Show a balloon describing the window when the pointer is moved into a
-  window in the pager. The default format (the window's icon name) can
-  be changed using BalloonStringFormat. If _type_ is _Pager_ balloons
-  are just shown for an un-iconified pager; if _type_ is _Icon_ balloons
-  are just shown for an iconified pager. If _type_ is anything else (or
-  null) balloons are always shown.
-
-*FvwmPager: BalloonFore color::
-  Specifies the color for text in the balloon window. If omitted it
-  defaults to the foreground color for the window being described.
-
-*FvwmPager: BalloonBack color::
-  Specifies the background color for the balloon window. If omitted it
-  defaults to the background color for the window being described.
-
-*FvwmPager: BalloonFont font-name::
-  Specifies a font to use for the balloon text. Defaults to _fixed_.
-
-*FvwmPager: BalloonBorderWidth number::
-  Sets the width of the balloon window's border. Defaults to 1.
-
-*FvwmPager: BalloonBorderColor color::
-  Sets the color of the balloon window's border. Defaults to black.
-
-*FvwmPager: BalloonYOffset number::
-  The balloon window is positioned to be horizontally centered against
-  the pager window it is describing. The vertical position may be set as
-  an offset. Negative offsets of _-n_ are placed _n_ pixels above the
-  pager window, positive offsets of _+n_ are placed _n_ pixels below.
-  Offsets of -1 and 1 represent the balloon window close to the original
-  window without a gap. Offsets of 0 are not permitted, as this would
-  permit direct transit from pager window to balloon window, causing an
-  event loop. Defaults to +3. The offset will change sign automatically,
-  as needed, to keep the balloon on the screen.
-
-*FvwmPager: BalloonStringFormat format::
-  The same as _*FvwmPager: WindowLabelFormat_, it just specifies the
-  string to display in the balloons. The default is "%i".
-
-*FvwmPager: WindowColorsets colorset activecolorset::
-  Uses colorsets in the same way as *FvwmPager: WindowColors. The shadow
-  and hilight colors of the colorset are only used for the window
-  borders if the *FvwmPager: Window3DBorders is specified too.
-
-*FvwmPager: WindowMinSize n::
-  Specifies the minimum size as _n_ pixels of the mini windows. This does
-  not include the width of the border, so the actual minimum size is
-  2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 3.
-
-*FvwmPager: WindowBorderWidth n::
-  Specifies the width of the border drawn around the mini windows. This
-  also affects the minimum size of the mini windows, which will be
-  2 * _WindowBorderWidth_ + _WindowMinSize_. The default is 1.
-
-*FvwmPager: HideSmallWindows::
-  Tells FvwmPager to not show windows that are the minimum size. Useful
-  for tiny pagers where small windows will appear out of place.
-
-*FvwmPager: Window3DBorders::
-  Specifies that the mini windows should have a 3d borders based on the
-  mini window background. This option only works if *FvwmPager:
-  WindowColorsets is specified.
-
-*FvwmPager: UseSkipList::
-  Tells FvwmPager to not show the windows that are using the
-  WindowListSkip style.
+FvwmPager supports multiple monitors and the per-monitor and shared
+_DesktopConfigurations_. FvwmPager can further be configured to show
+only a single monitor or to interact with the monitors in specific ways.
 
 *FvwmPager: Monitor RandRName::
   Tells FvwmPager to display windows only on _RandRName_ monitor. This
@@ -382,7 +404,7 @@ done about this - except not using SloppyFocus in the pager.
 *FvwmPager: IsNotShared::
   This setting turns off the previous, _IsShared_, setting.
 
-== DESK STYLE OPTIONS
+=== DESK STYLES
 
 These configuration options can be used to configure the look of each desk
 the pager shows individually. The options all take one or two parameters,
@@ -399,7 +421,7 @@ don't mix colorsets and color names.
 Note setting an option for all desks will override any previous options set,
 so make sure to set the global options for all desks first, and the individual
 options for single desks second. For example, to make all desks use colorsets
-10 and 11 except desk 12 which uses colorsets 12 and 13, use the following:
+10 and 11 except desk 2 which uses colorsets 12 and 13, use the following:
 
 ....
 *FvwmPager: Colorset 10
@@ -407,6 +429,8 @@ options for single desks second. For example, to make all desks use colorsets
 *FvwmPager: Colorset 2 12
 *FvwmPager: HilightColorset 2 13
 ....
+
+==== COLORSETS
 
 *FvwmPager: Colorset [desk] colorset::
   Sets the _colorset_ number used by each desktop. This colorset is used
@@ -422,9 +446,27 @@ options for single desks second. For example, to make all desks use colorsets
   In addition pixmaps or transparency can be used for the background instead.
   This colorset overrides and sets both _HiFore_ and _HiBack_ below.
 
+*FvwmPager: WindowColorset [desk] colorset::
+  Sets the _colorset_ the mini windows use. The foreground is used for the
+  border and text labels, while the background color is used for the window
+  itself. If _Windows3DBorders_ is specified, the hilight and shadow colors
+  from the colorset are used to for the 3D beveled borders. Supports pixmaps
+  and transparent colorsets too.
+
+*FvwmPager: FocusColorset [desk] colorset::
+  Sets the _colorset_ for the focused mini window. This is the same as
+  _WindowColorset_, except it applies to the focus window.
+
+*FvwmPager: WindowColorsets WindowColorset FocusColorset::
+  This option is for backwards compatibility, and sets both the window
+  _WindowColorset_ and the _FocusColorset_ for all desktops. Use
+  the individual commands to set per desktop colorsets.
+
 *FvwmPager: BalloonColorset [desk] colorset::
   Sets the _colorset_ used for both the foreground, background, and borders
   of the balloon window.
+
+==== COLORS
 
 *FvwmPager: Fore [desk] color::
   Sets the foreground color, which is used to write desktop labels and to
@@ -448,6 +490,39 @@ is an alias for this option and works the same.
 For backwards compatibility the option, '*FvwmPager: Hilight [desk] color',
 is an alias for this option and works the same.
 
+*FvwmPager: WindowFore [desk] color::
+  Sets the foreground color for the mini windows. This color is used for the
+  borders and any text labels in the windows.
+
+*FvwmPager: WindowBack [desk] color::
+  Sets the background color for the mini windows.
+
+*FvwmPager: FocusFore [desk] color::
+  Same as _WindowFore_, except it sets the foreground color of the focused
+  window.
+
+*FvwmPager: FocusBack [desk] color::
+  Same as _WindowBack_, except it sets the background color of the focused
+  window.
+
+*FvwmPager: WindowColors WindowFore WindowBack FocusFore FocusBack::
+  This option is for backwards compatibility, and sets all four colors
+  _WindowFore_, _WindowBack_, _FocusFore_, and _FocusBack_ in a single command
+  for all desktops. Use the individual commands to set per desktop colors.
+
+*FvwmPager: BalloonFore [desk] color::
+  Specifies the color for text in the balloon window. If omitted it
+  defaults to the foreground color for the window being described.
+
+*FvwmPager: BalloonBack [desk] color::
+  Specifies the background color for the balloon window. If omitted it
+  defaults to the background color for the window being described.
+
+*FvwmPager: BalloonBorderColor [desk] color::
+  Sets the color of the balloon window's border. Defaults to black.
+
+==== PIXMAPS
+
 *FvwmPager: Pixmap [desk] pixmap::
   Sets the _pixmap_ to be used as the background image instead of the _Back_
   color for the desktop _desk_.
@@ -462,10 +537,31 @@ is an alias for this option and works the same.
 
 *FvwmPager: LabelPixmap [desk] True|False::
   By default pixmaps are drawn in the root window for each desk, which covers
-  the labels. Turning this option by using _False_, _F_, or _0_, will draw
-  pixmaps only over the virtual desktop window. This option can be turned
-  back on with _True_, _T_, or _1_. Note, disabling this will not work with
-  transparent colorsets.
+  the labels. Turning this option off by using _False_, _F_, or _0_, will draw
+  pixmaps only over the virtual desktop window, making the labels easier to
+  see. This option can be turned back on with _True_, _T_, or _1_. Note,
+  disabling this will not work with transparent colorsets.
+
+=== MISCELLANEOUS
+
+*FvwmPager: UseSkipList::
+  Tells FvwmPager to not show the windows that are using the
+  WindowListSkip style.
+
+*FvwmPager: StartIconic::
+  Causes the pager to start iconified.
+
+*FvwmPager: NoStartIconic::
+  Causes the pager to start normally. Useful for canceling the effect of
+  the _StartIconic_ option.
+
+*FvwmPager: SolidSeparators::
+  By default the pages of the virtual desktop are separated by dashed
+  lines in the pager window. This option causes FvwmPager to use solid
+  lines instead.
+
+*FvwmPager: NoSeparators::
+  Turns off the lines separating the pages of the virtual desktop.
 
 == AUTHOR
 

--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -117,6 +117,11 @@ are listed below.
 
 == CONFIGURATION OPTIONS
 
+The configuration options are split into two groups. First is the
+collection of options that affect the overall look and behavior of
+the pager. Below these is a collection of options that can style each
+desk individually, allowing each desk to have its own unique look.
+
 *FvwmPager: Geometry geometry::
   Completely or partially specifies the pager windows location and
   geometry, in standard X11 notation. If both width and height are
@@ -197,67 +202,6 @@ size may be slightly different than the specified size.
   specified, the window labels will be omitted. Window labels seem to be
   fairly useless for desktop scales of 32 or greater. If _font_name_ is
   "none" then no window names will be displayed.
-
-*FvwmPager: Fore [desk] color::
-  Sets the foreground color, which is used to write desktop labels and to
-  draw the page-grid lines.  The _color_ is any valid 'X11/rgb.txt' color
-  name and _desk_ is an optional parameter which states what desk to set
-  the foreground color for. If _desk_ is not present or is equal to '*',
-  the color is used for all desks.
-
-*FvwmPager: Back [desk] color::
-  Sets the background color, which is used for the background of each desk.
-  The _color_ is any valid 'X11/rgb.txt' color name and _desk_ is an optional
-  parameter which states what desk to set the foreground color for. If _desk_
-  is not present or is equal to '*', the color is used for all desks.
-+
-For backwards compatibility the option, '*FvwmPager: DeskColor [desk] color',
-is an alias for this option and works the same.
-
-*FvwmPager: HiFore [desk] color::
-  Sets the foreground color the for text used in the highlighted _DeskLabels_
-  and _MonitorLabels_ if _DeskHilight_ is set. If _desk_ is not present or
-  is equal to '*' the color is used for all desks.
-
-*FvwmPager: HiBack [desk] color::
-  Sets the background color the for the highlighted labels when using
-  _DeskLabels_ or _MonitorLabels_ or for the location of any active monitors.
-  Has no effect if _DeskHilight_ is not on. If _desk_ is not present or equal
-  to '*' the color is used for all desks.
-+
-For backwards compatibility the option, '*FvwmPager: Hilight [desk] color',
-is an alias for this option and works the same.
-
-*FvwmPager: Colorset [desk] colorset::
-  Sets the _colorset_ number (see fvwm3commands(1)) used for both the
-  foreground and background of the optional _desk_. If _desk_ is not provided
-  or equal to '*', the colorset is used for all desks.
-
-*FvwmPager: BalloonColorset [desk] colorset::
-  Sets the _colorset_ number (see fvwm3commands(1)) used for both the
-  foreground and background of the balloon windows on the optional _desk_.
-  If _desk_ is not provided or equal to '*', the colorset is used for all
-  desks.
-
-*FvwmPager: HilightColorset [desk] colorset::
-  Sets the _colorset_ number (see fvwm3commands(1)) used for both the
-  foreground and background of the highlighted areas, which includes the
-  location of active monitors, and the desk and monitor labels. If _desk_
-  is not provided or equal to '*', the colorset is used for all desks.
-
-*FvwmPager: Pixmap [desk] pixmap::
-  Sets the _pixmap_ to be used as the background image instead of the _Back_
-  color for the desktop _desk_. If _desk_ is not provided or equal to '*',
-  the pixmap is used for all desks.
-+
-For backwards compatibility the option,
-'*FvwmPager: DeskPixmap [desk] pixmap',
-is an alias for this option and works the same.
-
-*FvwmPager: HilightPixmap [desk] pixmap::
-  Sets the _pixmap_ to be used as the background image of the active monitor
-  locations instead of 'Hilight' color for the desktop _desk_. If _desk_ is
-  not provided or equal to '*', the pixmap is used for all desks.
 
 *FvwmPager: DeskHilight::
   Hilight the area shown by all active monitors with the current hilight
@@ -426,6 +370,84 @@ done about this - except not using SloppyFocus in the pager.
 
 *FvwmPager: IsNotShared::
   This setting turns off the previous, _IsShared_, setting.
+
+== DESK STYLE OPTIONS
+
+These configuration options can be used to configure the look of each desk
+the pager shows individually. The options all take one or two parameters,
+The first optional parameter is the _desk_ to configure and the second is
+the value to set. If the _desk_ is not provided, or a "*" is used, the
+setting applies to all desktops.
+
+Colorsets are preferred over color names. Once a colorset is configured, the
+related color settings will have no affect. When using colorsets, the pager
+will update if the colorset is changed in fvwm. Color names are still
+supported, and any valid 'X11/rgb.txt' name is accepted. For best results,
+don't mix colorsets and color names.
+
+Note setting an option for all desks will override any previous options set,
+so make sure to set the global options for all desks first, and the individual
+options for single desks second. For example, to make all desks use colorsets
+10 and 11 except desk 12 which uses colorsets 12 and 13, use the following:
+
+....
+*FvwmPager: Colorset 10
+*FvwmPager: HilightColorset 11
+*FvwmPager: Colorset 2 12
+*FvwmPager: HilightColorset 2 13
+....
+
+*FvwmPager: Colorset [desk] colorset::
+  Sets the _colorset_ number used by each desktop. This colorset is used
+  for the foreground text in the _DeskLabels_ and _MonitorLabels_, and
+  the background color for each desktop. The colorset can also set a
+  pixmap to use for the background, or be transparent. This colorset
+  overrides and sets both _Fore_ and _Back_ below.
+
+*FvwmPager: HilightColorset [desk] colorset::
+  Sets the _colorset_ for the highlighted monitor location and labels.
+  The foreground color is used for the text in highlighted labels, and the
+  background sets the color of both the labels and active monitor locations.
+  In addition pixmaps or transparency can be used for the background instead.
+  This colorset overrides and sets both _HiFore_ and _HiBack_ below.
+
+*FvwmPager: BalloonColorset [desk] colorset::
+  Sets the _colorset_ used for both the foreground, background, and borders
+  of the balloon window.
+
+*FvwmPager: Fore [desk] color::
+  Sets the foreground color, which is used to write desktop labels and to
+  draw the page-grid lines.
+
+*FvwmPager: Back [desk] color::
+  Sets the background color, which is used for the background of each desk.
++
+For backwards compatibility the option, '*FvwmPager: DeskColor [desk] color',
+is an alias for this option and works the same.
+
+*FvwmPager: HiFore [desk] color::
+  Sets the foreground color the for text used in the highlighted _DeskLabels_
+  and _MonitorLabels_ if _DeskHilight_ is set.
+
+*FvwmPager: HiBack [desk] color::
+  Sets the background color the for the highlighted labels when using
+  _DeskLabels_ or _MonitorLabels_, and sets the color used for the location
+  of any active monitors. Has no effect if _DeskHilight_ is not set.
++
+For backwards compatibility the option, '*FvwmPager: Hilight [desk] color',
+is an alias for this option and works the same.
+
+*FvwmPager: Pixmap [desk] pixmap::
+  Sets the _pixmap_ to be used as the background image instead of the _Back_
+  color for the desktop _desk_.
++
+For backwards compatibility the option,
+'*FvwmPager: DeskPixmap [desk] pixmap',
+is an alias for this option and works the same.
+
+*FvwmPager: HilightPixmap [desk] pixmap::
+  Sets the _pixmap_ to be used as the background image of the active monitor
+  locations instead of 'Hilight' color for the desktop _desk_.
 
 == AUTHOR
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -823,6 +823,7 @@ void list_destroy(unsigned long *body)
 		free(t->res_name);
 		free(t->window_name);
 		free(t->icon_name);
+		free(t->window_label);
 		free(t);
 	}
 }
@@ -1023,7 +1024,6 @@ void list_iconify(unsigned long *body)
 	if (t == NULL)
 		return;
 
-	t->t = (char *)body[2];
 	t->frame = body[1];
 	t->icon_x = body[3];
 	t->icon_y = body[4];
@@ -1588,7 +1588,6 @@ void ParseOptions(void)
 	bool MoveThresholdSetForModule = false;
 
 	FvwmPictureAttributes fpa;
-	Scr.FvwmRoot = NULL;
 	Scr.VScale = 32;
 
 	fpa.mask = 0;
@@ -2087,19 +2086,41 @@ void ExitPager(void)
 {
   DeskStyle *style, *style2;
   struct fpmonitor *fp, *fp1;
+  PagerWindow *t, *t2;
 
+  /* Screen */
+  free(Scr.balloon_label);
+
+  /* Monitors */
   TAILQ_FOREACH_SAFE(fp, &fp_monitor_q, entry, fp1) {
 	TAILQ_REMOVE(&fp_monitor_q, fp, entry);
 	free(fp->CPagerWin);
 	free(fp);
   }
 
+  /* DeskStyles */
   TAILQ_FOREACH_SAFE(style, &desk_style_q, entry, style2) {
 	TAILQ_REMOVE(&desk_style_q, style, entry);
 	free(style->label);
 	free(style);
   }
   free(Desks);
+
+  /* PagerWindows */
+	t2 = Start;
+	while (t2 != NULL) {
+		t = t2;
+		t2 = t2->next;
+
+		XDestroyWindow(dpy, t->PagerView);
+		XDestroyWindow(dpy, t->IconView);
+		free(t->res_class);
+		free(t->res_name);
+		free(t->window_name);
+		free(t->icon_name);
+		free(t->window_label);
+		free(t);
+	}
 
   if (is_transient)
   {

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -918,8 +918,8 @@ void list_new_page(unsigned long *body)
 	}
 
 	if (do_reconfigure) {
-		MovePage(false);
-		MoveStickyWindow(true, false);
+		MovePage();
+		MoveStickyWindows(true, false);
 		Hilight(FocusWin,true);
 	}
 }
@@ -995,14 +995,15 @@ void list_new_desk(unsigned long *body)
 		Desks[0].style = style;
 		update_desk_background(0);
 		update_monitor_backgrounds(0);
+		ReConfigureAll();
 	}
 
 	XStoreName(dpy, Scr.Pager_w, style->label);
 	XSetIconName(dpy, Scr.Pager_w, style->label);
-	MovePage(true);
+	MovePage();
 	DrawGrid(oldDesk - desk1, None, NULL);
 	DrawGrid(newDesk - desk1, None, NULL);
-	MoveStickyWindow(false, true);
+	MoveStickyWindows(false, true);
 	Hilight(FocusWin, true);
 }
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -1933,10 +1933,12 @@ void ParseOptions(void)
 				style->hiPixmap = PCacheFvwmPicture(dpy,
 					Scr.pager_w, ImagePath, arg2, fpa);
 			}
-		} else if (StrEquals(resource, "SmallFont")) {
+		} else if (StrEquals(resource, "WindowFont") ||
+			   StrEquals(resource, "SmallFont"))
+		{
 			free(smallFont);
 			CopyStringWithQuotes(&smallFont, next);
-			if (strncasecmp(smallFont,"none",4) == 0) {
+			if (strncasecmp(smallFont, "none", 4) == 0) {
 				free(smallFont);
 				smallFont = NULL;
 			}
@@ -1944,7 +1946,7 @@ void ParseOptions(void)
 			sscanf(next, "%d", &Rows);
 		} else if (StrEquals(resource, "Columns")) {
 			sscanf(next, "%d", &Columns);
-		} else if (StrEquals(resource, "DeskTopScale")) {
+		} else if (StrEquals(resource, "DesktopScale")) {
 			sscanf(next, "%d", &Scr.VScale);
 		} else if (StrEquals(resource, "WindowBorderWidth")) {
 			MinSize = MinSize - 2*WindowBorderWidth;

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -26,6 +26,7 @@
 #include <sys/wait.h>
 #include "libs/FScreen.h"
 #include "libs/ftime.h"
+#include "libs/safemalloc.h"
 #include <ctype.h>
 
 #ifdef HAVE_SYS_BSDTYPES_H
@@ -54,9 +55,6 @@
  *
  */
 /* Colors, Pixmaps, Fonts, etc. */
-char		*HilightC = NULL;
-char		*PagerFore = NULL;
-char		*PagerBack = NULL;
 char		*smallFont = NULL;
 char		*ImagePath = NULL;
 char		*WindowBack = NULL;
@@ -71,9 +69,6 @@ char		*WindowLabelFormat = NULL;
 char		*BalloonTypeString = NULL;
 char		*BalloonBorderColor = NULL;
 char		*BalloonFormatString = NULL;
-Pixel		hi_pix;
-Pixel		back_pix;
-Pixel		fore_pix;
 Pixel		focus_pix;
 Pixel		win_back_pix;
 Pixel		win_fore_pix;
@@ -83,8 +78,6 @@ Pixel		win_hi_fore_pix;
 Pixmap		default_pixmap = None;
 FlocaleFont	*Ffont;
 FlocaleFont	*FwindowFont;
-FvwmPicture	*PixmapBack = NULL;
-FvwmPicture	*HilightPixmap = NULL;
 FlocaleWinString	*FwinString;
 
 /* Sizes / Dimensions */
@@ -280,9 +273,12 @@ int main(int argc, char **argv)
 	default_style->colorset = -1;
 	default_style->highcolorset = -1;
 	default_style->ballooncolorset = -1;
-	default_style->label = NULL;
-	default_style->Dcolor = NULL;
+	default_style->label = fxstrdup("-");
+	default_style->fgColor = fxstrdup("black");
+	default_style->bgColor = fxstrdup("white");
+	default_style->hiColor = fxstrdup("grey");
 	default_style->bgPixmap = NULL;
+	default_style->hiPixmap = NULL;
 	TAILQ_INSERT_TAIL(&desk_style_q, default_style, entry);
   }
 
@@ -457,20 +453,8 @@ int main(int argc, char **argv)
     yneg = false;
   }
 
-  if (PagerFore == NULL)
-    PagerFore = fxstrdup("black");
-
-  if (PagerBack == NULL)
-    PagerBack = fxstrdup("white");
-
-  if (HilightC == NULL)
-    HilightC = fxstrdup(PagerFore);
-
   if (WindowLabelFormat == NULL)
     WindowLabelFormat = fxstrdup("%i");
-
-  if ((HilightC == NULL) && (HilightPixmap == NULL))
-    HilightDesks = false;
 
   if (BalloonBorderColor == NULL)
     BalloonBorderColor = fxstrdup("black");
@@ -1509,7 +1493,6 @@ void ParseOptions(void)
 {
 	char *tline= NULL;
 	char *mname;
-	int desk;
 	bool MoveThresholdSetForModule = false;
 
 	FvwmPictureAttributes fpa;
@@ -1564,7 +1547,7 @@ void ParseOptions(void)
 
 			int val;
 			if (GetIntegerArguments(next, NULL, &val, 1) > 0)
-				MoveThreshold = (val => 0) ? val :
+				MoveThreshold = (val >= 0) ? val :
 						DEFAULT_PAGER_MOVE_THRESHOLD;
 			continue;
 		} else if (StrEquals(token, "DesktopName")) {
@@ -1588,37 +1571,10 @@ void ParseOptions(void)
 		tline2 = GetModuleResource(tline, &resource, MyName);
 		if (!resource)
 			continue;
-		tline2 = GetNextToken(tline2, &arg1);
-		if (!arg1)
-		{
-			arg1 = fxmalloc(1);
-			arg1[0] = 0;
-		}
-		tline2 = GetNextToken(tline2, &arg2);
-		if (!arg2)
-		{
-			arg2 = fxmalloc(1);
-			arg2[0] = 0;
-		}
 
-		if (StrEquals(resource, "Monitor")) {
-			free(preferred_monitor);
-			next = SkipSpaces(next, NULL, 0);
-			if (StrEquals(next, "none")) {
-				monitor_to_track = NULL;
-				preferred_monitor = NULL;
-				continue;
-			}
-			monitor_to_track = fpmonitor_by_name(next);
-			/* Fallback to current monitor. */
-			if (monitor_to_track == NULL)
-				monitor_to_track = fpmonitor_this(NULL);
-			preferred_monitor = fxstrdup(next);
-		} else if (StrEquals(resource, "CurrentMonitor")) {
-			next = SkipSpaces(next, NULL, 0);
-			current_monitor = (StrEquals(next, "none")) ?
-				NULL : fpmonitor_by_name(next);
-		} else if (StrEquals(resource, "DeskLabels")) {
+		/* Start by looking for options with no parameters. */
+		flags = 1;
+		if (StrEquals(resource, "DeskLabels")) {
 			use_desk_label = true;
 		} else if (StrEquals(resource, "NoDeskLabels")) {
 			use_desk_label = false;
@@ -1634,6 +1590,86 @@ void ParseOptions(void)
 			IsShared = true;
 		} else if (StrEquals(resource, "IsNotShared")) {
 			IsShared = false;
+		} else if (StrEquals(resource, "DeskHilight")) {
+			HilightDesks = true;
+		} else if (StrEquals(resource, "NoDeskHilight")) {
+			HilightDesks = false;
+		} else if (StrEquals(resource, "MiniIcons")) {
+			MiniIcons = true;
+		} else if (StrEquals(resource, "StartIconic")) {
+			StartIconic = true;
+		} else if (StrEquals(resource, "NoStartIconic")) {
+			StartIconic = false;
+		} else if (StrEquals(resource, "LabelsBelow")) {
+			LabelsBelow = true;
+		} else if (StrEquals(resource, "LabelsAbove")) {
+			LabelsBelow = false;
+		} else if (StrEquals(resource, "ShapeLabels")) {
+			if (FHaveShapeExtension)
+				ShapeLabels = true;
+		} else if (StrEquals(resource, "NoShapeLabels")) {
+			ShapeLabels = false;
+		} else if (StrEquals(resource, "HideSmallWindows")) {
+			HideSmallWindows = true;
+		} else if (StrEquals(resource, "Window3dBorders")) {
+			WindowBorders3d = true;
+		} else if (StrEquals(resource,"UseSkipList")) {
+			UseSkipList = true;
+		} else if (StrEquals(resource, "SloppyFocus")) {
+			do_focus_on_enter = true;
+		} else if (StrEquals(resource, "FocusAfterMove")) {
+			FocusAfterMove = true;
+		} else if (StrEquals(resource, "SolidSeparators")) {
+			use_dashed_separators = false;
+			use_no_separators = false;
+		} else if (StrEquals(resource, "NoSeparators")) {
+			use_no_separators = true;
+		} else {
+			/* No Match, set this to continue parsing. */
+			flags = 0;
+		}
+		if (flags == 1) {
+			free(resource);
+			continue;
+		}
+
+		/* Now look for options with additional inputs.
+		 * Many inputs are of the form: [desk] value
+		 * Since desk is optional, inputs are stored as:
+		 *     One input:  arg1 = '*';     arg2 = input1
+		 *     Two inputs: arg1 = input1;  arg2 = input2
+		 * Options that expect one input should use "next".
+		 */
+		tline2 = GetNextToken(tline2, &arg1);
+		if (!arg1)
+			/* No inputs, nothing to do. */
+			continue;
+
+		tline2 = GetNextToken(tline2, &arg2);
+		if (!arg2)
+		{
+			arg2 = arg1;
+			arg1 = NULL;
+			arg1 = fxmalloc(1);
+			arg1[0] = '*';
+		}
+
+		next = SkipSpaces(next, NULL, 0);
+		if (StrEquals(resource, "Monitor")) {
+			free(preferred_monitor);
+			if (StrEquals(next, "none")) {
+				monitor_to_track = NULL;
+				preferred_monitor = NULL;
+				goto free_vars;
+			}
+			monitor_to_track = fpmonitor_by_name(next);
+			/* Fallback to current monitor. */
+			if (monitor_to_track == NULL)
+				monitor_to_track = fpmonitor_this(NULL);
+			preferred_monitor = fxstrdup(next);
+		} else if (StrEquals(resource, "CurrentMonitor")) {
+			current_monitor = (StrEquals(next, "none")) ?
+				NULL : fpmonitor_by_name(next);
 		} else if(StrEquals(resource,"Colorset")) {
 			ParseColorset(arg1, arg2,
 				&(((DeskStyle *)(NULL))->colorset));
@@ -1645,7 +1681,7 @@ void ParseOptions(void)
 				&(((DeskStyle *)(NULL))->highcolorset));
 		} else if (StrEquals(resource, "Geometry")) {
 			flags = FScreenParseGeometry(
-					arg1, &g_x, &g_y, &width, &height);
+					next, &g_x, &g_y, &width, &height);
 			if (flags & WidthValue)
 				pwindow.width = width;
 			if (flags & HeightValue)
@@ -1664,7 +1700,7 @@ void ParseOptions(void)
 			}
 		} else if (StrEquals(resource, "IconGeometry")) {
 			flags = FScreenParseGeometry(
-					arg1, &g_x, &g_y, &width, &height);
+					next, &g_x, &g_y, &width, &height);
 			if (flags & WidthValue)
 				icon.width = width;
 			if (flags & HeightValue)
@@ -1689,82 +1725,115 @@ void ParseOptions(void)
 				font_string = NULL;
 			}
 		} else if (StrEquals(resource, "Fore")) {
-			if (Pdepth > 1) {
-				free(PagerFore);
-				CopyString(&PagerFore,arg1);
-			}
-		} else if (StrEquals(resource, "Back")) {
-			if (Pdepth > 1) {
-				free(PagerBack);
-				CopyString(&PagerBack,arg1);
-			}
-		} else if (StrEquals(resource, "DeskColor")) {
+			if (Pdepth == 0)
+				goto free_vars;
+
 			DeskStyle *style;
-
-			if (StrEquals(arg1, "*")) {
-				desk = 0;
-			} else {
-				desk = desk1;
-				sscanf(arg1, "%d", &desk);
-			}
-
-			style = FindDeskStyle(desk);
-			if (style->Dcolor)
-				free(style->Dcolor);
-			style->Dcolor = NULL;
-			CopyString(&(style->Dcolor), arg2);
-		} else if (StrEquals(resource, "DeskPixmap")) {
-			DeskStyle *style;
-
-			if (StrEquals(arg1, "*")) {
-				desk = 0;
-			}
-			else
-			{
-				desk = desk1;
-				sscanf(arg1, "%d", &desk);
-			}
-
-			style = FindDeskStyle(desk);
-			if (style->bgPixmap != NULL)
-			{
-				PDestroyFvwmPicture(dpy, style->bgPixmap);
-				style->bgPixmap = NULL;
-			}
-
-			style->bgPixmap = PCacheFvwmPicture(
-				dpy, Scr.Pager_w, ImagePath, arg2, fpa);
-		} else if (StrEquals(resource, "Pixmap")) {
-			if(Pdepth > 1)
-			{
-				if (PixmapBack) {
-					PDestroyFvwmPicture(dpy, PixmapBack);
-					PixmapBack = NULL;
+			if (arg1[0] == '*') {
+				TAILQ_FOREACH(style, &desk_style_q, entry) {
+					free(style->fgColor);
+					CopyString(&(style->fgColor), arg2);
 				}
+			} else {
+				int desk = 0;
+				sscanf(arg1, "%d", &desk);
+				style = FindDeskStyle(desk);
+				free(style->fgColor);
+				CopyString(&(style->fgColor), arg2);
+			}
+		} else if (StrEquals(resource, "Back") ||
+			   StrEquals(resource, "DeskColor"))
+		{
+			if (Pdepth == 0)
+				goto free_vars;
 
-				PixmapBack = PCacheFvwmPicture(dpy,
-					Scr.Pager_w, ImagePath, arg1, fpa);
+			DeskStyle *style;
+			if (arg1[0] == '*') {
+				TAILQ_FOREACH(style, &desk_style_q, entry) {
+					free(style->bgColor);
+					CopyString(&(style->bgColor), arg2);
+				}
+			} else {
+				int desk = 0;
+				sscanf(arg1, "%d", &desk);
+				style = FindDeskStyle(desk);
+				free(style->bgColor);
+				CopyString(&(style->bgColor), arg2);
+			}
+		} else if (StrEquals(resource, "Hilight")) {
+			if (Pdepth == 0)
+				goto free_vars;
+
+			DeskStyle *style;
+			if (arg1[0] == '*') {
+				TAILQ_FOREACH(style, &desk_style_q, entry) {
+					free(style->hiColor);
+					CopyString(&(style->hiColor), arg2);
+				}
+			} else {
+				int desk = 0;
+				sscanf(arg1, "%d", &desk);
+				style = FindDeskStyle(desk);
+				free(style->hiColor);
+				CopyString(&(style->hiColor), arg2);
+			}
+		} else if (StrEquals(resource, "Pixmap") ||
+			   StrEquals(resource, "DeskPixmap"))
+		{
+			if (Pdepth == 0)
+				goto free_vars;
+
+			DeskStyle *style;
+			if (arg1[0] == '*') {
+				TAILQ_FOREACH(style, &desk_style_q, entry) {
+					if (style->bgPixmap != NULL) {
+						PDestroyFvwmPicture(
+							dpy, style->bgPixmap);
+						style->bgPixmap = NULL;
+					}
+					style->bgPixmap = PCacheFvwmPicture(
+						dpy, Scr.Pager_w, ImagePath,
+						arg2, fpa);
+				}
+			} else {
+				int desk = 0;
+				sscanf(arg1, "%d", &desk);
+				style = FindDeskStyle(desk);
+				if (style->bgPixmap != NULL) {
+					PDestroyFvwmPicture(
+						dpy, style->bgPixmap);
+					style->bgPixmap = NULL;
+				}
+				style->bgPixmap = PCacheFvwmPicture(dpy,
+					Scr.Pager_w, ImagePath, arg2, fpa);
 			}
 		} else if (StrEquals(resource, "HilightPixmap")) {
-			if(Pdepth > 1)
-			{
-				if (HilightPixmap) {
-					PDestroyFvwmPicture(
-						dpy, HilightPixmap);
-					HilightPixmap = NULL;
-				}
+			if (Pdepth == 0)
+				goto free_vars;
 
-				HilightPixmap = PCacheFvwmPicture(dpy,
-					Scr.Pager_w, ImagePath, arg1, fpa);
-			}
-		} else if (StrEquals(resource, "DeskHilight")) {
-			HilightDesks = true;
-		} else if (StrEquals(resource, "NoDeskHilight")) {
-			HilightDesks = false;
-		} else if (StrEquals(resource, "Hilight")) {
-			if(Pdepth > 1) {
-				free(HilightC);
-				CopyString(&HilightC,arg1);
+			DeskStyle *style;
+			if (arg1[0] == '*') {
+				TAILQ_FOREACH(style, &desk_style_q, entry) {
+					if (style->hiPixmap != NULL) {
+						PDestroyFvwmPicture(
+							dpy, style->hiPixmap);
+						style->hiPixmap = NULL;
+					}
+					style->hiPixmap = PCacheFvwmPicture(
+						dpy, Scr.Pager_w, ImagePath,
+						arg2, fpa);
+				}
+			} else {
+				int desk = 0;
+				sscanf(arg1, "%d", &desk);
+				style = FindDeskStyle(desk);
+				if (style->hiPixmap != NULL) {
+					PDestroyFvwmPicture(
+						dpy, style->hiPixmap);
+					style->hiPixmap = NULL;
+				}
+				style->hiPixmap = PCacheFvwmPicture(dpy,
+					Scr.Pager_w, ImagePath, arg2, fpa);
 			}
 		} else if (StrEquals(resource, "SmallFont")) {
 			free(smallFont);
@@ -1773,28 +1842,12 @@ void ParseOptions(void)
 				free(smallFont);
 				smallFont = NULL;
 			}
-		} else if (StrEquals(resource, "MiniIcons")) {
-			MiniIcons = true;
-		} else if (StrEquals(resource, "StartIconic")) {
-			StartIconic = true;
-		} else if (StrEquals(resource, "NoStartIconic")) {
-			StartIconic = false;
-		} else if (StrEquals(resource, "LabelsBelow")) {
-			LabelsBelow = true;
-		} else if (StrEquals(resource, "LabelsAbove")) {
-			LabelsBelow = false;
-		} else if (FHaveShapeExtension &&
-			   StrEquals(resource, "ShapeLabels"))
-		{
-			ShapeLabels = true;
-		} else if (StrEquals(resource, "NoShapeLabels")) {
-			ShapeLabels = false;
 		} else if (StrEquals(resource, "Rows")) {
-			sscanf(arg1, "%d", &Rows);
+			sscanf(next, "%d", &Rows);
 		} else if (StrEquals(resource, "Columns")) {
-			sscanf(arg1, "%d", &Columns);
+			sscanf(next, "%d", &Columns);
 		} else if (StrEquals(resource, "DeskTopScale")) {
-			sscanf(arg1,"%d",&Scr.VScale);
+			sscanf(next, "%d", &Scr.VScale);
 		} else if (StrEquals(resource, "WindowColors")) {
 			if (Pdepth > 1)
 			{
@@ -1809,33 +1862,27 @@ void ParseOptions(void)
 			}
 		} else if (StrEquals(resource, "WindowBorderWidth")) {
 			MinSize = MinSize - 2*WindowBorderWidth;
-			sscanf(arg1, "%d", &WindowBorderWidth);
+			sscanf(next, "%d", &WindowBorderWidth);
 			if (WindowBorderWidth > 0)
 				MinSize = 2 * WindowBorderWidth + MinSize;
 			else
 				MinSize = MinSize + 2 *
 					  DEFAULT_PAGER_WINDOW_BORDER_WIDTH;
 		} else if (StrEquals(resource, "WindowMinSize")) {
-			sscanf(arg1, "%d", &MinSize);
+			sscanf(next, "%d", &MinSize);
 			if (MinSize > 0)
 				MinSize = 2 * WindowBorderWidth + MinSize;
 			else
 				MinSize = 2 * WindowBorderWidth +
 					  DEFAULT_PAGER_WINDOW_MIN_SIZE;
-		} else if (StrEquals(resource, "HideSmallWindows")) {
-			HideSmallWindows = true;
-		} else if (StrEquals(resource, "Window3dBorders")) {
-			WindowBorders3d = true;
 		} else if (StrEquals(resource,"WindowColorsets")) {
-			sscanf(arg1,"%d",&windowcolorset);
+			sscanf(arg1, "%d", &windowcolorset);
 			AllocColorset(windowcolorset);
-			sscanf(arg2,"%d",&activecolorset);
+			sscanf(arg2, "%d", &activecolorset);
 			AllocColorset(activecolorset);
 		} else if (StrEquals(resource,"WindowLabelFormat")) {
 			free(WindowLabelFormat);
-			CopyString(&WindowLabelFormat,arg1);
-		} else if (StrEquals(resource,"UseSkipList")) {
-			UseSkipList = true;
+			CopyString(&WindowLabelFormat, next);
 		} else if (StrEquals(resource, "MoveThreshold")) {
 			int val;
 			if (GetIntegerArguments(next, NULL, &val, 1) > 0 &&
@@ -1844,18 +1891,9 @@ void ParseOptions(void)
 				MoveThreshold = val;
 				MoveThresholdSetForModule = true;
 			}
-		} else if (StrEquals(resource, "SloppyFocus")) {
-			do_focus_on_enter = true;
-		} else if (StrEquals(resource, "FocusAfterMove")) {
-			FocusAfterMove = true;
-		} else if (StrEquals(resource, "SolidSeparators")) {
-			use_dashed_separators = false;
-			use_no_separators = false;
-		} else if (StrEquals(resource, "NoSeparators")) {
-			use_no_separators = true;
 		} else if (StrEquals(resource, "Balloons")) {
 			free(BalloonTypeString);
-			CopyString(&BalloonTypeString, arg1);
+			CopyString(&BalloonTypeString, next);
 
 			if (StrEquals(BalloonTypeString, "Pager")) {
 				ShowPagerBalloons = true;
@@ -1879,24 +1917,24 @@ void ParseOptions(void)
 			if (Pdepth > 1)
 			{
 				free(BalloonBack);
-				CopyString(&BalloonBack, arg1);
+				CopyString(&BalloonBack, next);
 			}
 		} else if (StrEquals(resource, "BalloonFore")) {
 			if (Pdepth > 1)
 			{
 				free(BalloonFore);
-				CopyString(&BalloonFore, arg1);
+				CopyString(&BalloonFore, next);
 			}
 		} else if (StrEquals(resource, "BalloonFont")) {
 			free(BalloonFont);
 			CopyStringWithQuotes(&BalloonFont, next);
 		} else if (StrEquals(resource, "BalloonBorderColor")) {
 			free(BalloonBorderColor);
-			CopyString(&BalloonBorderColor, arg1);
+			CopyString(&BalloonBorderColor, next);
 		} else if (StrEquals(resource, "BalloonBorderWidth")) {
-			sscanf(arg1, "%d", &BalloonBorderWidth);
+			sscanf(next, "%d", &BalloonBorderWidth);
 		} else if (StrEquals(resource, "BalloonYOffset")) {
-			sscanf(arg1, "%d", &BalloonYOffset);
+			sscanf(next, "%d", &BalloonYOffset);
 			if (BalloonYOffset == 0)
 			{
 				fvwm_debug(__func__,
@@ -1913,9 +1951,10 @@ void ParseOptions(void)
 			}
 		} else if (StrEquals(resource,"BalloonStringFormat")) {
 			free(BalloonFormatString);
-			CopyString(&BalloonFormatString,arg1);
+			CopyString(&BalloonFormatString, next);
 		}
 
+free_vars:
 		free(resource);
 		free(arg1);
 		free(arg2);
@@ -1936,24 +1975,23 @@ DeskStyle *FindDeskStyle(int desk)
 	}
 
 	/* No matching style found. Create new style and return it. */
-	DeskStyle *new_style;
+	style = NULL;
 	DeskStyle *default_style = TAILQ_FIRST(&desk_style_q);
-	char label[10];
 
-	new_style = fxcalloc(1, sizeof(DeskStyle));
-	new_style->desk = desk;
-	new_style->colorset = default_style->colorset;;
-	new_style->highcolorset = default_style->highcolorset;
-	new_style->ballooncolorset = default_style->ballooncolorset;
-	snprintf(label, sizeof(label), "Desk %d", desk);
-	new_style->label = fxstrdup(label);
-	new_style->Dcolor = NULL;
-	if (default_style->Dcolor)
-		new_style->Dcolor = fxstrdup(default_style->Dcolor);
-	new_style->bgPixmap = default_style->bgPixmap;
-	TAILQ_INSERT_TAIL(&desk_style_q, new_style, entry);
+	style = fxcalloc(1, sizeof(DeskStyle));
+	style->desk = desk;
+	style->colorset = default_style->colorset;;
+	style->highcolorset = default_style->highcolorset;
+	style->ballooncolorset = default_style->ballooncolorset;
+	xasprintf(&style->label, "Desk %d", desk);
+	style->fgColor = fxstrdup(default_style->fgColor);
+	style->bgColor = fxstrdup(default_style->bgColor);
+	style->hiColor = fxstrdup(default_style->hiColor);
+	style->bgPixmap = default_style->bgPixmap;
+	style->hiPixmap = default_style->hiPixmap;
+	TAILQ_INSERT_TAIL(&desk_style_q, style, entry);
 
-	return new_style;
+	return style;
 }
 
 void ExitPager(void)
@@ -1969,10 +2007,10 @@ void ExitPager(void)
 
   TAILQ_FOREACH_SAFE(style, &desk_style_q, entry, style2) {
 	TAILQ_REMOVE(&desk_style_q, style, entry);
-	if (style->label)
-		free(style->label);
-	if (style->Dcolor)
-		free(style->Dcolor);
+	free(style->label);
+	free(style->fgColor);
+	free(style->bgColor);
+	free(style->hiColor);
 	free(style);
   }
   free(Desks);

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -188,6 +188,7 @@ void fpmonitor_disable(struct fpmonitor *fp)
 
 	if (fp == monitor_to_track)
 		monitor_to_track = fpmonitor_this(NULL);
+
 }
 
 struct fpmonitor *
@@ -994,6 +995,7 @@ void list_new_desk(unsigned long *body)
 		/* Update DeskStyle */
 		Desks[0].style = style;
 		update_desk_background(0);
+		update_monitor_locations(0);
 		update_monitor_backgrounds(0);
 		ReConfigureAll();
 	}
@@ -1001,8 +1003,8 @@ void list_new_desk(unsigned long *body)
 	XStoreName(dpy, Scr.Pager_w, style->label);
 	XSetIconName(dpy, Scr.Pager_w, style->label);
 	MovePage();
-	DrawGrid(oldDesk - desk1, None, NULL);
-	DrawGrid(newDesk - desk1, None, NULL);
+	draw_desk_grid(oldDesk - desk1);
+	draw_desk_grid(newDesk - desk1);
 	MoveStickyWindows(false, true);
 	Hilight(FocusWin, true);
 }
@@ -1299,7 +1301,7 @@ void list_config_info(unsigned long *body)
 		{
 			val = val - desk1;
 		}
-		DrawGrid(val, None, NULL);
+		draw_desk_grid(val);
 	} else if (StrEquals(token, "Monitor")) {
 		parse_monitor_line(tline);
 		ReConfigure();

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -125,13 +125,14 @@ typedef struct balloon_window
 typedef struct desk_style
 {
 	int desk;
-	int colorset;
-	int highcolorset;
-	int ballooncolorset;
+	int cs;
+	int hi_cs;
+	int balloon_cs;
 	char *label;
-	char *fgColor;
-	char *bgColor;
-	char *hiColor;
+	Pixel fg;			/* Store colors as pixels. */
+	Pixel bg;
+	Pixel hi_fg;
+	Pixel hi_bg;
 	FvwmPicture *bgPixmap;		/* Pixmap used as background. */
 	FvwmPicture *hiPixmap;		/* Hilighted background pixmap. */
 	TAILQ_ENTRY(desk_style) entry;
@@ -293,7 +294,7 @@ void initialise_common_pager_fragments(void);
 void initialize_pager(void);
 void initialize_fpmonitor_windows(struct fpmonitor *);
 void initialize_viz_pager(void);
-Pixel GetColor(char *name);
+Pixel GetSimpleColor(char *name);
 void DispatchEvent(XEvent *Event);
 void ReConfigure(void);
 void ReConfigureAll(void);

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -46,8 +46,6 @@ typedef struct ScreenInfo
 {
   unsigned long screen;
 
-  char *FvwmRoot;       /* the head of the fvwm window list */
-
   Window Root;
   Window Pager_w;
   Window label_w;
@@ -73,7 +71,6 @@ typedef struct ScreenInfo
 
 typedef struct pager_window
 {
-  char *t;
   Window w;
   Window frame;
   struct monitor *m;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -125,10 +125,12 @@ typedef struct balloon_window
 typedef struct desk_style
 {
 	int desk;
+	char *label;
+
+	bool use_label_pixmap;		/* Stretch pixmap over label? */
 	int cs;
 	int hi_cs;
 	int balloon_cs;
-	char *label;
 	Pixel fg;			/* Store colors as pixels. */
 	Pixel bg;
 	Pixel hi_fg;
@@ -139,6 +141,7 @@ typedef struct desk_style
 	GC dashed_gc;			/* Page boundary lines. */
 	GC hi_bg_gc;			/* Hilighting monitor locations. */
 	GC hi_fg_gc;			/* Hilighting desk labels. */
+
 	TAILQ_ENTRY(desk_style) entry;
 } DeskStyle;
 TAILQ_HEAD(desk_styles, desk_style);
@@ -150,8 +153,6 @@ typedef struct desk_info
   Window title_w;
   BalloonWindow balloon;
   DeskStyle *style;
-  unsigned long fp_mask;        /* used for the fpmonitor window */
-  XSetWindowAttributes fp_attr; /* used for the fpmonitor window */
   struct fpmonitor *fp;         /* most recent monitor viewing desk. */
 } DeskInfo;
 
@@ -220,6 +221,7 @@ extern bool	win_pix_set;
 extern bool	is_transient;
 extern bool	HilightDesks;
 extern bool	ShowBalloons;
+extern bool	HilightLabels;
 extern bool	error_occured;
 extern bool	FocusAfterMove;
 extern bool	use_desk_label;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -129,8 +129,11 @@ typedef struct desk_style
 	int highcolorset;
 	int ballooncolorset;
 	char *label;
-	char *Dcolor;
+	char *fgColor;
+	char *bgColor;
+	char *hiColor;
 	FvwmPicture *bgPixmap;		/* Pixmap used as background. */
+	FvwmPicture *hiPixmap;		/* Hilighted background pixmap. */
 	TAILQ_ENTRY(desk_style) entry;
 } DeskStyle;
 TAILQ_HEAD(desk_styles, desk_style);
@@ -156,9 +159,6 @@ typedef struct desk_info
  *
  */
 /* Colors, Pixmaps, Fonts, etc. */
-extern char		*HilightC;
-extern char		*PagerFore;
-extern char		*PagerBack;
 extern char		*smallFont;
 extern char		*ImagePath;
 extern char		*WindowBack;
@@ -173,9 +173,6 @@ extern char		*WindowLabelFormat;
 extern char		*BalloonTypeString;
 extern char		*BalloonBorderColor;
 extern char		*BalloonFormatString;
-extern Pixel		hi_pix;
-extern Pixel		back_pix;
-extern Pixel		fore_pix;
 extern Pixel		focus_pix;
 extern Pixel		win_back_pix;
 extern Pixel		win_fore_pix;
@@ -185,8 +182,6 @@ extern Pixel		win_hi_fore_pix;
 extern Pixmap		default_pixmap;
 extern FlocaleFont	*Ffont;
 extern FlocaleFont	*FwindowFont;
-extern FvwmPicture	*PixmapBack;
-extern FvwmPicture	*HilightPixmap;
 extern FlocaleWinString	*FwinString;
 
 /* Sizes / Dimensions */

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -301,7 +301,7 @@ void DispatchEvent(XEvent *Event);
 void ReConfigure(void);
 void ReConfigureAll(void);
 void update_pr_transparent_windows(void);
-void MovePage(bool is_new_desk);
+void MovePage();
 void DrawGrid(int desk,Window ew,XRectangle *r);
 void DrawIconGrid(int erase);
 void SwitchToDesk(int Desk, struct fpmonitor *m);

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -122,17 +122,25 @@ typedef struct balloon_window
   int desk;
 } BalloonWindow;
 
+typedef struct desk_style
+{
+	int desk;
+	int colorset;
+	int highcolorset;
+	int ballooncolorset;
+	char *label;
+	char *Dcolor;
+	FvwmPicture *bgPixmap;		/* Pixmap used as background. */
+	TAILQ_ENTRY(desk_style) entry;
+} DeskStyle;
+TAILQ_HEAD(desk_styles, desk_style);
+
 typedef struct desk_info
 {
   Window w;
   Window title_w;
-  FvwmPicture *bgPixmap;                /* Pixmap used as background. */
   BalloonWindow balloon;
-  int colorset;
-  int highcolorset;
-  int ballooncolorset;
-  char *Dcolor;
-  char *label;
+  DeskStyle *style;
   GC NormalGC;
   GC DashedGC;                  /* used for the pages boundary lines */
   GC HiliteGC;                  /* used for hilighting the active desk */
@@ -141,18 +149,6 @@ typedef struct desk_info
   XSetWindowAttributes fp_attr; /* used for the fpmonitor window */
   struct fpmonitor *fp;         /* most recent monitor viewing desk. */
 } DeskInfo;
-
-typedef struct pager_string_list
-{
-  struct pager_string_list *next;
-  int desk;
-  int colorset;
-  int highcolorset;
-  int ballooncolorset;
-  char *Dcolor;
-  char *label;
-  FvwmPicture *bgPixmap;                /* Pixmap used as background. */
-} PagerStringList;
 
 /*
  *
@@ -293,6 +289,7 @@ void list_property_change(unsigned long *body);
 void list_end(void);
 void list_reply(unsigned long *body);
 int My_XNextEvent(Display *dpy, XEvent *event);
+DeskStyle *FindDeskStyle(int desk);
 void ExitPager(void);
 
 /* Stuff in x_pager.c */
@@ -333,6 +330,7 @@ void MapBalloonWindow(PagerWindow *t, bool is_icon_view);
 void UnmapBalloonWindow(void);
 void DrawInBalloonWindow(int i);
 void HandleScrollDone(void);
+void set_desk_background(int desk);
 int fpmonitor_get_all_widths(void);
 int fpmonitor_get_all_heights(void);
 struct fpmonitor *fpmonitor_from_desk(int desk);

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -302,14 +302,14 @@ void ReConfigure(void);
 void ReConfigureAll(void);
 void update_pr_transparent_windows(void);
 void MovePage();
-void DrawGrid(int desk,Window ew,XRectangle *r);
-void DrawIconGrid(int erase);
+void draw_desk_grid(int desk);
+void draw_icon_grid(int erase);
 void SwitchToDesk(int Desk, struct fpmonitor *m);
 void SwitchToDeskAndPage(int Desk, XEvent *Event);
 void AddNewWindow(PagerWindow *prev);
 void MoveResizePagerView(PagerWindow *t, bool do_force_redraw);
 void ChangeDeskForWindow(PagerWindow *t,long newdesk);
-void MoveStickyWindow(bool is_new_page, bool is_new_desk);
+void MoveStickyWindows(bool is_new_page, bool is_new_desk);
 void Hilight(PagerWindow *, int);
 void Scroll(int x, int y, int Desk, bool do_scroll_icon);
 void MoveWindow(XEvent *Event);
@@ -334,6 +334,7 @@ struct fpmonitor *fpmonitor_from_desk(int desk);
 void initialize_desk_style_gcs(DeskStyle *style);
 void update_desk_style_gcs(DeskStyle *style);
 void update_desk_background(int desk);
+void update_monitor_locations(int desk);
 void update_monitor_backgrounds(int desk);
 
 #endif /* FVWMPAGER_H */

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -57,20 +57,18 @@ typedef struct ScreenInfo
 
   GC NormalGC;           /* used for window names and setting backgrounds */
   GC MiniIconGC;         /* used for clipping mini-icons */
-  GC whGC, wsGC, ahGC, asGC; /* used for 3d shadows on mini-windows */
-  GC label_gc;
   GC balloon_gc;
 
   int balloon_desk;
   char *balloon_label;   /* the label displayed inside the balloon */
-  char  *Hilite;         /* the fvwm window that is highlighted
-			  * except for networking delays, this is the
-			  * window which REALLY has the focus */
+
   unsigned VScale;       /* Panner scale factor */
   Pixmap sticky_gray_pixmap;
   Pixmap light_gray_pixmap;
   Pixmap gray_pixmap;
-  Pixel black;
+  Pixel focus_win_fg; /* The fvwm focus pixel. */
+  Pixel focus_win_bg;
+
 } ScreenInfo;
 
 typedef struct pager_window
@@ -130,17 +128,27 @@ typedef struct desk_style
 	bool use_label_pixmap;		/* Stretch pixmap over label? */
 	int cs;
 	int hi_cs;
+	int win_cs;
+	int focus_cs;
 	int balloon_cs;
 	Pixel fg;			/* Store colors as pixels. */
 	Pixel bg;
 	Pixel hi_fg;
 	Pixel hi_bg;
+	Pixel win_fg;
+	Pixel win_bg;
+	Pixel focus_fg;
+	Pixel focus_bg;
 	FvwmPicture *bgPixmap;		/* Pixmap used as background. */
 	FvwmPicture *hiPixmap;		/* Hilighted background pixmap. */
 	GC label_gc;			/* Label GC. */
 	GC dashed_gc;			/* Page boundary lines. */
 	GC hi_bg_gc;			/* Hilighting monitor locations. */
 	GC hi_fg_gc;			/* Hilighting desk labels. */
+	GC win_hi_gc;			/* GCs for 3D borders. */
+	GC win_sh_gc;
+	GC focus_hi_gc;
+	GC focus_sh_gc;
 
 	TAILQ_ENTRY(desk_style) entry;
 } DeskStyle;
@@ -164,24 +172,16 @@ typedef struct desk_info
 /* Colors, Pixmaps, Fonts, etc. */
 extern char		*smallFont;
 extern char		*ImagePath;
-extern char		*WindowBack;
-extern char		*WindowFore;
 extern char		*font_string;
 extern char		*BalloonFore;
 extern char		*BalloonBack;
 extern char		*BalloonFont;
-extern char		*WindowHiFore;
-extern char		*WindowHiBack;
 extern char		*WindowLabelFormat;
 extern char		*BalloonTypeString;
 extern char		*BalloonBorderColor;
 extern char		*BalloonFormatString;
-extern Pixel		focus_pix;
-extern Pixel		win_back_pix;
-extern Pixel		win_fore_pix;
-extern Pixel		focus_fore_pix;
-extern Pixel		win_hi_back_pix;
-extern Pixel		win_hi_fore_pix;
+extern Pixel		focus_win_fg;
+extern Pixel		focus_win_bg;
 extern Pixmap		default_pixmap;
 extern FlocaleFont	*Ffont;
 extern FlocaleFont	*FwindowFont;
@@ -203,8 +203,6 @@ extern rectangle	pwindow;
 extern rectangle	icon;
 
 /* Settings */
-extern int	windowcolorset;
-extern int	activecolorset;
 extern bool	xneg;
 extern bool	yneg;
 extern bool	IsShared;
@@ -217,7 +215,6 @@ extern bool	UseSkipList;
 extern bool	StartIconic;
 extern bool	LabelsBelow;
 extern bool	ShapeLabels;
-extern bool	win_pix_set;
 extern bool	is_transient;
 extern bool	HilightDesks;
 extern bool	ShowBalloons;
@@ -225,7 +222,6 @@ extern bool	HilightLabels;
 extern bool	error_occured;
 extern bool	FocusAfterMove;
 extern bool	use_desk_label;
-extern bool	win_hi_pix_set;
 extern bool	WindowBorders3d;
 extern bool	HideSmallWindows;
 extern bool	ShowIconBalloons;
@@ -312,15 +308,8 @@ void AddNewWindow(PagerWindow *prev);
 void MoveResizePagerView(PagerWindow *t, bool do_force_redraw);
 void ChangeDeskForWindow(PagerWindow *t,long newdesk);
 void MoveStickyWindows(bool is_new_page, bool is_new_desk);
-void Hilight(PagerWindow *, int);
 void Scroll(int x, int y, int Desk, bool do_scroll_icon);
 void MoveWindow(XEvent *Event);
-void BorderWindow(PagerWindow *t);
-void BorderIconWindow(PagerWindow *t);
-void LabelWindow(PagerWindow *t);
-void LabelIconWindow(PagerWindow *t);
-void PictureWindow(PagerWindow *t);
-void PictureIconWindow(PagerWindow *t);
 void ReConfigureIcons(bool do_reconfigure_desk_only);
 void IconSwitchPage(XEvent *Event);
 void IconMoveWindow(XEvent *Event,PagerWindow *t);
@@ -338,5 +327,9 @@ void update_desk_style_gcs(DeskStyle *style);
 void update_desk_background(int desk);
 void update_monitor_locations(int desk);
 void update_monitor_backgrounds(int desk);
+void update_window_background(PagerWindow *t);
+void update_window_decor(PagerWindow *t);
+void update_pager_window_decor(PagerWindow *t);
+void update_icon_window_decor(PagerWindow *t);
 
 #endif /* FVWMPAGER_H */

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -135,9 +135,14 @@ typedef struct desk_style
 	Pixel hi_bg;
 	FvwmPicture *bgPixmap;		/* Pixmap used as background. */
 	FvwmPicture *hiPixmap;		/* Hilighted background pixmap. */
+	GC label_gc;			/* Label GC. */
+	GC dashed_gc;			/* Page boundary lines. */
+	GC hi_bg_gc;			/* Hilighting monitor locations. */
+	GC hi_fg_gc;			/* Hilighting desk labels. */
 	TAILQ_ENTRY(desk_style) entry;
 } DeskStyle;
 TAILQ_HEAD(desk_styles, desk_style);
+extern struct desk_styles	desk_style_q;
 
 typedef struct desk_info
 {
@@ -145,10 +150,6 @@ typedef struct desk_info
   Window title_w;
   BalloonWindow balloon;
   DeskStyle *style;
-  GC NormalGC;
-  GC DashedGC;                  /* used for the pages boundary lines */
-  GC HiliteGC;                  /* used for hilighting the active desk */
-  GC rvGC;                      /* used for drawing hilighted desk title */
   unsigned long fp_mask;        /* used for the fpmonitor window */
   XSetWindowAttributes fp_attr; /* used for the fpmonitor window */
   struct fpmonitor *fp;         /* most recent monitor viewing desk. */
@@ -287,6 +288,7 @@ void list_reply(unsigned long *body);
 int My_XNextEvent(Display *dpy, XEvent *event);
 DeskStyle *FindDeskStyle(int desk);
 void ExitPager(void);
+void initialize_colorsets();
 
 /* Stuff in x_pager.c */
 void change_colorset(int colorset);
@@ -326,9 +328,12 @@ void MapBalloonWindow(PagerWindow *t, bool is_icon_view);
 void UnmapBalloonWindow(void);
 void DrawInBalloonWindow(int i);
 void HandleScrollDone(void);
-void set_desk_background(int desk);
 int fpmonitor_get_all_widths(void);
 int fpmonitor_get_all_heights(void);
 struct fpmonitor *fpmonitor_from_desk(int desk);
+void initialize_desk_style_gcs(DeskStyle *style);
+void update_desk_style_gcs(DeskStyle *style);
+void update_desk_background(int desk);
+void update_monitor_backgrounds(int desk);
 
 #endif /* FVWMPAGER_H */

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -384,6 +384,9 @@ void update_monitor_backgrounds(int desk)
 	DeskStyle *style = Desks[desk].style;
 
 	TAILQ_FOREACH(fp, &fp_monitor_q, entry) {
+		if (CurrentDeskPerMonitor && fAlwaysCurrentDesk)
+			style = FindDeskStyle(fp->m->virtual_scr.CurrentDesk);
+
 		if (style->hi_cs < 0) {
 			XSetWindowBackground(dpy,
 				fp->CPagerWin[desk], style->hi_bg);
@@ -1815,6 +1818,18 @@ void draw_grid_label(const char *label, const char *small, int desk,
 			XFillRectangle(dpy, Desks[desk].title_w,
 				       Desks[desk].style->hi_bg_gc,
 				       x, y, width, height);
+		} else if (CurrentDeskPerMonitor && fAlwaysCurrentDesk) {
+			/* Draw label colors based on location of monitor. */
+			struct fpmonitor *fp = fpmonitor_from_n(x / width);
+			DeskStyle *style;
+
+			style = FindDeskStyle(fp->m->virtual_scr.CurrentDesk);
+			cs = style->hi_cs;
+			FwinString->gc = style->hi_fg_gc;
+
+			style = FindDeskStyle(fp->m->virtual_scr.CurrentDesk);
+			XFillRectangle(dpy, Desks[desk].title_w,
+				       style->hi_bg_gc, x, y, width, height);
 		} else {
 			cs = Desks[desk].style->cs;
 			FwinString->gc = Desks[desk].style->label_gc;


### PR DESCRIPTION
DeskStyles provide a more standardized way to apply settings to each desktop individually (which can be used both when viewing multiple desks or just viewing only the current active desk). This restructures how to configure setting mostly colorsets settings on a per desk basis. With this the colors of the desktop, active monitors, windows, focus windows, and balloon window can all be configured for individual desktops. This also uses a standardized format to configure all the different colorsets or colors.

```
# Set a colorset for all desks, both syntax's do the same thing.
*FvwmPager: Colorset 12
*FvwmPager: HilightColorset * 12
```

To set a configuration for a specific desk, let's say desk 2, provide the desk number as the first parameter.

```
# Set colorset for desk 2.
*FvwmPager: Colorset 2 14
*FvwmPager: HilightColorset 2 15
```

The FvwmPager manual page is updated to explain the way to many settings that can be configured. It was also restructured to give some format to the large number of customizable options.

![myscrot](https://github.com/fvwmorg/fvwm3/assets/18082412/9c0eff42-3f4c-439d-b1ac-56c77e1b16f3)

![myscrot](https://github.com/fvwmorg/fvwm3/assets/18082412/b09870de-8c01-4e27-a61f-dc6ebc7dec76)
