### PR TITLE
FvwmPager: Use NULL not "" to avoid crashes on some systems.

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -351,12 +351,12 @@ the following options.
   Change the virtual page and/or desktop currently visible, base on the
   location clicked. The exact behavior depends on which _DesktopConfiguration_
   is used what mode the pager is in. In general the pager will only change
-  desk/page if it is absolutely clear which monitor to move to move. The
+  desk/page if it is absolutely clear which monitor to move. The
   behavior for each _DesktopConfiguration_ is:
 +
 --
 * *global*: Clicks on labels or pages will move all monitors to the desktop
-  and or page clicked.
+  and/or page clicked.
 * *per-monitor*: Clicks on monitor labels will move that monitor to the
   corresponding desktop. Clicks on desk labels will do nothing. Clicks on
   a page will move the monitor corresponding to the area clicked to that page.

--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -247,7 +247,7 @@ void initialize_fonts(void)
 	FlocaleInit(LC_CTYPE, "", "", "FvwmPager");
 
 	/* load a default font. */
-	Scr.Ffont = FlocaleLoadFont(dpy, "", MyName);
+	Scr.Ffont = FlocaleLoadFont(dpy, NULL, MyName);
 
 	/* init our Flocale window string */
 	FlocaleAllocateWinString(&FwinString);
@@ -488,7 +488,7 @@ void initialize_balloon_window(void)
 	if (Balloon.label_format == NULL)
 		Balloon.label_format = fxstrdup("%i");
 	if (!Balloon.Ffont)
-		Balloon.Ffont = FlocaleLoadFont(dpy, "", MyName);
+		Balloon.Ffont = FlocaleLoadFont(dpy, NULL, MyName);
 
 	valuemask = CWOverrideRedirect | CWEventMask | CWColormap;
 	/* tell WM to ignore this window */


### PR DESCRIPTION
Fix a crash on some systems, due to incorrectly using `""` instead of `NULL`.

This also fixes two minor typos in the manual page.