### PR TITLE
FvwmMFL: introduce FVWMML_SOCKET_PATH for namespacing

### DIFF
--- a/bin/FvwmCommand.in
+++ b/bin/FvwmCommand.in
@@ -9,27 +9,36 @@ import json
 
 # Fvwm3 - socket API and MFL UNIX socket
 # Simple Python 3 FvwmMFL client which purpose is to act as FVWM2 FvwmCommand
-# replacement in FVWM3. It uses FvwmMFL unix domain socket to send FVWM commands
-# at this moment, that is all. It doesn't parse json structures yet, or anything
-# fancy and new from FVWM3 new command processing interface.
+# replacement in FVWM3. It uses FvwmMFL unix domain socket to send FVWM
+# commands at this moment, that is all. It doesn't parse json structures yet,
+# or anything fancy and new from FVWM3 new command processing interface.
 
 def mflclnt(verbose, read_from_stdin, info, fvwm_socket, args):
+    # Check DISPLAY is defined, else bail:
+    if not 'DISPLAY' in os.environ:
+        print("$DISPLAY not set, is xorg/fvwm running?")
+        sys.exit(1)
+    sock_file_name = '/fvwm_mfl_' + str(os.environ.get('DISPLAY')) + '.sock'
+
     # Create a unix domain socket
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
     # Connect the socket to the "port" where the server is listening
-    # FvwmMFL is setting this in environment. This is done by using
-    # the explicit -f <sockname> flag if it is provided, otherwise
-    # use the environment FVWMMFL_SOCKET if it is defined, then fall
-    # back to TMPDIR/fvwm_mfl.sock if TMPDIR is defined, and last use
-    # the default location /tmp/fvwm_mfl.sock.
+    # FvwmMFL is setting this in environment. This is done by checking
+    # in the following order:
+    #  + Use the explicit -f <sockname> if it is provided.
+    #  + Use FVWMMFL_SOCKET_PATH/fvwm_mfl_DISPLAY.sock if defined.
+    #  + Use TMPDIR/fvwmmfl/fvwm_mfl_DISPLAY.sock if defined.
+    #  + Last use default location /tmp/fvwmmfl/fvwm_mfl_DISPLAY.sock
     if not fvwm_socket:
-        if 'FVWMMFL_SOCKET' in os.environ:
-            fvwm_socket = str(os.environ.get('FVWMMFL_SOCKET'))
+        if 'FVWMMFL_SOCKET_PATH' in os.environ:
+            fvwm_socket = str(os.environ.get('FVWMMFL_SOCKET_PATH'))
+            fvwm_socket += sock_file_name
         elif 'TMPDIR' in os.environ:
-            fvwm_socket = str(os.environ.get('TMPDIR')) + '/fvwm_mfl.sock'
+            fvwm_socket = str(os.environ.get('TMPDIR'))
+            fvwm_socket += '/fvwmmfl' + sock_file_name
         else:
-            fvwm_socket = '/tmp/fvwm_mfl.sock'
+            fvwm_socket = '/tmp/fvwmmfl' + sock_file_name
         def_socket = True
     else:
         def_socket = False
@@ -71,7 +80,7 @@ def mflclnt(verbose, read_from_stdin, info, fvwm_socket, args):
                 sock.sendall(message)
         if verbose:
             print('Sent {!r}'.format(message) + " to FvwmMFL")
-    
+
         amount_received = 0
         data = sock.recv(32768)
         # amount_received += len(data)

--- a/doc/FvwmMFL.adoc
+++ b/doc/FvwmMFL.adoc
@@ -30,9 +30,12 @@ packet has different fields, depending on the type requested.
 
 == COMMUNICATION
 
-The default unix-domain socket for _FvwmMFL_ is _$TMPDIR/fvwm_mfl.sock_,
-although this can be overridden via an environment variable
-_FVWMMFL_SOCKET_.
+The default unix-domain socket for _FvwmMFL_ is
+_$TMPDIR/fvwmmfl/fvwm_mfl_$DISPLAY.sock_.
+
+The path for where _fvwm_mfl-$DISPLAY_.sock is created can be changed by
+setting the _FVWMMFL_SOCKET_PATH_ environment variable.  _FvwmMFL_ will create
+this if it does not exist, and set relevant permissions.
 
 == REGISTERING INTEREST
 


### PR DESCRIPTION
Currently, it's possible to change the listening socket for FvwmMFL via
an environment variable, FVWMMFL_SOCKET. The reasons for this is that it
makes it easier to move the socket path to different locations away from
/tmp, to, say, $FVWM_USERDIR.
    
However, this single environment variable is reused across different
running fvwm instances which means commands sent via FvwmPrompt or
FvwmCommand end up going to the wrong fvwm instance, as it's a case of
whichever process reads that first, is sent to the DISPLAY that fvwm is
running on.
    
Therefore, set FVWMMFL_SOCKET_PATH to a base directory, under which,
namespaced directories per DISPLAY for the relevant FvwmMFL sockets can
be created.
    
Fixes #995
