### PR TITLE
New Style syntax for finer-grained matching

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -2928,6 +2928,16 @@ the newcomer.
 
 === Miscellaneous Commands
 
+*Capabilities* [_option_ [_bool_]], ...::
+	This command enables features which are still experimental.
++
+_FvwmStyleV3_ activates enhanced style matching whereby different aspects of
+styles can be matched, for example:
++
+....
+Style (Class=XTerm, Name=mc) Sticky
+....
+
 *BugOpts* [_option_ [_bool_]], ...::
 	This command controls several workarounds for bugs in third party
 	programs. The individual options are separated by commas. The optional

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -3179,6 +3179,52 @@ void CMD_UnsetEnv(F_CMD_ARGS)
 	return;
 }
 
+void CMD_Capabilities(F_CMD_ARGS)
+{
+	char *opt;
+	int toggle;
+	char *optstring;
+
+	while (action && *action && *action != '\n')
+	{
+		action = GetNextFullOption(action, &optstring);
+		if (!optstring)
+		{
+			/* no more options */
+			return;
+		}
+		toggle = ParseToggleArgument(
+			SkipNTokens(optstring,1), NULL, 2, False);
+		opt = PeekToken(optstring, NULL);
+		free(optstring);
+
+		if (!opt)
+		{
+			return;
+		}
+
+		if (StrEquals(opt, "FvwmStyleV3"))
+		{
+			switch (toggle)
+			{
+			case -1:
+				Scr.cap.fvwm_style_v3 ^= 1;
+				break;
+			case 0:
+			case 1:
+				Scr.cap.fvwm_style_v3 = toggle;
+				break;
+			default:
+				Scr.cap.fvwm_style_v3 = 0;
+				break;
+			}
+		} else {
+			fvwm_debug(__func__,
+				   "Unknown capability '%s'", opt);
+		}
+	}
+}
+
 void CMD_BugOpts(F_CMD_ARGS)
 {
 	char *opt;

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -29,6 +29,7 @@ enum
 	F_BUSY_CURSOR,
 	F_BUTTON_STATE,
 	F_BUTTON_STYLE,
+	F_CAPABILITIES,
 	F_CHANGE_MENUSTYLE,
 	F_CIRCULATE_DOWN,
 	F_CIRCULATE_UP,
@@ -206,6 +207,7 @@ void CMD_BugOpts(F_CMD_ARGS);
 void CMD_BusyCursor(F_CMD_ARGS);
 void CMD_ButtonState(F_CMD_ARGS);
 void CMD_ButtonStyle(F_CMD_ARGS);
+void CMD_Capabilities(F_CMD_ARGS);
 void CMD_ChangeDecor(F_CMD_ARGS);
 void CMD_ChangeMenuStyle(F_CMD_ARGS);
 void CMD_CleanupColorsets(F_CMD_ARGS);

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -113,6 +113,9 @@ const func_t func_table[] =
 		FUNC_DECOR, 0),
 	/* - Define a window button look (will be reworked) */
 
+	CMD_ENT("capabilities", CMD_Capabilities, F_CAPABILITIES, 0, 0),
+	/* - Define capabilities which can be changed at runtime */
+
 	CMD_ENT("changedecor", CMD_ChangeDecor, F_CHANGE_DECOR,
 		FUNC_NEEDS_WINDOW, CRS_SELECT),
 	/* - Attach decor to a window (will be obsolete) */

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -572,12 +572,18 @@ typedef struct style_flags
 
 typedef struct style_id_t
 {
-	char *name;
 	XID window_id;
+	char *name;
+	char *class;
+	char *resource;
+	char *icon;
 	struct
 	{
 		unsigned has_name:1;
 		unsigned has_window_id:1;
+		unsigned has_class:1;
+		unsigned has_resource:1;
+		unsigned has_icon:1;
 	} flags;
 } style_id_t;
 

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -445,6 +445,10 @@ typedef struct ScreenInfo
 	} bo; /* bug workaround control options */
 	struct
 	{
+		unsigned fvwm_style_v3 : 1;
+	} cap; /* Capabilities. */
+	struct
+	{
 		unsigned do_emulate_mwm : 1;
 		unsigned do_emulate_win : 1;
 		unsigned do_hide_position_window : 1;

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -54,6 +54,7 @@
 /* ---------------------------- forward declarations ----------------------- */
 
 static int style_set_border_colorset(window_style *, char *, int);
+static char *parse_v3_style_id(char *, style_id_t *);
 
 /* ---------------------------- local variables ---------------------------- */
 
@@ -4524,15 +4525,13 @@ static void _style_command(F_CMD_ARGS, char *prefix, Bool is_window_style)
 
 	if (!is_window_style)
 	{
-		/* parse style name */
-		action = GetNextToken(action, &SGET_NAME(*ps));
-		/* in case there was no argument! */
-		if (SGET_NAME(*ps) == NULL)
-		{
+		/* FIXME: capability check. */
+		action = parse_v3_style_id(action, &SGET_ID(*ps));
+		if (action == NULL) {
 			free(ps);
 			return;
 		}
-		SSET_ID_HAS_NAME(*ps, True);
+
 	}
 	else
 	{
@@ -4581,6 +4580,11 @@ static void _style_command(F_CMD_ARGS, char *prefix, Bool is_window_style)
 	}
 
 	return;
+}
+
+static char *parse_v3_style_id(char *action, style_id_t *r)
+{
+	return action;
 }
 
 /* ---------------------------- interface functions ------------------------ */

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -384,6 +384,18 @@
 	((id).flags.has_window_id = !!(x))
 #define SID_GET_HAS_WINDOW_ID(id) \
 	((id).flags.has_window_id)
+#define SID_GET_HAS_RESOURCE(id) \
+	((id).flags.has_resource)
+#define SID_SET_HAS_RESOURCE(id,x) \
+	((id).flags.has_resource = (x))
+#define SID_GET_HAS_CLASS(id) \
+	((id).flags.has_class)
+#define SID_SET_HAS_CLASS(id,x) \
+	((id).flags.has_class = (x))
+#define SID_GET_HAS_ICON(id) \
+	((id).flags.has_icon)
+#define SID_SET_HAS_ICON(id,x) \
+	((id).flags.has_icon = (x))
 
 /* access to other parts of a style (call with the style itself) */
 #define SGET_NEXT_STYLE(s) \


### PR DESCRIPTION
This PR changes the style command such that it's possible to specify attributes of a window which should be matched.  For example:

```
Style (Class=XTerm, Title=mc) Sticky
```

To wrap this change (and possibly future changes), a new command, `Capabilities` has been added to be able to toggle this on/off at run-time, but also to allow backward-compatibility to remain largely unaffected.