### PR TITLE
fsm_init: fix implicit function declaration _IceTransNoListen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -379,7 +379,11 @@ if test ! x"$with_sm" = xno; then
     [$X_LIBS $X_PRE_LIBS -lX11 $X_EXTRA_LIBS])
   ac_LIBS="$LIBS"
   LIBS="$LIBS -lICE"
-  AC_CHECK_FUNCS([_IceTransNoListen])
+  AC_CHECK_FUNCS([_IceTransNoListen],
+    [AC_CHECK_HEADERS([X11/Xtrans/Xtrans.h],
+      [AC_DEFINE(ICE_t, 1, [Xtrans transport type])
+      dnl AC_DEFINE(TRANS_CLIENT, 1, [Xtrans transport client code])
+      AC_DEFINE(TRANS_SERVER, 1, [Xtrans transport server code])])])
   LIBS="$ac_LIBS"
 fi
 dnl AC_SUBST(sm_LIBS)

--- a/libs/fsm.c
+++ b/libs/fsm.c
@@ -33,6 +33,11 @@
 #include <X11/Xutil.h>
 #include <X11/Xproto.h>
 #include <X11/Xatom.h>
+#if defined(HAVE_X11_XTRANS_XTRANS_H) && defined(HAVE__ICETRANSNOLISTEN)
+#include <X11/Xtrans/Xtrans.h>
+#elif defined(HAVE__ICETRANSNOLISTEN)
+extern void _IceTransNoListen(char *protocol);
+#endif
 
 #include "fvwmlib.h"
 #include "System.h"


### PR DESCRIPTION
* **What does this PR do?**
Add a check in configure.ac to determine if the build system has X11/Xtrans/Xtrans.h, and define `ICE_t` and `TRANS_SERVER` if it does.
\
Add a preprocessor step in lib/fsm.c to switch between using Xtrans.h or an extern declaration for the `_IceTransNoListen` symbol depending on whether or not the build system has Xtrans.h.

* **Issue number(s)**
Fixes #1031