### PR TITLE
FvwmCommand: use FVWMMFL_SOCKET when it's present

### DIFF
--- a/bin/FvwmCommand.in
+++ b/bin/FvwmCommand.in
@@ -31,7 +31,9 @@ def mflclnt(verbose, read_from_stdin, info, fvwm_socket, args):
     #  + Use TMPDIR/fvwmmfl/fvwm_mfl_DISPLAY.sock if defined.
     #  + Last use default location /tmp/fvwmmfl/fvwm_mfl_DISPLAY.sock
     if not fvwm_socket:
-        if 'FVWMMFL_SOCKET_PATH' in os.environ:
+        if 'FVWMMFL_SOCKET' in os.environ:
+            fvwm_socket = str(os.environ.get('FVWMMFL_SOCKET'))
+        elif 'FVWMMFL_SOCKET_PATH' in os.environ:
             fvwm_socket = str(os.environ.get('FVWMMFL_SOCKET_PATH'))
             fvwm_socket += sock_file_name
         elif 'TMPDIR' in os.environ:
@@ -162,4 +164,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Follow-up to da4387bd FvwmMFL: introduce FVWMML_SOCKET_PATH for namespacing. It breaks FvwmCommand for me because instead of taking FVWMMFL_SOCKET from the environment, FvwmCommand guesses it from FVWMMFL_SOCKET_PATH (incorrectly, DISPLAY=:1.0 while socket being :1.sock)

When running FvwmCommand from a specific fvwm instance, FVWMMFL_SOCKET is available, so let FvwmCommand use it. In the "outer" environment where only FVWMML_SOCKET_PATH is available, let it resort to guessing socket by $DISPLAY. Fixes #1034.