### PR TITLE
bring back negative desks, if ALLOW_NEGATIVE_DESKS is defined

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2435,7 +2435,7 @@ FvwmWindow *AddWindow(
 	setup_key_and_button_grabs(fw);
 
 	/****** inform modules of new window ******/
-	fw->UpdateDesk = -1; /* Initialize to ensure desk update. */
+	fw->UpdateDesk = INT_MIN; /* Initialize to ensure desk update. */
 	update_fvwm_monitor(fw);
 	BroadcastConfig(M_ADD_WINDOW,fw);
 	BroadcastWindowIconNames(fw, True, False);

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -756,7 +756,7 @@ int GetMoveArguments(FvwmWindow *fw,
 
 		free(s1);
 		token = PeekToken(action, &action);
-		if (sscanf(token, "%d", &desk) && desk >= 0)
+		if (sscanf(token, "%d", &desk) && desk != INT_MIN)
 			fw->UpdateDesk = desk;
 		action = GetNextToken(action, &s1);
 	}

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -671,10 +671,10 @@ Bool update_fvwm_monitor(FvwmWindow *fw)
 	mnew = FindScreenOfXY(g.x, g.y);
 
 	/* Avoid unnecessary updates. */
-	if (mnew == fw->m && fw->UpdateDesk < 0)
+	if (mnew == fw->m && fw->UpdateDesk == INT_MIN)
 		return False;
 
-	if (fw->UpdateDesk < 0) {
+	if (fw->UpdateDesk == INT_MIN) {
 		fw->Desk = mnew->virtual_scr.CurrentDesk;
 		goto out;
 	}
@@ -701,7 +701,7 @@ Bool update_fvwm_monitor(FvwmWindow *fw)
 		map_window(fw);
 	}
 	fw->Desk = fw->UpdateDesk;
-	fw->UpdateDesk = -1;
+	fw->UpdateDesk = INT_MIN;
 
 out:
 	if (fw->m != mnew) {

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -128,6 +128,11 @@ static int My_XNextEvent(Display *dpy, XEvent *event);
 int main(int argc, char **argv)
 {
 	short opt_num;
+#ifdef ALLOW_NEGATIVE_DESKS
+	int min_desk = INT_MIN+1;
+#else
+	int min_desk = 0;
+#endif
 
 	/* Save our program name */
 	MyName = GetFileNameFromPath(argv[0]);
@@ -229,10 +234,10 @@ int main(int argc, char **argv)
 			desk2 = desk1;
 		else
 			desk2 = atoi(argv[opt_num+1]);
-		if (desk1 < 0)
-			desk1 = 0;
-		if (desk2 < 0)
-			desk2 = 0;
+		if (desk1 < min_desk)
+			desk1 = min_desk;
+		if (desk2 < min_desk)
+			desk2 = min_desk;
 		if (desk2 < desk1) {
 			int dtemp = desk1;
 			desk1 = desk2;

--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -76,7 +76,7 @@ void init_fvwm_pager(void)
 	}
 	/* Initialize any non configured desks. */
 	for (i = 0; i < ndesks; i++) {
-		style = FindDeskStyle(i);
+		style = FindDeskStyle(i+desk1);
 	}
 
 	/* After DeskStyles are initialized, initialize desk windows. */
@@ -170,7 +170,7 @@ void initialize_desks_and_monitors(void)
 
 	/* Initialize default DeskStyle, stored on desk -1. */
 	default_style = fxcalloc(1, sizeof(DeskStyle));
-	default_style->desk = -1;
+	default_style->desk = INT_MIN;
 	default_style->label = fxstrdup("-");
 
 	default_style->use_label_pixmap = true;
@@ -196,7 +196,7 @@ void initialize_desks_and_monitors(void)
 
 	Desks = fxcalloc(1, ndesks*sizeof(DeskInfo));
 	for(i = 0; i < ndesks; i++) {
-		Desks[i].style = FindDeskStyle(i);
+		Desks[i].style = FindDeskStyle(i + desk1);
 		Desks[i].fp = fpmonitor_from_desk(i + desk1);
 	}
 }
@@ -330,7 +330,7 @@ void initialize_transient(void)
 
 void initialise_common_pager_fragments(void)
 {
-	DeskStyle *style = FindDeskStyle(-1);
+	DeskStyle *style = FindDeskStyle(INT_MIN);
 
 	/* I don't think that this is necessary - just let pager die */
 	/* domivogt (07-mar-1999): But it is! A window being moved in the pager

--- a/modules/FvwmPager/x_update.c
+++ b/modules/FvwmPager/x_update.c
@@ -241,7 +241,7 @@ void update_desk_style_gcs(DeskStyle *style)
 	initialize_colorset(style);
 
 	/* Don't update GC's for default style. */
-	if (style->desk < 0)
+	if (style->desk == INT_MIN)
 		return;
 
 	XSetForeground(dpy, style->label_gc, style->fg);


### PR DESCRIPTION
- use INT_MIN instead of -1 to flag "special desks"
- check for "special desks" against INT_MIN for instead of == -1 or < 0
- two loops from 0 to ndesks use i+desk1 instead of i (no-op if desk1 is 0)
- new cpp defintion ALLOW_NEGATIVE_DESKS
- FvwmPager defines min_desk as 0, if above not defined, as INT_MIN+1 if defined
- defining ALLOW_NEGATIVE_DESKS will allow desks from INT_MIN+1 through INT_MAX, breaking EWMH
- not defining, the default, should not change any behavior