### PR TITLE
Don't check final_pos against MAX/MIN_X_WINDOW_POSITION

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -664,14 +664,6 @@ static int GetOnePositionArgument(
 		fvwm_debug(
 			__func__, "new position is out of range: %d",
 			final_pos);
-		if (final_pos > MAX_X_WINDOW_POSITION)
-		{
-			final_pos = MAX_X_WINDOW_POSITION;
-		}
-		else if (final_pos < MIN_X_WINDOW_POSITION)
-		{
-			final_pos = MIN_X_WINDOW_POSITION;
-		}
 	}
 	*pFinalPos = final_pos;
 
@@ -4426,7 +4418,7 @@ static Bool _resize_window(F_CMD_ARGS)
 			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild, &x,
 				    &y, &JunkX, &JunkY, &JunkMask);
-			
+
 			fev_make_null_event(&e2, dpy);
 			e2.type = MotionNotify;
 			e2.xmotion.time = fev_get_evtime();


### PR DESCRIPTION
- don't check final_pos against MAX/MIN_X_WINDOW_POSITION
- allows creating windows on virtual positions outside of those limits
- seems to run fine, or my use of fvwm3 doesn't ever hit a problem with this
