### PR TITLE
adds PrintInfo Colorsets to print currenly defined Colorsets

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -3471,6 +3471,9 @@ If _verbose_ is one or greater the palette used by fvwm is printed. If
 you have a limited color palette, and you run out of colors, this
 command might be helpful.
 +
+_Colorsets_ which prints information about the colorsets currently in
+use by fvwm.
++
 _ImageCache_ which prints information about the images loaded by fvwm.
 If _verbose_ is one or greater all images in the cache will be listed
 together with their respective reuse.
@@ -8873,7 +8876,9 @@ colorset is modified all parts of fvwm react to that change. A colorset
 includes a foreground color, background color, shadow and highlight
 color (often based on the background color), background face (this
 includes images and all kinds of gradients). There is a way to render
-background face and specify other color operations.
+background face and specify other color operations. You can use the
+*PrintInfo* _Colorsets_ command to get information on the currently
+allocated colorsets.
 
 *Colorset* _num_ [_options_]::
 	Creates or modifies colorset _num_. Colorsets are identified by this

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2746,6 +2746,10 @@ void CMD_PrintInfo(F_CMD_ARGS)
 	{
 		PicturePrintColorInfo(verbose);
 	}
+	else if (StrEquals(subject, "Colorsets"))
+	{
+		print_colorsets(verbose);
+	}
 	else if (StrEquals(subject, "Locale"))
 	{
 		FlocalePrintLocaleInfo(dpy, verbose);

--- a/libs/Colorset.c
+++ b/libs/Colorset.c
@@ -121,6 +121,20 @@ char *DumpColorset(int n, colorset_t *cs)
 	return csetbuf;
 }
 
+void print_colorsets()
+{
+	int n;
+
+	fvwm_debug(__func__, "Info on fvwm Colorsets:\n");
+	for (n = 0; n < nColorsets; n++)
+	{
+		fvwm_debug(__func__,
+			   "  %s\n",
+			   DumpColorset(n, &Colorset[n]));
+	}
+	return;
+}
+
 /*
  * LoadColorset() takes a strings and stuffs it into the array
  */

--- a/libs/Colorset.h
+++ b/libs/Colorset.h
@@ -84,7 +84,7 @@ typedef struct Colorset
 
 /* colorsets are stored as an array of structs to permit fast dereferencing */
 extern colorset_t *Colorset;
-
+extern void print_colorsets();
 
 /* some macro for transparency */
 #define CSET_IS_TRANSPARENT(cset) \


### PR DESCRIPTION
Add Print Colorsets option.
Function print_colorsets just walks the Colorsets array and calls DumpColorsets on each entry.
Added to lib/Colorset.c, could also be added to fvwm/colorset.c. 
To do so one would need to add an extern int nColorsets to libs/Colorset.h, which seems to be missing, though it may not be needed.  In libs/Colorset.h the declaration of nColorsets is one of the two lines following a /* globals */ comment.