### PR TITLE
FvwmMFL: ignore SIGUSR2

### DIFF
--- a/modules/FvwmMFL/FvwmMFL.c
+++ b/modules/FvwmMFL/FvwmMFL.c
@@ -175,6 +175,7 @@ setup_signal_handlers(struct event_base *base)
 	struct event	*hup, *term, *intrp, *quit, *child;
 
 	signal(SIGPIPE, SIG_IGN);
+	signal(SIGUSR2, SIG_IGN);
 
 	hup   =  evsignal_new(base, SIGHUP,  HandleTerminate, NULL);
 	term  =  evsignal_new(base, SIGTERM, HandleTerminate, NULL);


### PR DESCRIPTION
When fvwm receives SIGUSR2 it will toggle its logfile open/closed.
However, the signal is propagated to modules.  We want to ignore this
signal in FvwmMFL so that it doesn't quit.
