### PR TITLE
Adjust windows to fit working area after move.

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -3906,10 +3906,16 @@ Move [screen _S_] [desk _N_] [w | m | v]_x_[p | w] [w | m | v]_y_[p | w] [Warp] 
 ....
 +
 This will move the window to the _x_ and _y_ position (see below).
-By default, the EWMH working area is honoured. If he trailing option
-_ewmhiwa_ is given, then the window position will ignore the working
-area (such as ignoring any values set via *EwmhBaseStruts*). If the
-option _Warp_ is given then the pointer is warped to the window.
+By default, the EWMH working area of each monitor is honoured (the
+working area for each monitor is set via *EwmhBaseStruts* and honors
+any strut hints provided by windows on the monitor). This means that
+if a window is placed outside the working area, the position of the
+window will be adjusted to fit inside the working area of the screen
+the center of the window is on. If the trailing option _ewmhiwa_ is
+given, then the window position will ignore the working area and its
+position will not be adjusted (this option is needed to move windows
+off the screen and to have full control of where it is placed). If
+the option _Warp_ is given then the pointer is warped to the window.
 +
 If the literal option _screen_ followed by a RandR screen name _S_ is
 specified, the coordinates are interpreted as relative to the given
@@ -3925,15 +3931,17 @@ is updated to be the same as the new monitor. This option can override
 that behavior by specifying which desk the window should end up on.
 +
 The positional arguments _x_ and _y_ can specify an absolute or relative
-position from either the left/top or right/bottom of the screen. By default,
-the numeric value given is interpreted as a percentage of the screen
-width/height, but a trailing '_p_' changes the interpretation to mean pixels,
-while a trailing '_w_' means percent of the window width/height. To move the
-window relative to its current position, add the '_w_' (for "window") prefix
-before the _x_ and/or _y_ value. To move the window to a position relative to
-the current location of the pointer, add the '_m_' (for "mouse") prefix. To
-move the window relative to the virtual screen coordinates, add the '_v_'
-(for "virtual screen") prefix. This is mostly for internal use with FvwmPager,
+position from either the left/top (positive values) or right/bottom
+(negative values) of the global screen (the bounding box that contains all
+monitors) or specified _screen_. By default, the numeric value given is
+interpreted as a percentage of the screen's width/height, but a trailing
+'_p_' changes the interpretation to mean pixels, while a trailing '_w_'
+means percent of the window width/height. To move the window relative to
+its current position, add the '_w_' (for "window") prefix before the _x_
+and/or _y_ value. To move the window to a position relative to the current
+location of the pointer, add the '_m_' (for "mouse") prefix. To move the
+window relative to the virtual screen coordinates, add the '_v_' (for
+"virtual screen") prefix. This is mostly for internal use with FvwmPager,
 but can be used to give exact coordinates on the virtual screen and is best
 used with the '_p_' suffix. To leave either coordinate unchanged, "_keep_"
 can be specified in place of _x_ or _y_.

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -1116,9 +1116,9 @@ void EWMH_UpdateWorkArea(struct monitor *m)
 }
 
 void EWMH_GetWorkAreaIntersection(
-	FvwmWindow *fw, int *x, int *y, int *w, int *h, int type)
+	struct monitor *mon, int *x, int *y, int *w, int *h, int type)
 {
-	struct monitor	*m = (fw && fw->m) ? fw->m : monitor_get_current();
+	struct monitor	*m = (mon) ? mon : monitor_get_current();
 
 	EWMH_UpdateWorkArea(m);
 

--- a/fvwm/ewmh.h
+++ b/fvwm/ewmh.h
@@ -38,7 +38,7 @@ void EWMH_SetClientList(struct monitor *);
 void EWMH_SetClientListStacking(struct monitor *);
 void EWMH_UpdateWorkArea(struct monitor *);
 void EWMH_GetWorkAreaIntersection(
-	FvwmWindow *fw, int *x, int *y, int *w, int *h, int type);
+	struct monitor *mon, int *x, int *y, int *w, int *h, int type);
 float EWMH_GetBaseStrutIntersection(struct monitor *m,
 	int x11, int y11, int x12, int y12, Bool use_percent);
 float EWMH_GetStrutIntersection(struct monitor *m,

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -460,8 +460,8 @@ static pl_penalty_t _pl_position_get_pos_simple(
 		 * options.
 		 */
 		EWMH_GetWorkAreaIntersection(
-			arg->place_fw, (int *)&arg->screen_g.x, (int *)&arg->screen_g.y,
-			(int *)&arg->screen_g.width,
+			arg->place_fw->m, (int *)&arg->screen_g.x,
+			(int *)&arg->screen_g.y, (int *)&arg->screen_g.width,
 			(int *)&arg->screen_g.height, EWMH_USE_WORKING_AREA);
 
 		if (ret_p->x + arg->place_fw->g.frame.width > arg->screen_g.x
@@ -1812,7 +1812,7 @@ static int _place_window(
 		 * for this placement policy.
 		 */
 		EWMH_GetWorkAreaIntersection(
-			fw, &screen_g.x, &screen_g.y, &screen_g.width,
+			fw->m, &screen_g.x, &screen_g.y, &screen_g.width,
 			&screen_g.height,
 			SEWMH_PLACEMENT_MODE(&pstyle->flags));
 		reason->screen.was_modified_by_ewmh_workingarea = 1;


### PR DESCRIPTION
When moving windows, it made sense to consider the working area base struts before the move when the base struts were on the global view port. Now that the base struts are per monitor this no longer makes sense, and caused strange behavior when computing where to move a window.

Instead the window's position should be adjusted to fit inside the working area after the move is done. This way the position of the window is always computed relative to the global screen (unless the 'screen RANDR_NAME' option is provided).

Notes, this is a breaking change as many multiple monitor configs have updated to work around this behavior. This should also fix #1033 and other issues where computations are done relative to the global screen but incorrectly adjusted when ran on monitors not located at `(0,0)`.

This should also be tested, I've only done limited testing so far, but all my tests have been favorable. Hopefully anything this breaks is due to having to work around the old incorrect behavior.