### PR TITLE
FvwmPager: Honor ewmh working area and option to ignore working area.

### DIFF
--- a/doc/FvwmPager.adoc
+++ b/doc/FvwmPager.adoc
@@ -374,7 +374,10 @@ the following options.
   _MoveThreshold_, will have the optional fvwm _command_ (if set) sent
   to them. The default is command "FlipFocus NoWarp". Setting the
   _SendCmdAfterMove_ option will also send the _command_ after the
-  window is placed in its new location.
+  window is placed in its new location. Note, by default the EWMH
+  working area is honored, and windows placement will be adjusted
+  to fit inside the working area of the monitor they are placed on.
+  To turn this off use the _IgnoreWorkingArea_ option.
 
 *FvwmPager: Mouse <N> WindowCmd command::
   Send the fvwm _command_ to the window clicked. This can be used to
@@ -420,6 +423,11 @@ done about this - except not using SloppyFocus in the pager.
   After moving a window using the pager, send the configured command,
   "FlipFocus NoWarp" by default, to the window. By default the command
   is only sent on a click, not a move.
+
+*FvwmPager: IgnoreWorkingArea::
+  After moving a window, ignore the working area when placing the window.
+  This makes it so the window's position will no longer be adjusted to
+  fit inside the working area of the monitor it is placed in.
 
 === MONITOR AND DESKTOP CONFIGURATION
 

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -77,6 +77,7 @@ rectangle	pwindow = {0, 0, 0, 0};
 rectangle	icon = {-10000, -10000, 0, 0};
 
 /* Settings */
+bool	ewmhiwa = false;
 bool	IsShared = false;
 bool	MiniIcons = false;
 bool	Swallowed = false;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -208,6 +208,7 @@ extern rectangle	pwindow;
 extern rectangle	icon;
 
 /* Settings */
+extern bool	ewmhiwa;
 extern bool	IsShared;
 extern bool	MiniIcons;
 extern bool	Swallowed;

--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -953,6 +953,8 @@ void parse_options(void)
 			use_no_separators = false;
 		} else if (StrEquals(resource, "NoSeparators")) {
 			use_no_separators = true;
+		} else if (StrEquals(resource, "IgnoreWorkingArea")) {
+			ewmhiwa = true;
 		} else {
 			/* No Match, set this to continue parsing. */
 			flags = 0;

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1834,7 +1834,7 @@ void MoveWindow(XEvent *Event)
 
 	fp = fpmonitor_from_xy(
 		rec.x * fp->virtual_scr.VWidth / desk_w,
-		rec.y * fp->virtual_scr.VHeight / desk_h);
+		rec.y * fp->virtual_scr.VHeight / (desk_h + label_h));
 	if (fp == NULL)
 		fp = fpmonitor_this(NULL);
 
@@ -1872,6 +1872,7 @@ void MoveWindow(XEvent *Event)
 	}
 
 	char buf[64];
+	const char *iwa = ewmhiwa ? "ewmhiwa" : "";
 
 	/* Move using the virtual screen's coordinates "+vXp +vYp", to avoid
 	 * guessing which monitor fvwm will use. The "desk" option is sent
@@ -1883,13 +1884,13 @@ void MoveWindow(XEvent *Event)
 	if (CurrentDeskPerMonitor && fAlwaysCurrentDesk) {
 		NewDesk = fp->m->virtual_scr.CurrentDesk;
 		/* Let fvwm handle any desk changes in this case. */
-		snprintf(buf, sizeof(buf), "Silent Move v+%dp v+%dp ewmhiwa",
-			 rec.x, rec.y);
+		snprintf(buf, sizeof(buf), "Silent Move v+%dp v+%dp %s",
+			 rec.x, rec.y, iwa);
 	} else {
 		NewDesk += desk1;
 		snprintf(buf, sizeof(buf),
-			 "Silent Move desk %d v+%dp v+%dp ewmhiwa",
-			 NewDesk, rec.x, rec.y);
+			 "Silent Move desk %d v+%dp v+%dp %s",
+			 NewDesk, rec.x, rec.y, iwa);
 	}
 	SendText(fd, buf, t->w);
 	XSync(dpy,0);
@@ -1989,6 +1990,7 @@ void IconMoveWindow(XEvent *Event, PagerWindow *t)
 		SendText(fd, "Silent Move Pointer", t->w);
 	} else if (moved) {
 		char buf[64];
+		const char *iwa = ewmhiwa ? "ewmhiwa" : "";
 
 		rec.x = x - rec.x;
 		rec.y = y - rec.y;
@@ -2000,15 +2002,15 @@ void IconMoveWindow(XEvent *Event, PagerWindow *t)
 		pagerrec_to_fvwm(&rec, true, fp);
 		if (CurrentDeskPerMonitor)
 			snprintf(buf, sizeof(buf),
-				 "Silent Move v+%dp v+%dp ewmhiwa",
-				 rec.x, rec.y);
+				 "Silent Move v+%dp v+%dp %s",
+				 rec.x, rec.y, iwa);
 		else
 			/* Keep window on current desk, even if another
 			 * monitor is currently on a different desk.
 			 */
 			snprintf(buf, sizeof(buf),
-				 "Silent Move desk %d v+%dp v+%dp ewmhiwa",
-				 desk_i, rec.x, rec.y);
+				 "Silent Move desk %d v+%dp v+%dp %s",
+				 desk_i, rec.x, rec.y, iwa);
 		SendText(fd, buf, t->w);
 		XSync(dpy, 0);
 		SendText(fd, "Silent Raise", t->w);


### PR DESCRIPTION
This allows FvwmPager to take advantage of the change to how
EWMH working area is used to move windows into the current working
area of the monitor they are placed in. This helps windows being
placed by FvwmPager not appear slightly off screen. This adds a
new option, *FvwmPager: IgnoreWorkingArea, which turns off this
feature, returning to the previous behavior of using the option
`ewmhiwa` option when moving windows.

This is built on top of #1067.