### PR TITLE
ConfigWinPacket: no longer send monitor_name

### DIFF
--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -320,8 +320,6 @@ action_flags *_get_allowed_actions(const FvwmWindow *fw)
 		(unsigned long)(0),			\
 		&(*(_fw))->m->si->rr_output,		\
 		(unsigned long)(sizeof(unsigned long)),\
-		(*(_fw))->m->si->name,			\
-		(unsigned long)(0),			\
 		&(*(_fw))->layer,			\
 		(unsigned long)(0),			\
 		&(*(_fw))->hints.base_width,		\

--- a/libs/vpacket.h
+++ b/libs/vpacket.h
@@ -30,7 +30,6 @@ typedef struct ConfigWinPacket
 	unsigned long  frame_height;
 	unsigned long  desk;
 	unsigned long  monitor_id;
-	unsigned long  monitor_name;
 	unsigned long  layer;
 	unsigned long  hints_base_width;
 	unsigned long  hints_base_height;

--- a/modules/FvwmIconMan/fvwm.c
+++ b/modules/FvwmIconMan/fvwm.c
@@ -181,7 +181,16 @@ WinData *id_to_win(Ulong id)
 
 static void set_win_configuration(WinData *win, FvwmPacketBody *body)
 {
-	copy_string(&win->monitor, (char *)&(body->add_config_data.monitor_name));
+	struct monitor *m = monitor_by_output(body->add_config_data.monitor_id);
+
+	if (m == NULL) {
+		fprintf(stderr,
+			"FvwmIconMan: %s: couldn't find mon with id: %ld\n",
+			__func__, body->add_config_data.monitor_id);
+		copy_string(&win->monitor, "Unknown");
+	} else
+		copy_string(&win->monitor, m->si->name);
+
 	win->desknum = body->add_config_data.desk;
 	win->x = body->add_config_data.frame_x;
 	win->y = body->add_config_data.frame_y;


### PR DESCRIPTION
Because of the padding and the alignment in the CongfigWinPacket, trying
to fit a monitor name >8 characters would truncate.

Instead, if modules need to look up the monitor from the window packet,
do so via the monitor_id which was already being sent down.

Currently, only FvwmIconMan is affected.

Noticed by jns and somiaj on IRC.
