### PR TITLE
Fix issue with placement in per-monitor configuration.

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -205,8 +205,12 @@ static void setup_window_structure(
 	FW_W(*pfw) = w;
 	if (savewin != NULL)
 	{
+		/* JS: 2024-10-19
+		 * Set initial monitor to NULL, so current monitor can
+		 * be used for placement and finding current desk.
+		 */
+		(*pfw)->m = NULL;
 		(*pfw)->Desk = savewin->Desk;
-		(*pfw)->m = savewin->m;
 		SET_SHADED(*pfw, IS_SHADED(savewin));
 		SET_USED_TITLE_DIR_FOR_SHADING(
 			*pfw, USED_TITLE_DIR_FOR_SHADING(savewin));
@@ -2332,8 +2336,6 @@ FvwmWindow *AddWindow(
 	else
 	{
 		rectangle attr_g;
-
-		update_fvwm_monitor(fw);
 
 		if (IS_SHADED(fw))
 		{


### PR DESCRIPTION
When two monitors are on different desks, ensure that the correct monitor is used when placing windows. Otherwise placement policies can use the wrong desk when computing where to place a window. This is done two fold, first initialize windows with a NULL monitor so current monitor is used in cases a monitor is not specified for the window to start on, and second delay updating the window's monitor until after the window has been placed, so the correct monitor is found based on the windows location.

This fixes #1043.