### PR TITLE
Autotools make dist include meson build files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,12 @@ xsessions_DATA = $(XSESSIONFILE)
 
 CLEANFILES = $(XSESSIONFILE)
 
-EXTRA_DIST = CHANGELOG.md $(XSESSIONFILE).in
+EXTRA_DIST = CHANGELOG.md \
+    $(XSESSIONFILE).in \
+    meson.build \
+    meson.options \
+    meson-scripts \
+    config_defines.h
 
 ## ---------------------------------------------------------------------------
 ## Manage bzip2 archive together with gzip archive

--- a/bin/FvwmPrompt/Makefile.am
+++ b/bin/FvwmPrompt/Makefile.am
@@ -4,6 +4,7 @@ GOBUILD=$(GOCMD) build
 GOFLAGS=-ldflags="-s -w"
 GOCLEAN=$(GOCMD) clean
 BINARY_NAME=FvwmPrompt
+EXTRA_DIST=meson.build
 
 all: build
 build:

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -22,7 +22,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(xpm_CFLAGS) $(X_CFLAGS) $(png_CFLAGS) \
 configdir = @FVWM_DATADIR@
 config_DATA = fvwm-menu-desktop-config.fpl
 
-EXTRA_DIST = fvwm-menu-desktop-config.fpl FvwmPrompt
+EXTRA_DIST = fvwm-menu-desktop-config.fpl FvwmPrompt meson.build
 
 dist-hook:
 	rm -f $(distdir)/FvwmPrompt/FvwmPrompt

--- a/default-config/Makefile.am
+++ b/default-config/Makefile.am
@@ -13,7 +13,8 @@ EXTRA_DIST  = images \
 	      stalonetrayrc \
 	      FvwmScript-DateTime \
 	      FvwmScript-ConfirmQuit \
-	      FvwmScript-ConfirmCopyConfig
+	      FvwmScript-ConfirmCopyConfig \
+              meson.build
 
 install-data-hook:
 	cp -r $(srcdir)/images $(inst_location)/default-config

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -19,7 +19,7 @@ MODULE_ADOC = $(filter-out FvwmPrompt.adoc, $(MODULE_ADOC_SRCS))
 REMOVE_LINK = FvwmPrompt.adoc
 endif
 
-EXTRA_DIST = $(MODULE_ADOC_SRCS)
+EXTRA_DIST = $(MODULE_ADOC_SRCS) meson.build index.adoc.in
 
 nothing:
 

--- a/fvwm/Makefile.am
+++ b/fvwm/Makefile.am
@@ -3,7 +3,7 @@
 configdir = @FVWM_DATADIR@
 bin_PROGRAMS = fvwm3
 
-EXTRA_DIST = $(config_DATA)
+EXTRA_DIST = $(config_DATA) meson.build
 
 config_DATA = ConfigFvwmDefaults
 

--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -2,6 +2,8 @@
 
 noinst_LIBRARIES = libfvwm3.a
 
+EXTRA_DIST=meson.build
+
 ## please keep .c files in largest first order to speed up parallel makes
 libfvwm3_a_SOURCES = \
 	BidiJoin.h Bindings.h ClientMsg.h ColorUtils.h Colorset.h \

--- a/modules/FvwmAnimate/Makefile.am
+++ b/modules/FvwmAnimate/Makefile.am
@@ -5,6 +5,8 @@ program_transform_name =
 moduledir = @FVWM_MODULEDIR@
 module_PROGRAMS = FvwmAnimate
 
+EXTRA_DIST = meson.build
+
 FvwmAnimate_SOURCES = FvwmAnimate.c FvwmAnimate.h
 FvwmAnimate_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 

--- a/modules/FvwmAuto/Makefile.am
+++ b/modules/FvwmAuto/Makefile.am
@@ -5,6 +5,8 @@ program_transform_name =
 moduledir = @FVWM_MODULEDIR@
 module_PROGRAMS = FvwmAuto
 
+EXTRA_DIST = meson.build
+
 FvwmAuto_SOURCES = FvwmAuto.c
 FvwmAuto_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 

--- a/modules/FvwmBacker/Makefile.am
+++ b/modules/FvwmBacker/Makefile.am
@@ -7,7 +7,7 @@ configdir = @FVWM_DATADIR@
 
 module_PROGRAMS = FvwmBacker
 
-EXTRA_DIST = ConfigFvwmBacker
+EXTRA_DIST = ConfigFvwmBacker meson.build
 config_DATA = ConfigFvwmBacker
 
 FvwmBacker_SOURCES = FvwmBacker.c FvwmBacker.h root_bits.c

--- a/modules/FvwmButtons/Makefile.am
+++ b/modules/FvwmButtons/Makefile.am
@@ -6,7 +6,7 @@ moduledir = @FVWM_MODULEDIR@
 configdir = @FVWM_DATADIR@
 
 module_PROGRAMS = FvwmButtons
-EXTRA_DIST = CHANGES samplebuttonrc BUGS ConfigFvwmButtons
+EXTRA_DIST = CHANGES samplebuttonrc BUGS ConfigFvwmButtons meson.build
 
 config_DATA = ConfigFvwmButtons
 

--- a/modules/FvwmConsole/Makefile.am
+++ b/modules/FvwmConsole/Makefile.am
@@ -12,6 +12,8 @@ if !FVWM_BUILD_GOLANG
 
 module_PROGRAMS = FvwmConsole FvwmConsoleC
 
+EXTRA_DIST = meson.build
+
 FvwmConsole_SOURCES = FvwmConsole.c FvwmConsole.h
 FvwmConsoleC_SOURCES = FvwmConsoleC.c FvwmConsole.h getline.c
 

--- a/modules/FvwmEvent/Makefile.am
+++ b/modules/FvwmEvent/Makefile.am
@@ -5,6 +5,8 @@ program_transform_name =
 moduleexecdir = @FVWM_MODULEDIR@
 moduleexec_PROGRAMS = FvwmEvent
 
+EXTRA_DIST = meson.build
+
 FvwmEvent_SOURCES = FvwmEvent.c
 FvwmEvent_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 

--- a/modules/FvwmForm/Makefile.am
+++ b/modules/FvwmForm/Makefile.am
@@ -27,7 +27,9 @@ EXTRA_DIST = Changes \
   FvwmForm-Talk           \
   FvwmForm-TalkHelp       \
   FvwmForm-XDGOptionsHelp \
-  FvwmForm-XDGMenuHelp
+  FvwmForm-XDGMenuHelp    \
+  FvwmTalk-wrapper.in     \
+  meson.build
 
 FvwmForm_SOURCES = FvwmForm.c FvwmForm.h ReadXServer.c ParseCommand.c
 

--- a/modules/FvwmIconMan/Makefile.am
+++ b/modules/FvwmIconMan/Makefile.am
@@ -6,7 +6,7 @@ moduledir = @FVWM_MODULEDIR@
 configdir = @FVWM_DATADIR@
 
 module_PROGRAMS = FvwmIconMan
-EXTRA_DIST = ConfigFvwmIconMan
+EXTRA_DIST = ConfigFvwmIconMan meson.build
 
 config_DATA = \
   ConfigFvwmIconMan

--- a/modules/FvwmIdent/Makefile.am
+++ b/modules/FvwmIdent/Makefile.am
@@ -6,7 +6,7 @@ moduledir = @FVWM_MODULEDIR@
 configdir = @FVWM_DATADIR@
 
 module_PROGRAMS = FvwmIdent
-EXTRA_DIST = ConfigFvwmIdent
+EXTRA_DIST = ConfigFvwmIdent meson.build
 
 config_DATA = \
   ConfigFvwmIdent

--- a/modules/FvwmMFL/Makefile.am
+++ b/modules/FvwmMFL/Makefile.am
@@ -6,6 +6,8 @@ moduledir = @FVWM_MODULEDIR@
 module_PROGRAMS = FvwmMFL
 module_SCRIPTS = FvwmCommandS
 
+EXTRA_DIST = meson.build FvwmCommandS.in
+
 FvwmMFL_SOURCES = FvwmMFL.c
 FvwmMFL_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 

--- a/modules/FvwmPager/Makefile.am
+++ b/modules/FvwmPager/Makefile.am
@@ -6,7 +6,7 @@ moduledir = @FVWM_MODULEDIR@
 configdir = @FVWM_DATADIR@
 
 module_PROGRAMS = FvwmPager
-EXTRA_DIST = ConfigFvwmPager
+EXTRA_DIST = ConfigFvwmPager meson.build
 
 config_DATA = \
   ConfigFvwmPager

--- a/modules/FvwmPerl/Makefile.am
+++ b/modules/FvwmPerl/Makefile.am
@@ -5,3 +5,5 @@ program_transform_name =
 moduledir = @FVWM_MODULEDIR@
 
 module_SCRIPTS = FvwmPerl
+
+EXTRA_DIST = meson.build FvwmPerl.in

--- a/modules/FvwmRearrange/Makefile.am
+++ b/modules/FvwmRearrange/Makefile.am
@@ -6,6 +6,8 @@ program_transform_name =
 moduledir = @FVWM_MODULEDIR@
 module_PROGRAMS = FvwmRearrange
 
+EXTRA_DIST = meson.build
+
 FvwmRearrange_SOURCES = FvwmRearrange.c
 FvwmRearrange_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a
 

--- a/modules/FvwmScript/Makefile.am
+++ b/modules/FvwmScript/Makefile.am
@@ -15,7 +15,7 @@ FvwmScript_DEPENDENCIES = $(top_builddir)/libs/libfvwm3.a Widgets/libWidgets.a
 
 YFLAGS = -d
 
-EXTRA_DIST = scanner.l script.y TODO
+EXTRA_DIST = scanner.l script.y TODO meson.build
 
 LDADD = Widgets/libWidgets.a -L$(top_builddir)/libs -lfvwm3 $(Xft_LIBS) \
 	$(X_LIBS) $(xpm_LIBS) $(XRandR_LIBS) $(X_PRE_LIBS) -lXext -lX11 \

--- a/perllib/Makefile.am
+++ b/perllib/Makefile.am
@@ -1,6 +1,7 @@
 ## Process this file with automake to create Makefile.in
 
 SUBDIRS = FVWM General
+EXTRA_DIST = meson.build
 
 uninstall-hook:
 	rm -fr @FVWM_DATADIR@/perllib

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -2,7 +2,7 @@
 localedir = @LOCALEDIR@
 
 EXTRA_DIST = \
-	@POFILES@ @GMOFILES@ fvwm3.pot
+	@POFILES@ @GMOFILES@ fvwm3.pot meson.build
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.


### PR DESCRIPTION
Include the meson build files with autotools make dist so tarballs created this wan can use autotools or meson to build fvwm3 from.