### PR TITLE
FvwmRearrange overhaul

### DIFF
--- a/doc/FvwmRearrange.adoc
+++ b/doc/FvwmRearrange.adoc
@@ -6,147 +6,320 @@ FvwmRearrange - rearrange fvwm windows
 
 == SYNOPSIS
 
-**Module FvwmRearrange [-cascade | -tile] [options] [bounding box]**
+**FvwmRearrange [options] [bounding box] [options]**
 
-FvwmRearrange is spawned by fvwm, so no command line invocation will
-work.
+FvwmRearrange is spawned by fvwm, so no command line invocation will work.
 
 == DESCRIPTION
 
 This module can be called to tile or cascade windows.
 
-When tiling the module attempts to tile windows on the current screen
-subject to certain constraints. Horizontal or vertical tiling is
-performed so that each window does not overlap another, and by default
-each window is resized to its nearest resize increment (note sometimes
-some space might appear between tiled windows -- this is why).
+When tiling the module will tile the windows into a grid (table or matrix)
+inside the bounding box (the current monitor's working area by default).
+Tiling is performed so that windows will not overlap. When moving and
+resizing windows to fit into the grid, windows are resized to their nearest
+increment size, specified by the window's size hints (this is why sometimes
+space might appear between tiled windows, common with terminals). Use the
+_ResizeHintOverride_ style on widows with increment size hints to override
+this behavior (which removes the gaps).
 
-When cascading the module attempts to cascade windows on the current
-screen subject to certain constraints. Layering is performed so
-consecutive windows will have their window titles visible underneath the
-previous.
+When cascading the module will cascade the windows inside the bounding box
+from the top left of the bounding box. Windows will be resized to fit the
+bounding box and layering is performed so that consecutive windows all have
+their titles visible underneath the previous window.
+
+The behavior of both tiling and cascading can be configured by the options
+listed below. This can control the size of the bounding box, if windows are
+resized, and which windows are affected, and so on.
 
 == INVOCATION
 
-FvwmRearrange is best invoked from a menu, pop up or button. There are a
-number of command line options which can be used to constrain the
-layering, these are described below. As an example case, one could call
-FvwmRearrange with the following arguments:
+FvwmRearrange is best invoked from a menu, keybinding, or button. There are
+a number of command line options which can be used to control how windows
+will be cascaded/tiled, described below. Invoking FvwmRearrange with no
+options will auto tile (see _-auto_tile) windows on the current monitor:
 
 ....
-FvwmRearrange -tile -h 10 10 90 90
+FvwmRearrange
 ....
 
-or
+This tiles all windows in the working area of the current monitor into
+a grid. This size of the grid will be computed using the number of
+windows trying to make the grid as square as possible. Windows on the top
+row will be resized to take up any extra space filling the full working
+area. Adding additional arguments can change the behavior, for example:
 
 ....
-FvwmRearrange -cascade -resize 10 2 80 70
+FvwmRearrange -tile -swap 10 10 90 90
 ....
 
-The first invocation will horizontally tile windows with a bounding box
-which starts at 10 by 10 percent into and down the screen and ends at 90
-by 90 percent into and down the screen.
+This invocation will tile windows in a single column with a bounding box
+which starts at 10 by 10 percent into and down the monitor's working area
+and ends at 90 by 90 percent into and down the working area. Another example:
 
-The second invocation will cascade windows starting 10 by 2 percent into
-and down the screen. Windows will be constrained to 80 by 70 percent of
-the screen dimensions. Since the _resize_ is also specified, windows
-will be resized to the given constrained width and height.
+....
+FvwmRearrange -cascade 10 2 80 70
+....
+
+This invocation will cascade windows starting 10 by 2 percent into and down
+the monitor's working area. Windows will be resized so their height and width
+are 75 percent of the bounding box, which ends at 80 by 70 percent of the
+working area.
+
+FvwmRearrange can also be run multiple times on the same monitor with
+different bounding boxes. This way you can better control how windows are
+tiled. Consider the following example:
+
+....
+FvwmRearrange -tile -swap 0 0 35 100
+FvwmRearrange 35 0 100 100
+....
+
+The first command will create a single column of windows located on the left
+35% of the monitor, and the second will auto tile the windows on the right
+65% of the monitor. This way you can control how windows are tiled in
+different parts of the monitor independent of each other.
+
+If you want to run FvwmRearrange automatically when new windows are added,
+use FvwmEvent to trigger FvwmRearrange with an _add_window_ event. If using
+multiple bounding boxes (like the above example), a ManualPlacement Style
+would allow you to place a window in the portion of the screen you wanted
+it to be tiled in.
 
 == OPTIONS
 
--a::
-  Causes _all_ window types to be affected, even ones with the
-  WindowListSkip style.
--animate::
-  Attempt to do an animated move, this is ignored if _-resize_ or
-  _-maximize_ are used.
+FvwmRearrange is only configured using command line options. These options
+can come before or after the _bounding box_, and all start with a '-'.
+Below the options are split into categories, *TILING OPTIONS*,
+*CASCADING OPTIONS*, *GENERAL OPTIONS*, *RESIZING OPTIONS*,
+*FILTERING OPTIONS*, and *ORDERING OPTIONS*.
+
+=== TILING OPTIONS
+
+Tiling takes the windows inside the bounding box, creates a grid of equal
+sized cells based on the number of windows, then resizes and moves the
+windows to fill the cells, starting at the top left. The cells are then
+filled one row at a time (from left to right) working downward.
+
+Windows may have minimum size or size increment EMWH hints, so there
+could be gaps between windows or some windows minimum size might be
+bigger than the cell. The _ResizeHintOverride_ fvwm _Style_ will
+override this behavior and make windows fit in their cells better.
+
+-auto_tile::
+  This is the default behavior which tiles all windows into as close to
+  a square grid as possible. There can be up to one more column than row
+  (or one more row than column with _-swap_), depending on number of windows.
+  If the option _-max_n N_ is also provided, then the grid will have _N_ more
+  columns than rows (or _N_ more rows than columns if _-swap_ is included).
+  This option implies _-fill_start_ so all space will be used. If _-fill_end_
+  option is provided, the free space is used at the end instead.
+-tile::
+  This will tile the windows into a single row (or column if with _-swap_).
+  If _-max_n N_ is also provided, there will be at most _N_ columns per row
+  (or _N_ rows per column with _-sawp_) in the resulting grid. If the grid
+  has more cells than the number of windows, then the additional cells at
+  the end will be left open, unless the _-fill_start_ or _-fill_end_ options
+  are included.
+-max_n _N_::
+  This option alters how the grid is computed. When using _-auto_tile_ this
+  gives the number of more columns than rows (or more rows than columns with
+  _-swap_). When using _-tile_ this gives the max number of columns, before
+  a new row is created (or max number of rows with _-swap_). Default is 0.
+-swap::
+  Swaps the rows and columns, and swaps the direction the cells are filled,
+  by starting at the top left cell and filling each column downward (from
+  top to bottom) while working to the right. This use to be called horizontal
+  sort (with the default being vertical sort), and the old option _-h_ is
+  an alias for _-swap_, due to this history.
+-fill_start::
+  This will use any unused space in the grid by filling the first row (or
+  first column with _-swap_) left open in the grid. This is done by growing
+  the windows in the row (or column) to fill the unused space. The rest of
+  the windows will then fill up the rest of the grid.
+-fill_end::
+  This will use any unused space in the grid by filling the last row (or
+  last column with _-swap_) left open in the grid.
+
+=== CASCADING OPTIONS
+
+Cascading takes all windows in the bounding box, places the first window
+in the upper left corer of the bounding box, then stacks the second window
+just below the first shifted slightly down and to the right, so the previous
+window can be seen behind it. This process is repeated placing each window
+slightly down and to the right of the previous window.
+
+By default the windows are resized such that their height and width are
+75% of the bounding box's height and width. Though as the windows are
+cascaded, windows will shrunk so they will stay inside the bounding box.
+The _-nostretch_ and _-noresize_ options will prevent windows from being
+stretched or resized.
+
 -cascade::
-  Cascade windows. This argument must be the first on the command line.
-  This is the default.
--desk::
-  Causes all windows on the desk to be cascaded/tiled instead of the
-  current screen only.
+  Cascade windows inside the bounding box.
+-cascadew _arg_::
+  Specifies the width of the cascade windows. _arg_ is a percentage of the
+  bounding box's width, or a pixel value if a _p_ is suffixed. Windows are
+  shrunk if the width pushes them outside the bounding box. Default is 75.
+-cascadeh _arg_::
+  Specifies the height of the cascade windows. _arg_ is a percentage of the
+  bounding box's height, or a pixel value if a _p_ is suffixed. Windows are
+  shrunk if the height pushes them outside the bounding box. Default is 75.
+-inc_equal::
+  Make the x and y increment equal to the maximum of the two values. This is
+  useful to get the offset to be equal to the size of the border and title
+  bar in both directions. This can be combined with _-incx, _-incy_,
+  _-flatx_, and _-flaty_.
+-incx _arg_::
+  Specifies an additional horizontal increment which is successively added
+  to cascaded windows. _arg_ is a percentage of bounding box's width, or a
+  pixel value if a _p_ is suffixed. Default is zero.
+-incy _arg_::
+  Specifies an additional vertical increment which is successively added to
+  cascaded windows. _arg_ is a percentage of bounding box's height, or a
+  pixel value if a _p_ is suffixed. Default is zero.
 -flatx::
-  Inhibits border width increment. Only used when cascading.
+  Inhibits incrementing the horizontal position by a windows border width
+  (and title width if titles are on the right or left). Useful with _-incx_
+  to better control the horizontal increment.
 -flaty::
-  Inhibits border height increment. Only used when cascading.
--h::
-  Tiles horizontally (default is to tile vertically). Used for tiling
-  only.
--incx arg::
-  Specifies a horizontal increment which is successively added to
-  cascaded windows. _arg_ is a percentage of screen width, or pixel
-  value if a _p_ is suffixed. Default is zero. Used only for cascading.
--incy arg::
-  Specifies a vertical increment which is successively added to cascaded
-  windows. _arg_ is a percentage of screen height, or pixel value if a
-  _p_ is suffixed. Default is zero. Used only for cascading.
--m::
-  Causes maximized windows to also be affected (implied by -a).
--maximize::
-  When moving/resizing a window, put it also into maximized state.
--mn arg::
-  Tiles up to _arg_ windows in tile direction. If more windows exist, a
-  new direction row or column is created (in effect, a matrix is
-  created). Used only when tiling windows.
--noanimate::
-  Do not attempt to do an animated move.
--nomaximize::
-  Do not put windows into maximized state.
+  Inhibits incrementing the vertical position by a windows border width
+  (and title width if titles are on the top or bottom). Useful with _-incy_
+  to better control the vertical increment.
+
+=== GENERAL OPTIONS
+
+-screen _name_::
+  By default the current monitor is used to determine what windows to
+  cascade/tile, and is used as the base bounding box. This will use the
+  monitor specified by the RandR _name_ instead. If _name_ is equal to "g"
+  the global monitor (bounding box containing all monitors is used). Since
+  this may cause windows to span across multiple monitors, the working area
+  is ignored (see _ewmhiwa_).
 -noraise::
   Inhibits window raising, leaving the depth ordering intact.
--noresize::
-  Inhibits window resizing, leaving window sizes intact. This is the
-  default when cascading windows.
--nostretch::
-  If tiling: inhibits window growth to fit tile. Windows are shrunk to
-  fit the tile but not expanded.
-+
-If cascading: inhibits window expansion when using the -resize option.
-Windows will only shrink to fit the maximal width and height (if given).
-
--r::
-  Reverses the window sequence.
--resize::
-  Forces all windows to resize to the constrained width and height (if
-  given). This is the default when tiling windows.
--s::
-  Causes sticky windows to also be affected (implied by -a).
--sp::
-  Causes windows sticky across pages to also be affected (implied by
-  -a).
--sd::
-  Causes windows sticky across desks to also be affected (implied by
-  -a).
--t::
-  Causes transient windows to also be affected (implied by -a).
--tile::
-  Tile windows. This argument must be the first on the command line.
--u::
-  Causes untitled windows to also be affected (implied by -a).
+-maximize::
+  When moving/resizing a window, put them into a maximized state. This makes
+  so _Maximize_ can be used to restore the previous size and position.
+-animate::
+  When only moving windows (_-noresize_ is used), use _AnimateMove_ instead
+  of _Move_ to move windows.
 -ewmhiwa::
-  When rearranging windows, make the calculation ignore the working
-  area, such as EwmhBaseStruts; by default, FvwmRearrange will honour
-  the working area.
+  When rearranging windows, make the calculation ignore the working area,
+  such as _EwmhBaseStruts_; by default, FvwmRearrange will honour the
+  working area. This option may place windows outside of the current monitor.
 
+=== RESIZING OPTIONS
+
+By default both tiling and cascading will resize windows based on the
+provided options. These options will limit this behavior.
+
+-noresize::
+  Inhibits window resizing, leaving window sizes intact.
+-nostretch::
+  Inhibits windows from growing to fit the grid cell (when tiling) or
+  bounding box (when cascading). Windows are still shrunk to fit but not
+  expanded. This implies both _-nostretchx_ and _-nostretchy_.
+-nostretchx::
+  Inhibits windows from growing horizontally to fit, but they will still
+  be shrunk.
+-nostretchy::
+  Inhibits windows from growing vertically to fit, but they will still be
+  shrunk.
+
+=== FILTERING OPTIONS
+
+These options affect which windows inside the bounding box will be tiled
+or cascaded.
+
+-all::
+  Cause skipped, sticky, and transient windows to also be cascaded/tiled
+  (ignored by default). This is a shortcut for _-skiplist_, _-sticky_ and
+  _-transient_.
+-some::
+  Don't include maximized windows and windows without title bars (useful
+  when cascading) when cascading/tiling. This is a shortcut for
+  _-no_maximized_ and _-no_titled_.
+-skiplist::
+  Causes windows on the windows skip list (see _WindowListSkip_ style) to
+  also be affected.
+-sticky::
+  Causes sticky windows to also be affected. This is a shortcut for
+  _-sticky_page_ and _-sticky_desk_.
+-sticky_page::
+  Causes windows sticky across pages to also be affected.
+-sticky_desk::
+  Causes windows sticky across desks to also be affected.
+-transient::
+  Causes transient windows to also be affected.
+-no_maximized::
+  Don't include windows in the maximized state to be cascaded/tiled.
+-no_titled::
+  Don't include windows with title bars to be cascaded/tiled.
+-desk::
+  Causes all windows on the desk to be cascaded/tiled instead of only
+  windows that intersect the bounding box.
+
+=== ORDERING OPTIONS
+
+Windows are tiled or cascaded based on their order. By default the order
+is based off fvwm's _WindowList_ order (usually based off the order the
+windows were last focused). These options control the window order.
+
+-order_name::
+  Order the windows by their name.
+-order_icon::
+  Order the windows by their icon name.
+-order_class::
+  Order the windows by their class.
+-order_resource::
+  Order the windows by their resource.
+-order_xy::
+  Order the windows based on their (x, y) coordinate position. This is a
+  lexicographic ordering, by comparing x-coordinates first, then if the
+  x-coordinates are equal compare the y-coordinates. This ordering matches
+  the ordering of the _-swap_ tiling option.
+-order_yx::
+  Order the windows based on their (x, y) coordinate position. This is a
+  lexicographic ordering, by comparing y-coordinates first, then if the
+  y-coordinates are equal compare the x-coordinates. This ordering matches
+  the default positing of tiling windows.
+-order_hw::
+  Order the windows based on their height, and if their heights are the same
+  compare windows based on their width. This can be useful with _-cascade_
+  and _-noresize_ to stack windows based on their size.
+-order_wh::
+  Order the windows based on their width, and if their widths are the same
+  compare windows based on their height. This can be useful with _-cascade_
+  and _-noresize_ to stack windows based on their size.
+-reverse::
+  Reverses the window ordering.
 
 == BOUNDING BOX
 
-Up to four numbers can be placed on the command line that are not
-switches. The first pair specify an x and y offset to start the first
-window (default is 0, 0). The meaning of the second pair depends on
-operation mode:
+The bounding box is the area in which FvwmRearrange will both find and place
+windows when cascading/tiling.  The base bounding box is the working area of
+the current or specified monitor via the _-screen name_ option. If the option
+_-ewmhiwa_ is provided the base bounding box will ignore the working area and
+use the full monitor.
 
-When tiling windows it specifies an absolute coordinate reference
-denoting the lower right bounding box for tiling.
+Up to four numbers can be placed on the command line to specify a bounding
+box relative to the base bounding box of the given monitor.  The numbers
+give the position of the corners of the bounding box in the following order
+(default is "0 0 100 100"):
 
-When cascading it specifies a maximal width and height for the layered
-windows. If an affected window exceeds either this width or height, it
-is resized to the maximal width or height.
+....
+Left Top Right Bottom
+....
 
-If any number is suffixed with the letter p, then it is taken to be a
-pixel value, otherwise it is interpreted as a screen percentage.
-Specifying zero for any parameter is equivalent to not specifying it.
+These numbers are treated as a percentage of the base bounding box. For
+instance the bounding box "10 5 85 80" would use a bounding starting 10%
+across the working area from the left and ending 85% across the working
+area, while starting 5% down the working area from the top and ending
+80% down the working area. If any number is suffixed with the letter _p_,
+then it is taken to be a pixel value instead of a percentage.
+Specifying zero for any parameter is equivalent to not specifying it
+(for example "0 0 0 0" is the same as "0 0 100 100").
 
 == BUGS
 
@@ -155,5 +328,6 @@ rearranged.
 
 == AUTHORS
 
-Andrew Veliath (original FvwmTile and FvwmCascade modules) Dominik Vogt
-(merged FvwmTile and FvwmCascade to FvwmRearrange)
+Andrew Veliath (original FvwmTile and FvwmCascade modules),
+Dominik Vogt (merged FvwmTile and FvwmCascade to FvwmRearrange),
+Jaimos Skriletz (updated for fvwm3 including adding the auto_tile option).

--- a/fvwm/ewmh.c
+++ b/fvwm/ewmh.c
@@ -2064,3 +2064,26 @@ void EWMH_fullscreen(FvwmWindow *fw)
 
 	return;
 }
+
+boundingbox
+get_ewmhc_boundingbox(struct monitor *m)
+{
+	boundingbox r = {0};
+	int left = 0, right = 0, top = 0, bottom = 0;
+
+	EWMH_UpdateWorkArea(m);
+
+	left = m->Desktops->ewmh_working_area.x;
+	right = m->si->w - left -
+		m->Desktops->ewmh_working_area.width;
+	top = m->Desktops->ewmh_working_area.y;
+	bottom = m->si->h - top -
+		 m->Desktops->ewmh_working_area.height;
+
+	r.left = left;
+	r.right = right;
+	r.top = top;
+	r.bottom = bottom;
+
+	return r;
+}

--- a/fvwm/ewmh.h
+++ b/fvwm/ewmh.h
@@ -59,6 +59,7 @@ void EWMH_ExitStuff(void);
 
 /* ewmh_conf.c */
 void set_ewmhc_strut_values(struct monitor *, int *);
+boundingbox get_ewmhc_boundingbox(struct monitor *);
 
 /* ewmh_events.c */
 Bool EWMH_ProcessClientMessage(const exec_context_t *exc);

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -397,13 +397,7 @@ void CMD_Send_ConfigInfo(F_CMD_ARGS)
 	int match_len = 0;
 	fmodule *mod = exc->m.module;
 
-	/* Don't send the monitor list when a module asks for its
-	 * configuration... in this case, fvwm -> module could get in an
-	 * infinite loop, continually telling that module the same
-	 * information over and over.
-	 *
-	 * send_monitor_list(mod);
-	 */
+	send_monitor_list(mod);
 	/* send ImagePath and ColorLimit first */
 	send_image_path(mod);
 	send_color_limit(mod);

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -45,6 +45,7 @@
 #include "geometry.h"
 #include "libs/fvwmsignal.h"
 #include "decorations.h"
+#include "ewmh.h"
 #include "commands.h"
 
 /* A queue of commands from the modules */
@@ -480,17 +481,21 @@ static
 void send_monitor_info(fmodule *send)
 {
 	struct monitor	*m;
+	boundingbox	 r;
 	const char	*m_info;
 	char		*name;
 
-	m_info = "Monitor %s %d %d %d %d %d %d %d %d %d %d";
+	m_info = "Monitor %s %d %d %d %d %d %d %d %d %d %d %d %d %d %d";
 
 	RB_FOREACH(m, monitors, &monitor_q) {
+		r = get_ewmhc_boundingbox(m);
 		xasprintf(&name, m_info, m->si->name, m->flags,
 		    m->dx, m->dy, m->virtual_scr.Vx,
 		    m->virtual_scr.Vy, m->virtual_scr.VxMax,
 		    m->virtual_scr.VyMax, m->virtual_scr.CurrentDesk,
-		    monitor_get_all_widths(), monitor_get_all_heights());
+		    monitor_get_all_widths(), monitor_get_all_heights(),
+		    r.left, r.right, r.top, r.bottom
+		);
 
 		SendName(send, M_CONFIG_INFO, 0, 0, 0, name);
 		free(name);

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -284,9 +284,9 @@ static void move_to_next_monitor(
 	FvwmWindow *fw, rectangle *win_r, bool ewmh, direction_t dir)
 {
 	position page;
+	boundingbox r = {0};
 	struct monitor *m;
 	int x1, x2, y1, y2; /* Working area bounds */
-	int left = 0, right = 0, top = 0, bottom = 0;
 	int check_vert = 0, check_hor = 0;
 
 	get_page_offset_check_visible(&page.x, &page.y, fw);
@@ -298,49 +298,42 @@ static void move_to_next_monitor(
 		if (fw->m == m)
 			continue;
 
-		if (ewmh) {
-			EWMH_UpdateWorkArea(m);
-			left = m->Desktops->ewmh_working_area.x;
-			right = m->si->w - left -
-				m->Desktops->ewmh_working_area.width;
-			top = m->Desktops->ewmh_working_area.y;
-			bottom = m->si->h - top -
-				 m->Desktops->ewmh_working_area.height;
-		}
+		if (ewmh)
+			r = get_ewmhc_boundingbox(m);
 
 		if (dir == DIR_N && m->si->y + m->si->h == fw->m->si->y &&
 			win_r->x < m->si->x + m->si->w &&
 			win_r->x + win_r->width > m->si->x)
 		{
 			check_hor = 1;
-			win_r->y = m->si->y + m->si->h - win_r->height - bottom;
+			win_r->y = m->si->y + m->si->h - win_r->height - r.bottom;
 		}
 		else if (dir == DIR_E && m->si->x == fw->m->si->x +
 			fw->m->si->w &&	win_r->y < m->si->y + m->si->h &&
 				win_r->y + win_r->height > m->si->y)
 		{
 			check_vert = 1;
-			win_r->x = m->si->x + left;
+			win_r->x = m->si->x + r.left;
 		}
 		else if (dir == DIR_S && m->si->y == fw->m->si->y +
 			fw->m->si->h &&	win_r->x < m->si->x + m->si->w &&
 			win_r->x + win_r->width > m->si->x)
 		{
 			check_hor = 1;
-			win_r->y = m->si->y + top;
+			win_r->y = m->si->y + r.top;
 		}
 		else if (dir == DIR_W && m->si->x + m->si->w == fw->m->si->x &&
 			win_r->y < m->si->y + m->si->h &&
 			win_r->y + win_r->height > m->si->y)
 		{
 			check_vert = 1;
-			win_r->x = m->si->x + m->si->w - win_r->width - right;
+			win_r->x = m->si->x + m->si->w - win_r->width - r.right;
 		}
 		if (check_hor || check_vert) {
-			x1 = m->si->x + left;
-			y1 = m->si->y + top;
-			x2 = x1 + m->si->w - right;
-			y2 = y1 + m->si->h - bottom;
+			x1 = m->si->x + r.left;
+			y1 = m->si->y + r.top;
+			x2 = x1 + m->si->w - r.right;
+			y2 = y1 + m->si->h - r.bottom;
 			break;
 		}
 	}

--- a/libs/fvwmrect.h
+++ b/libs/fvwmrect.h
@@ -23,6 +23,14 @@ typedef struct
 
 typedef struct
 {
+	int top;
+	int bottom;
+	int left;
+	int right;
+} boundingbox;
+
+typedef struct
+{
 	int x;
 	int y;
 } position;

--- a/modules/FvwmPager/messages.c
+++ b/modules/FvwmPager/messages.c
@@ -755,6 +755,7 @@ void set_desk_label(int desk, const char *label)
 void parse_monitor_line(char *tline)
 {
 	int		  dx, dy, Vx, Vy, VxMax, VyMax, CurrentDesk;
+	int		  bs_top, bs_bottom, bs_left, bs_right;
 	int		  scr_width, scr_height;
 	int		  flags;
 	char		 *mname;
@@ -763,9 +764,9 @@ void parse_monitor_line(char *tline)
 
 	tline = GetNextToken(tline, &mname);
 
-	sscanf(tline, "%d %d %d %d %d %d %d %d %d %d", &flags,
+	sscanf(tline, "%d %d %d %d %d %d %d %d %d %d %d %d %d %d", &flags,
 	    &dx, &dy, &Vx, &Vy, &VxMax, &VyMax, &CurrentDesk,
-	    &scr_width, &scr_height);
+	    &scr_width, &scr_height, &bs_left, &bs_right, &bs_top, &bs_bottom);
 
 	monitor_refresh_module(dpy);
 

--- a/modules/FvwmRearrange/FvwmRearrange.c
+++ b/modules/FvwmRearrange/FvwmRearrange.c
@@ -44,22 +44,46 @@
 #include "fvwm/fvwm.h"
 #include "libs/log.h"
 #include "libs/Module.h"
+#include "libs/Parse.h"
 #include "libs/System.h"
 #include "libs/fvwmlib.h"
 #include "libs/vpacket.h"
 
+#define MIN_CELL_SIZE 10
+
+enum window_order_methods
+{
+	WIN_ORDER_DEFAULT = 0,
+	WIN_ORDER_NAME,
+	WIN_ORDER_ICON,
+	WIN_ORDER_CLASS,
+	WIN_ORDER_RESOURCE,
+	WIN_ORDER_XY,
+	WIN_ORDER_YX,
+	WIN_ORDER_HW,
+	WIN_ORDER_WH,
+};
+
 typedef struct window_item
 {
-	Window		    frame;
+	Window		    w, frame;
+	int		    x, y;
 	int		    th, bw;
-	unsigned long	    width, height;
+	int		    width, height;
+	int		    min_w, min_h;
+	int		    max_w, max_h;
+	int		    base_w, base_h;
+	int		    inc_w, inc_h;
+	char		   *name;
+	char		   *icon_name;
+	char		   *class;
+	char		   *resource;
+	window_flags	    flags;
 	struct window_item *prev, *next;
 } window_item, *window_list;
 
 /* vars */
 Display		  *dpy;
-int		   dx, dy;
-int		   dwidth, dheight;
 static ModuleArgs *module;
 int		   fd[2];
 fd_set_size_t	   fd_width;
@@ -67,49 +91,180 @@ window_list	   wins = NULL, wins_tail = NULL;
 int		   wins_count = 0;
 FILE		  *console;
 
-/* switches */
-int ofsx = 0, ofsy = 0;
-int maxw = 0, maxh = 0;
-int maxx, maxy;
-int untitled = 0, transients = 0;
-int maximized = 0;
-int all	      = 0;
-int desk      = 0;
-int reversed = 0, raise_window = 1;
-int resize	= 0;
-int nostretch	= 0;
-int sticky_page = 0;
-int sticky_desk = 0;
-int flatx = 0, flaty = 0;
-int incx = 0, incy = 0;
-int horizontal = 0;
-int maxnum     = 0;
+static void	   free_window_list(window_list);
 
-int do_maximize = 0;
-int do_animate	= 0;
-int do_ewmhiwa	= 0;
+/* Computation variables */
+int box_x, box_y, box_w, box_h; /* Box dimensions. */
+int usr_l = 0, usr_r = 0;	/* User adjustments to box. */
+int usr_t = 0, usr_b = 0;
+int inc_x = 0, inc_y = 0;	/* FvwmCascade increment sizes. */
+int c_width = 0, c_height = 0;	/* FvwmCascade window sizes. */
+int max_n	 = 0;		/* FvwmTile maximum rows or cols. */
+int current_desk = 0;
+int win_order = WIN_ORDER_DEFAULT;
 
-int FvwmTile	= 0;
-int FvwmCascade = 1;
+/* Switches */
+int FvwmTile	 = 1;
+int FvwmCascade	 = 0;
+int auto_tile	 = 1;
+int horizontal	 = 0;
+int fill_start	 = 0;
+int fill_end	 = 0;
+int inc_equal	 = 0;
+int flatx	 = 0;
+int flaty	 = 0;
+int raise_window = 1;
+int resize	 = 1;
+int nostretchx	 = 0;
+int nostretchy	 = 0;
+int do_maximize	 = 0;
+int do_animate	 = 0;
+int skip_list	 = 0;
+int sticky_page	 = 0;
+int sticky_desk	 = 0;
+int transients	 = 0;
+int maximized	 = 1;
+int titled	 = 1;
+int desk	 = 0;
+int reversed	 = 0;
+int do_ewmhiwa	 = 0;
+
+/* Monitor to act on. */
+struct monitor *mon;
+int is_global = 0;
+
+void
+free_resources(void)
+{
+	free_window_list(wins);
+
+	if (console != stderr)
+		fclose(console);
+}
 
 RETSIGTYPE
 DeadPipe(int sig)
 {
+	free_resources();
+
 	exit(0);
 	SIGNAL_RETURN;
 }
 
 void
-insert_window_list(window_list *wl, window_item *i)
+insert_window_list(window_item *wi_new)
 {
-	if (*wl) {
-		if ((i->prev = (*wl)->prev))
-			i->prev->next = i;
-		i->next	    = *wl;
-		(*wl)->prev = i;
-	} else
-		i->next = i->prev = NULL;
-	*wl = i;
+	if (wins == NULL) {
+		/* First item, initialize list. */
+		wi_new->next = wi_new->prev = NULL;
+		wins = wins_tail = wi_new;
+	} else {
+		/* Insert item at end. */
+		wi_new->prev = wins_tail;
+		wi_new->next = NULL;
+		wins_tail->next = wi_new;
+		wins_tail = wi_new;
+	}
+}
+
+/* Returns negative if a < b, 0 if a = b, and positive if a > b. */
+int
+compare_window_items(window_item *a, window_item *b)
+{
+	switch (win_order)
+	{
+		case WIN_ORDER_NAME:
+			return strcmp(a->name, b->name);
+		case WIN_ORDER_ICON:
+			return strcmp(a->icon_name, b->icon_name);
+		case WIN_ORDER_CLASS:
+			return strcmp(a->class, b->class);
+		case WIN_ORDER_RESOURCE:
+			return strcmp(a->resource, b->resource);
+		case WIN_ORDER_XY:
+			if (a->x < b->x || (a->x == b->x && a->y < b->y))
+				return -1;
+			else if (a->x == b->x && a->y == b->y)
+				return 0;
+			else
+				return 1;
+		case WIN_ORDER_YX:
+			if (a->y < b->y || (a->y == b->y && a->x < b->x))
+				return -1;
+			else if (a->x == b->x && a->y == b->y)
+				return 0;
+			else
+				return 1;
+		case WIN_ORDER_HW:
+			if (a->height < b->height || (a->height == b->height
+			    && a->width < b->width))
+				return -1;
+			else if (a->height == b->height
+				 && a->width == b->width)
+				return 0;
+			else
+				return 1;
+		case WIN_ORDER_WH:
+			if (a->width < b->width || (a->width == b->width
+			    && a->height < b->height))
+				return -1;
+			else if (a->width == b->width
+				 && a->height == b->height)
+				return 0;
+			else
+				return 1;
+		default:
+			/* Shouldn't happen. */
+			return 0;
+	}
+}
+
+void
+sort_window_items(void)
+{
+	window_item *a, *b, *cur;
+
+	/* Nothing to sort. */
+	if (wins == NULL || win_order == WIN_ORDER_DEFAULT)
+		return;
+
+	/* Insertion short. Simple but not efficient, O(n^2),
+	 * but window lists are small enough it shouldn't matter.
+	 */
+	cur = wins->next;
+	while (cur) {
+		a = cur->prev;
+		b = cur;
+		cur = cur->next;
+
+		/* Find first element smaller than b */
+		while (a && compare_window_items(a, b) > 0)
+			a = a->prev;
+
+		if (a == NULL) {
+			/* Put b at start of list. */
+			b->prev->next = b->next;
+			if (b->next == NULL)
+				wins_tail = b->prev;
+			else
+				b->next->prev = b->prev;
+			b->prev = NULL;
+			b->next = wins;
+			wins->prev = b;
+			wins = b;
+		} else if (a->next != b) {
+			/* Put b between a and a->next */
+			b->prev->next = b->next;
+			if (b->next == NULL)
+				wins_tail = b->prev;
+			else
+				b->next->prev = b->prev;
+			a->next->prev = b;
+			b->next = a->next;
+			b->prev = a;
+			a->next = b;
+		}
+	}
 }
 
 void
@@ -120,6 +275,10 @@ free_window_list(window_list wl)
 	while (wl) {
 		q  = wl;
 		wl = wl->next;
+		free(q->name);
+		free(q->icon_name);
+		free(q->class);
+		free(q->resource);
 		free(q);
 	}
 }
@@ -129,17 +288,28 @@ is_suitable_window(unsigned long *body)
 {
 	XWindowAttributes	xwa;
 	struct ConfigWinPacket *cfgpacket = (void *)body;
+	struct monitor	       *m = monitor_by_output(cfgpacket->monitor_id);
 
-	if ((DO_SKIP_WINDOW_LIST(cfgpacket)) && !all)
+	if (m == NULL) {
+		fprintf(console, "FvwmRearrange: MONITOR WAS NULL\n");
+		return 0;
+	}
+	if (!is_global && strcmp(mon->si->name, m->si->name) != 0)
 		return 0;
 
-	if ((IS_MAXIMIZED(cfgpacket)) && !maximized)
+	if (!skip_list && DO_SKIP_WINDOW_LIST(cfgpacket))
 		return 0;
 
-	if ((IS_STICKY_ACROSS_PAGES(cfgpacket)) && !sticky_page)
+	if (!maximized && IS_MAXIMIZED(cfgpacket))
 		return 0;
 
-	if ((IS_STICKY_ACROSS_DESKS(cfgpacket)) && !sticky_desk)
+	if (!titled && !HAS_TITLE(cfgpacket))
+		return 0;
+
+	if (!sticky_page && IS_STICKY_ACROSS_PAGES(cfgpacket))
+		return 0;
+
+	if (!sticky_desk && IS_STICKY_ACROSS_DESKS(cfgpacket))
 		return 0;
 
 	if (!XGetWindowAttributes(dpy, cfgpacket->w, &xwa))
@@ -148,28 +318,61 @@ is_suitable_window(unsigned long *body)
 	if (xwa.map_state != IsViewable)
 		return 0;
 
-	if (!(IS_MAPPED(cfgpacket)))
+	if (!IS_MAPPED(cfgpacket))
 		return 0;
 
 	if (IS_ICONIFIED(cfgpacket))
 		return 0;
 
-	if (!desk) {
-		int x = (int)cfgpacket->frame_x, y = (int)cfgpacket->frame_y;
-		int w = (int)cfgpacket->frame_width,
-		    h = (int)cfgpacket->frame_height;
-		if (x >= dx + dwidth || y >= dy + dheight || x + w <= dx
-		    || y + h <= dy)
+	if (desk) {
+		if ((int)cfgpacket->desk != current_desk)
+			return 0;
+	} else {
+		/* Only select windows that intersect box. */
+		int x = (int)cfgpacket->frame_x;
+		int y = (int)cfgpacket->frame_y;
+		int w = (int)cfgpacket->frame_width;
+		int h = (int)cfgpacket->frame_height;
+		if (x >= box_x + box_w || x + w <= box_x
+		    || y >= box_y + box_h || y + h <= box_y)
 			return 0;
 	}
 
-	if (!(HAS_TITLE(cfgpacket)) && !untitled)
-		return 0;
-
-	if ((IS_TRANSIENT(cfgpacket)) && !transients)
+	if (!transients && IS_TRANSIENT(cfgpacket))
 		return 0;
 
 	return 1;
+}
+
+void
+process_name(unsigned long type, unsigned long *body)
+{
+	window_item *wi = wins;
+
+	while (wi != NULL && wi->w != body[0])
+		wi = wi->next;
+
+	if (wi == NULL)
+		return;
+
+	switch(type) {
+		case M_RES_NAME:
+			free(wi->resource);
+			wi->resource = fxstrdup((char *)(&body[3]));
+			break;
+		case M_RES_CLASS:
+			free(wi->class);
+			wi->class = fxstrdup((char *)(&body[3]));
+			break;
+		case M_ICON_NAME:
+			free(wi->icon_name);
+			wi->icon_name = fxstrdup((char *)(&body[3]));
+			break;
+		case M_WINDOW_NAME:
+			free(wi->name);
+			wi->name = fxstrdup((char *)(&body[3]));
+			break;
+	}
 }
 
 int
@@ -177,7 +380,7 @@ get_window(void)
 {
 	FvwmPacket	       *packet;
 	struct ConfigWinPacket *cfgpacket;
-	int			last = 0;
+	int			last = 1;
 	fd_set			infds;
 
 	FD_ZERO(&infds);
@@ -192,20 +395,41 @@ get_window(void)
 		case M_CONFIGURE_WINDOW:
 			if (is_suitable_window(packet->body)) {
 				window_item *wi = fxmalloc(sizeof(window_item));
+				wi->w		= cfgpacket->w;
+				wi->x		= cfgpacket->frame_x;
+				wi->y		= cfgpacket->frame_y;
 				wi->frame	= cfgpacket->frame;
 				wi->th		= cfgpacket->title_height;
 				wi->bw		= cfgpacket->border_width;
 				wi->width	= cfgpacket->frame_width;
 				wi->height	= cfgpacket->frame_height;
-				if (!wins_tail)
-					wins_tail = wi;
-				insert_window_list(&wins, wi);
+				wi->base_w	= cfgpacket->hints_base_width;
+				wi->base_h	= cfgpacket->hints_base_height;
+				wi->min_w	= cfgpacket->hints_min_width;
+				wi->min_h	= cfgpacket->hints_min_height;
+				wi->max_w	= cfgpacket->hints_max_width;
+				wi->max_h	= cfgpacket->hints_max_height;
+				wi->inc_w	= cfgpacket->hints_width_inc;
+				wi->inc_h	= cfgpacket->hints_height_inc;
+				wi->flags	= cfgpacket->flags;
+				wi->name	= NULL;
+				wi->icon_name	= NULL;
+				wi->class	= NULL;
+				wi->resource	= NULL;
+				insert_window_list(wi);
 				++wins_count;
 			}
-			last = 1;
+			break;
+
+		case M_RES_NAME:
+		case M_RES_CLASS:
+		case M_ICON_NAME:
+		case M_WINDOW_NAME:
+			process_name(packet->type, packet->body);
 			break;
 
 		case M_END_WINDOWLIST:
+			last = 0;
 			break;
 
 		default:
@@ -213,7 +437,6 @@ get_window(void)
 			    "%s: internal inconsistency: unknown message "
 			    "0x%08x\n",
 			    module->name, (int)packet->type);
-			last = 1;
 			break;
 		}
 	}
@@ -242,18 +465,30 @@ wait_configure(window_item *wi)
 }
 
 int
-atopixel(char *s, unsigned long f)
+atopixel(char *s, int length)
 {
 	int l = strlen(s);
+
 	if (l < 1)
 		return 0;
-	if (isalpha(s[l - 1])) {
+
+	if (s[l - 1] == 'p') {
 		char s2[24];
 		strcpy(s2, s);
 		s2[strlen(s2) - 1] = 0;
 		return atoi(s2);
 	}
-	return (atoi(s) * f) / 100;
+	return (atoi(s) * length) / 100;
+}
+
+int
+frame_size(window_item *wi, int is_width)
+{
+	int length = 2 * wi->bw;
+	if ((is_width && HAS_VERTICAL_TITLE(wi))
+	    || (!is_width && !HAS_VERTICAL_TITLE(wi)))
+		length += wi->th;
+	return length;
 }
 
 void
@@ -261,246 +496,415 @@ move_resize_raise_window(window_item *wi, int x, int y, int w, int h)
 {
 	static char msg[78];
 	const char *ewmhiwa = do_ewmhiwa ? "ewmhiwa" : "";
+	int orig_w = wi->width - frame_size(wi, 1);
+	int orig_h = wi->height - frame_size(wi, 0);
+	int do_wait = 1;
 
-	if (resize) {
+	if (x == wi->x && y == wi->y && (!resize ||
+	    (w == orig_w && h == orig_h))) {
+		/* Window is the same size/position. Do nothing. */
+		do_wait = 0;
+	} else if (resize) {
 		const char *function =
 		    do_maximize ? "ResizeMoveMaximize" : "ResizeMove";
-		snprintf(msg, sizeof(msg), "%s %dp %dp %up %upi %s", function,
-		    w, h, x, y, ewmhiwa);
+		snprintf(msg, sizeof(msg), "%s %dp %dp %up %up %s",
+		    function, w, h, x, y, ewmhiwa);
 		SendText(fd, msg, wi->frame);
 	} else {
-		const char *function = do_maximize  ? "ResizeMoveMaximize"
+		const char *function = do_maximize
+					   ? "ResizeMoveMaximize keep keep"
 				       : do_animate ? "AnimatedMove"
 						    : "Move";
-		if (do_maximize)
-			snprintf(msg, sizeof(msg), "%s keep keep %up %up %s",
-			    function, x, y, ewmhiwa);
-		else
-			snprintf(msg, sizeof(msg), "%s %up %up %s", function, x,
-			    y, ewmhiwa);
+		snprintf(
+		    msg, sizeof(msg), "%s %up %up %s", function, x, y, ewmhiwa);
 		SendText(fd, msg, wi->frame);
 	}
 
 	if (raise_window)
 		SendText(fd, "Raise", wi->frame);
 
-	wait_configure(wi);
+	if (do_wait)
+		wait_configure(wi);
+}
+
+int
+get_hint_size(int val, int base, int min, int max, int inc)
+{
+	if (val < min)
+		val = min;
+	if (val > max)
+		val = max;
+	if (inc > 1) {
+		val = base + ((val - base) / inc) * inc;
+		if (val < min)
+			val += inc;
+	}
+
+	return val;
+}
+
+void
+size_hints_adjustment(window_item *wi, int *w, int *h)
+{
+	/* Subtract borders/title to get size of window. */
+	*w -= frame_size(wi, 1);
+	*h -= frame_size(wi, 0);
+
+	if (HAS_OVERRIDE_SIZE_HINTS(wi))
+		return;
+
+	/* Apply size hints */
+	*w = get_hint_size(*w, wi->base_w, wi->min_w, wi->max_w, wi->inc_w);
+	*h = get_hint_size(*h, wi->base_h, wi->min_h, wi->max_h, wi->inc_h);
+}
+
+void
+size_win_to_cell(window_item *wi, int x, int y, int cell_w, int cell_h,
+		int extra_w, int extra_h)
+{
+		int w = cell_w, h = cell_h;
+
+		if (x < extra_w) {
+			w++;
+			x = box_x + x * cell_w + x;
+		} else {
+			x = box_x + x * cell_w + extra_w;
+		}
+		if (y < extra_h) {
+			h++;
+			y = box_y + y * cell_h + y;
+		} else {
+			y = box_y + y * cell_h + extra_h;
+		}
+
+		if (nostretchx && w > wi->width)
+			w = wi->width;
+		if (nostretchy && h > wi->height)
+			h = wi->height;
+
+		size_hints_adjustment(wi, &w, &h);
+		move_resize_raise_window(wi, x, y, w, h);
+}
+
+window_item
+*fill_cells(window_item *wi, int n, int rows, int cols,
+	int cell_w, int cell_h, int extra_w, int extra_h)
+{
+	int i, extra_wins, cell_l, extra_l;
+
+	if (horizontal) {
+		extra_wins = wins_count % rows;
+		cell_l = box_h / extra_wins;
+		extra_l = box_h % extra_wins;
+	} else {
+		extra_wins = wins_count % cols;
+		cell_l = box_w / extra_wins;
+		extra_l = box_w % extra_wins;
+	}
+
+	for (i = 0; i < extra_wins; i++) {
+		if (horizontal)
+			size_win_to_cell(wi, n, i,
+				cell_w, cell_l, extra_w, extra_l);
+		else
+			size_win_to_cell(wi, i, n,
+				cell_l, cell_h, extra_l, extra_h);
+
+		wi = reversed ? wi->prev : wi->next;
+	}
+	return wi;
 }
 
 void
 tile_windows(void)
 {
-	int	     cur_x = ofsx, cur_y = ofsy;
-	int	     final_w = -1, final_h = -1;
-	int	     wdiv, hdiv, i, j, count = 1;
-	window_item *w = reversed ? wins_tail : wins;
+	int cols = 1, rows = 1, cell_w, cell_h, extra_w, extra_h, n = 0;
+	int x, y, extra_cells;
+	window_item *wi = reversed ? wins_tail : wins;
 
-	if (horizontal) {
-		if ((maxnum > 0) && (maxnum < wins_count)) {
-			count = wins_count / maxnum;
-			if (wins_count % maxnum)
-				++count;
-			hdiv = (maxy - ofsy + 1) / maxnum;
-		} else {
-			maxnum = wins_count;
-			hdiv   = (maxy - ofsy + 1) / wins_count;
+	/* Compute grid dimensions. */
+	if (auto_tile) {
+		if (max_n > 0) {
+			cols += max_n;
+			if (cols > wins_count)
+				cols = wins_count;
 		}
-		wdiv = (maxx - ofsx + 1) / count;
+		if (!fill_end)
+			fill_start = 1;
 
-		for (i = 0; w && (i < count); ++i) {
-			for (j = 0; w && (j < maxnum); ++j) {
-				int nw = wdiv - w->bw * 2;
-				int nh = hdiv - w->bw * 2 - w->th;
-
-				if (resize) {
-					if (nostretch) {
-						if (nw > w->width)
-							nw = w->width;
-						if (nh > w->height)
-							nh = w->height;
-					}
-					final_w = (nw > 0) ? nw : w->width;
-					final_h = (nh > 0) ? nh : w->height;
-				}
-				move_resize_raise_window(
-				    w, cur_x, cur_y, final_w, final_h);
-
-				cur_y += hdiv;
-				w = reversed ? w->prev : w->next;
-			}
-			cur_x += wdiv;
-			cur_y = ofsy;
+		/* Loop to find the desired size. */
+		while (cols * rows < wins_count) {
+			cols++;
+			if (cols * rows < wins_count)
+				rows++;
 		}
+	} else if (max_n > 0 && max_n < wins_count) {
+		rows = (wins_count - 1) / max_n + 1;
+		cols = max_n;
 	} else {
-		if ((maxnum > 0) && (maxnum < wins_count)) {
-			count = wins_count / maxnum;
-			if (wins_count % maxnum)
-				++count;
-			wdiv = (maxx - ofsx + 1) / maxnum;
+		cols = wins_count;
+	}
+	if (horizontal) { /* Swap rows and columns. */
+		int tmp = cols;
+		cols = rows;
+		rows = tmp;
+	}
+
+	/* Compute single cell size. */
+	cell_w  = box_w / cols;
+	cell_h  = box_h / rows;
+	/* Extra space to spread across initial cells. */
+	extra_w = box_w % cols;
+	extra_h = box_h % rows;
+
+	/* Do nothing if cells are too small. */
+	if (cell_w < MIN_CELL_SIZE || cell_h < MIN_CELL_SIZE) {
+		fprintf(console,
+			"FvwmRearrange: Cell size to small. Aborting!");
+		free_resources();
+		exit(1);
+	}
+
+	/* Fill empty cells at start of grid. */
+	extra_cells = cols * rows - wins_count;
+	if (fill_start && extra_cells > 0) {
+		wi = fill_cells(wi, 0, rows, cols,
+			cell_w, cell_h, extra_w, extra_h);
+		n += horizontal ? rows : cols;
+	}
+
+	/* Loop through windows to compute their location and sizes. */
+	while (wi) {
+		if (horizontal) {
+			x = n / rows;
+			y = n % rows;
+			if (fill_end && extra_cells > 0 && x + 1 == cols)
+				break;
 		} else {
-			maxnum = wins_count;
-			wdiv   = (maxx - ofsx + 1) / wins_count;
+			x = n % cols;
+			y = n / cols;
+			if (fill_end && extra_cells > 0 && y + 1 == rows)
+				break;
 		}
-		hdiv = (maxy - ofsy + 1) / count;
+		size_win_to_cell(wi, x, y, cell_w, cell_h, extra_w, extra_h);
 
-		for (i = 0; w && (i < count); ++i) {
-			for (j = 0; w && (j < maxnum); ++j) {
-				int nw = wdiv - w->bw * 2;
-				int nh = hdiv - w->bw * 2 - w->th;
+		wi = reversed ? wi->prev : wi->next;
+		n++;
+	}
 
-				if (resize) {
-					if (nostretch) {
-						if (nw > w->width)
-							nw = w->width;
-						if (nh > w->height)
-							nh = w->height;
-					}
-					final_w = (nw > 0) ? nw : w->width;
-					final_h = (nh > 0) ? nh : w->height;
-				}
-				move_resize_raise_window(
-				    w, cur_x, cur_y, final_w, final_h);
-
-				cur_x += wdiv;
-				w = reversed ? w->prev : w->next;
-			}
-			cur_x = ofsx;
-			cur_y += hdiv;
-		}
+	/* Fill empty cells at end of grid. */
+	if (fill_end && extra_cells > 0) {
+		n = horizontal ? cols - 1 : rows - 1;
+		wi = fill_cells(wi, n, rows, cols, cell_w, cell_h, 0, 0);
 	}
 }
 
 void
 cascade_windows(void)
 {
-	int	     cur_x = ofsx, cur_y = ofsy;
-	int	     final_w = -1, final_h = -1;
-	window_item *w = reversed ? wins_tail : wins;
-	while (w) {
-		unsigned long nw = 0, nh = 0;
-		if (resize) {
-			if (nostretch) {
-				if (maxw && (w->width > maxw))
-					nw = maxw;
-				if (maxh && (w->height > maxh))
-					nh = maxh;
-			} else {
-				nw = maxw;
-				nh = maxh;
-			}
-			if (nw || nh) {
-				final_w = nw ? nw : w->width;
-				final_h = nh ? nh : w->height;
-			}
-		}
-		move_resize_raise_window(w, cur_x, cur_y, final_w, final_h);
+	int x = box_x, y = box_y, w, h;
+	window_item *wi = reversed ? wins_tail : wins;
 
-		if (!flatx)
-			cur_x += w->bw;
-		cur_x += incx;
-		if (!flaty)
-			cur_y += w->bw + w->th;
-		cur_y += incy;
-		w = reversed ? w->prev : w->next;
+	while (wi) {
+		if (resize) {
+			/* Default size is 75% of the bounding box. */
+			w = c_width > 0 ? c_width : 3 * box_w / 4;
+			h = c_height > 0 ? c_height : 3 * box_h / 4;
+
+			if (x + w > box_x + box_w)
+				w = box_x + box_w - x;
+			if (y + h > box_y + box_h)
+				h = box_y + box_h - y;
+			if (nostretchx && w > wi->width)
+				w = wi->width;
+			if (nostretchy && h > wi->height)
+				h = wi->height;
+			size_hints_adjustment(wi, &w, &h);
+		}
+		move_resize_raise_window(wi, x, y, w, h);
+
+		/* Increment x and y to offset next window. */
+		w = flatx ? inc_x : inc_x + frame_size(wi, 1) - wi->bw;
+		h = flaty ? inc_y : inc_y + frame_size(wi, 0) - wi->bw;
+		if (inc_equal) {
+			if (h < w)
+				h = w;
+			else
+				w = h;
+		}
+		x += w;
+		y += h;
+		wi = reversed ? wi->prev : wi->next;
 	}
 }
 
 void
-parse_args(char *s, int argc, char *argv[], int argi)
+parse_args(int argc, char *argv[], int argi)
 {
 	int nsargc = 0;
-	/* parse args */
 	for (; argi < argc; ++argi) {
-		if (!strcmp(argv[argi], "-tile")) {
+		/* Tiling options */
+		if (StrEquals(argv[argi], "-auto_tile")) {
 			FvwmTile    = 1;
 			FvwmCascade = 0;
-			resize	    = 1;
-		} else if (!strcmp(argv[argi], "-cascade")) {
+			auto_tile   = 1;
+		} else if (StrEquals(argv[argi], "-tile")) {
+			FvwmTile    = 1;
+			FvwmCascade = 0;
+			auto_tile   = 0;
+		} else if (StrEquals(argv[argi], "-max_n")
+			   && ((argi + 1) < argc)) {
+			max_n = atoi(argv[++argi]);
+		} else if (StrEquals(argv[argi], "-swap")
+			   || StrEquals(argv[argi], "-h")) {
+			horizontal = 1;
+		} else if (StrEquals(argv[argi], "-fill_start")) {
+			fill_start = 1;
+		} else if (StrEquals(argv[argi], "-fill_end")) {
+			fill_end = 1;
+
+		/* Cascading options */
+		} else if (StrEquals(argv[argi], "-cascade")) {
 			FvwmCascade = 1;
 			FvwmTile    = 0;
-		} else if (!strcmp(argv[argi], "-u")) {
-			untitled = 1;
-		} else if (!strcmp(argv[argi], "-t")) {
-			transients = 1;
-		} else if (!strcmp(argv[argi], "-a")) {
-			all = untitled = transients = maximized = 1;
-			if (FvwmCascade) {
-				sticky_page = 1;
-				sticky_desk = 1;
-			}
-		} else if (!strcmp(argv[argi], "-r")) {
-			reversed = 1;
-		} else if (!strcmp(argv[argi], "-noraise")) {
-			raise_window = 0;
-		} else if (!strcmp(argv[argi], "-noresize")) {
-			resize = 0;
-		} else if (!strcmp(argv[argi], "-nostretch")) {
-			nostretch = 1;
-		} else if (!strcmp(argv[argi], "-desk")) {
-			desk = 1;
-		} else if (!strcmp(argv[argi], "-flatx")) {
+		} else if (StrEquals(argv[argi], "-cascadew")
+			   && ((argi + 1) < argc)) {
+			c_width = ++argi;
+		} else if (StrEquals(argv[argi], "-cascadeh")
+			   && ((argi + 1) < argc)) {
+			c_height = ++argi;
+		} else if (StrEquals(argv[argi], "-inc_equal")) {
+			inc_equal = 1;
+		} else if (StrEquals(argv[argi], "-incx")
+			   && ((argi + 1) < argc)) {
+			inc_x = ++argi;
+		} else if (StrEquals(argv[argi], "-incy")
+			   && ((argi + 1) < argc)) {
+			inc_y = ++argi;
+		} else if (StrEquals(argv[argi], "-flatx")) {
 			flatx = 1;
-		} else if (!strcmp(argv[argi], "-flaty")) {
+		} else if (StrEquals(argv[argi], "-flaty")) {
 			flaty = 1;
-		} else if (!strcmp(argv[argi], "-r")) {
-			reversed = 1;
-		} else if (!strcmp(argv[argi], "-h")) {
-			horizontal = 1;
-		} else if (!strcmp(argv[argi], "-m")) {
-			maximized = 1;
-		} else if (!strcmp(argv[argi], "-s")) {
-			sticky_page = 1;
-			sticky_desk = 1;
-		} else if (!strcmp(argv[argi], "-sp")) {
-			sticky_page = 1;
-		} else if (!strcmp(argv[argi], "-sd")) {
-			sticky_desk = 1;
-		} else if (!strcmp(argv[argi], "-mn") && ((argi + 1) < argc)) {
-			maxnum = atoi(argv[++argi]);
-		} else if (!strcmp(argv[argi], "-resize")) {
-			resize = 1;
-		} else if (!strcmp(argv[argi], "-nostretch")) {
-			nostretch = 1;
-		} else if (!strcmp(argv[argi], "-incx")
+
+		/* General options */
+		} else if (StrEquals(argv[argi], "-screen")
 			   && ((argi + 1) < argc)) {
-			incx = atopixel(argv[++argi], dwidth);
-		} else if (!strcmp(argv[argi], "-incy")
-			   && ((argi + 1) < argc)) {
-			incy = atopixel(argv[++argi], dheight);
-		} else if (!strcmp(argv[argi], "-ewmhiwa")) {
-			do_ewmhiwa = 1;
-		} else if (!strcmp(argv[argi], "-maximize")) {
+			mon = monitor_resolve_name(argv[++argi]);
+			/* Ignore hints for global monitor. */
+			if (mon == monitor_get_global())
+				do_ewmhiwa = is_global = 1;
+		} else if (StrEquals(argv[argi], "-noraise")) {
+			raise_window = 0;
+		} else if (StrEquals(argv[argi], "-maximize")) {
 			do_maximize = 1;
-		} else if (!strcmp(argv[argi], "-nomaximize")) {
-			do_maximize = 0;
-		} else if (!strcmp(argv[argi], "-animate")) {
+		} else if (StrEquals(argv[argi], "-animate")) {
 			do_animate = 1;
-		} else if (!strcmp(argv[argi], "-noanimate")) {
-			do_animate = 0;
+		} else if (StrEquals(argv[argi], "-ewmhiwa")) {
+			do_ewmhiwa = 1;
+
+		/* Resizing options */
+		} else if (StrEquals(argv[argi], "-noresize")) {
+			resize = 0;
+		} else if (StrEquals(argv[argi], "-nostretch")) {
+			nostretchx = nostretchy = 1;
+		} else if (StrEquals(argv[argi], "-nostretchx")) {
+			nostretchx = 1;
+		} else if (StrEquals(argv[argi], "-nostretchy")) {
+			nostretchy = 1;
+
+		/* Filtering options */
+		} else if (StrEquals(argv[argi], "-all")) {
+			sticky_page = sticky_desk = transients = skip_list = 1;
+		} else if (StrEquals(argv[argi], "-some")) {
+			maximized = titled = 0;
+		} else if (StrEquals(argv[argi], "-skiplist")) {
+			skip_list = 1;
+		} else if (StrEquals(argv[argi], "-sticky")) {
+			sticky_page = sticky_desk = 1;
+		} else if (StrEquals(argv[argi], "-sticky_page")) {
+			sticky_page = 1;
+		} else if (StrEquals(argv[argi], "-sticky_desk")) {
+			sticky_desk = 1;
+		} else if (StrEquals(argv[argi], "-transient")) {
+			transients = 1;
+		} else if (StrEquals(argv[argi], "-no_maximized")) {
+			maximized = 0;
+		} else if (StrEquals(argv[argi], "-no_titled")) {
+			titled = 0;
+		} else if (StrEquals(argv[argi], "-desk")) {
+			desk = 1;
+		} else if (StrEquals(argv[argi], "-ewmhiwa")) {
+			do_ewmhiwa = 1;
+
+		/* Window ordering */
+		} else if (StrEquals(argv[argi], "-order_name")) {
+			win_order = WIN_ORDER_NAME;
+		} else if (StrEquals(argv[argi], "-order_icon")) {
+			win_order = WIN_ORDER_ICON;
+		} else if (StrEquals(argv[argi], "-order_class")) {
+			win_order = WIN_ORDER_CLASS;
+		} else if (StrEquals(argv[argi], "-order_resource")) {
+			win_order = WIN_ORDER_RESOURCE;
+		} else if (StrEquals(argv[argi], "-order_xy")) {
+			win_order = WIN_ORDER_XY;
+		} else if (StrEquals(argv[argi], "-order_yx")) {
+			win_order = WIN_ORDER_YX;
+		} else if (StrEquals(argv[argi], "-order_hw")) {
+			win_order = WIN_ORDER_HW;
+		} else if (StrEquals(argv[argi], "-order_wh")) {
+			win_order = WIN_ORDER_WH;
+		} else if (StrEquals(argv[argi], "-reverse")) {
+			reversed = 1;
+
+		/* Bounding box */
 		} else {
-			if (++nsargc > 4) {
+			if (argv[argi][0] == '-' || ++nsargc > 4) {
 				fprintf(console,
-				    "%s: %s: ignoring unknown arg %s\n",
-				    module->name, s, argv[argi]);
+				    "%s: ignoring unknown arg %s\n",
+				    module->name, argv[argi]);
 				continue;
 			}
 			if (nsargc == 1) {
-				ofsx = atopixel(argv[argi], dwidth);
+				usr_l = argi;
 			} else if (nsargc == 2) {
-				ofsy = atopixel(argv[argi], dheight);
+				usr_t = argi;
 			} else if (nsargc == 3) {
-				maxw = atopixel(argv[argi], dwidth);
-				maxx = maxw;
+				usr_r = argi;
 			} else if (nsargc == 4) {
-				maxh = atopixel(argv[argi], dheight);
-				maxy = maxh;
+				usr_b = argi;
 			}
 		}
 	}
-	ofsx += dx;
-	ofsy += dy;
-	maxx += dx;
-	maxy += dy;
+}
+
+void
+update_sizes(char *argv[])
+{
+	int left = 0, top = 0;
+
+	/* Adjust box size first. */
+	if (usr_l > 0)
+		left = atopixel(argv[usr_l], box_w);
+	if (usr_t > 0)
+		top = atopixel(argv[usr_t], box_h);
+	if (usr_r > 0)
+		box_w = atopixel(argv[usr_r], box_w);
+	if (usr_b > 0)
+		box_h = atopixel(argv[usr_b], box_h);
+	box_x += left;
+	box_y += top;
+	box_w -= left;
+	box_h -= top;
+
+	/* Cascade increments, based off size of resulting bounding box. */
+	if (inc_x > 0)
+		inc_x = atopixel(argv[inc_x], box_w);
+	if (inc_y > 0)
+		inc_y = atopixel(argv[inc_y], box_h);
+	if (c_width > 0)
+		c_width = atopixel(argv[c_width], box_w);
+	if (c_height > 0)
+		c_height = atopixel(argv[c_height], box_h);
 }
 
 int
@@ -515,7 +919,7 @@ main(int argc, char *argv[])
 
 	module = ParseModuleArgs(argc, argv, 0);
 	if (module == NULL) {
-		fvwm_debug(__func__,
+		fprintf(console,
 		    "FvwmRearrange: module should be executed by fvwm only\n");
 		exit(-1);
 	}
@@ -533,44 +937,78 @@ main(int argc, char *argv[])
 	FScreenInit(dpy);
 	fd_width = GetFdWidth();
 
+	/* Need to parse args first so we know what monitor to use. */
+	parse_args(module->user_argc, module->user_argv, 0);
+	if (mon == NULL)
+		mon = monitor_get_current();
+
+	box_x = mon->si->x;
+	box_y = mon->si->y;
+	box_w = mon->si->w;
+	box_h = mon->si->h;
+
 	strcpy(match, "*");
 	strcat(match, module->name);
 	InitGetConfigLine(fd, match);
-	GetConfigLine(fd, &config_line);
-	while (config_line != NULL) {
-		GetConfigLine(fd, &config_line);
+	for (GetConfigLine(fd, &config_line); config_line != NULL;
+	     GetConfigLine(fd, &config_line)) {
+		char *token, *next, *mname;
+		int   dummy, bs_top, bs_bottom, bs_left, bs_right;
+
+		token = PeekToken(config_line, &next);
+		if (!StrEquals(token, "Monitor"))
+			continue;
+
+		config_line = GetNextToken(next, &mname);
+
+		/* Skip unless we found the correct monitor or using global
+		 * monitor for the full desk, so we need to set current_desk.
+		 */
+		if (!StrEquals(mname, mon->si->name)
+		    && !(is_global && desk))
+			continue;
+
+		sscanf(config_line, "%d %d %d %d %d %d %d %d %d %d %d %d %d %d",
+		    &dummy, &dummy, &dummy, &dummy, &dummy, &dummy, &dummy,
+		    &current_desk, &dummy, &dummy, &bs_left, &bs_right, &bs_top,
+		    &bs_bottom);
+		if (!do_ewmhiwa) {
+			box_x += bs_left;
+			box_y += bs_top;
+			box_w -= bs_left + bs_right;
+			box_h -= bs_top + bs_bottom;
+		}
 	}
-	FScreenGetScrRect(NULL, FSCREEN_CURRENT, &dx, &dy, &dwidth, &dheight);
 
-	parse_args("module args", module->user_argc, module->user_argv, 0);
+	/* Update sizes now that monitor + working area dimensions are known */
+	update_sizes(module->user_argv);
 
-	SetMessageMask(fd, M_CONFIGURE_WINDOW | M_END_WINDOWLIST);
-	SetMessageMask(fd, M_EXTENDED_MSG);
-
-	if (FvwmTile) {
-		if (maxx == dx)
-			maxx = dx + dwidth;
-		if (maxy == dy)
-			maxy = dy + dheight;
-	}
+	SetMessageMask(fd,
+		M_CONFIGURE_WINDOW
+		| M_END_WINDOWLIST
+		| M_WINDOW_NAME
+		| M_ICON_NAME
+		| M_RES_CLASS
+		| M_RES_NAME
+	);
 
 	SendText(fd, "Send_WindowList", 0);
 
-	/* tell fvwm we're running */
+	/* Tell fvwm we're running */
 	SendFinishedStartupNotification(fd);
 
 	while (get_window()) /* */
 		;
+
+	sort_window_items();
 	if (wins_count) {
 		if (FvwmCascade)
 			cascade_windows();
 		else /* FvwmTile */
 			tile_windows();
 	}
-	free_window_list(wins);
 
-	if (console != stderr)
-		fclose(console);
+	free_resources();
 
 	return 0;
 }


### PR DESCRIPTION
Update, improve, rewrite, and add to the functionality of FvwmRearrange to fix issues, better understand monitors and their working area, make use of window hints when computing window sizes, and more. The following is a summary of the changes.

* Update fvwm to send the base struts with the monitor information to modules.
* Add a `-screen` option. Default to current monitor.
* Parse Monitor lines from `M_CONFIG_INFO` to get both the base struts and current desk. The default bounding box is the monitors working area.
* Compare windows desk against current_desk with `-desk` option, so now only windows on the same desk are included. If using the global screen, `-screen g`, this will use the current desk of the last monitor sent.
* Store windows flags, position and size hints. Use window hints to compute the final size of the window (to match what fvwm would do). This honors `ResizeHintOverride` style and only uses size hints if that style is not set. Note, aspect ratio hints are not supplied to modules so will be ignored.
* Skip sending Move/Resize commands to windows whose size or position will not change.
* Redo math and logic for tiling and cascading functions. This simplifies things, and vertical and horizontal tiling are no
  longer separate loops.
* Restructure a lot of the options and rename one letter options.
* Update the manual page to list all the current options and describe new behavior. Options are grouped by tiling options, cascade options, general options, resizing options, filtering options, and ordering options.
* Cascade windows resizes by default so it is consistent with tiling, remove the `-resize` option reducing this to a single `-noresize` flag to stop resizing for both tiling and cascading. The default size for cascading is 75 percent of the bounding box.
* Add option `-cascadew` and `-cascadeh` to specific size to make cascaded windows. This accepts both percent of bounding box and pixel sizes.
* Honor title bars placed in other locations besides the top, this way the padding due to the frame is correctly computed when using vertical tile bars. Note title bars on the bottom or right will not be visible when cascading windows, but their width will still affect offsets.
* Add `-fill_start` and `-fill_end` options when tiling windows. This will allow empty cells in the grid to be filled by expanding windows in the first row/column or last row/column.
* Add `-auto_tile` option which computes the size of the grid to tile in based off the number of windows. Make this behavior default if no options are sent. The default is to keep columns and rows close to equal, but this can be modified with the `-max_n` option which states the number of more columns (or rows with -h) to use.
* Add `-inc_equal` option for cascading windows to make the x and y incremental offsets equal to the maximum of the two computed offsets using the default or combined with `-incx`, `-incy`, `-flatx`, and `-flaty` options.
* Rename `-h` option as `-swap`, as this is more accurately describing what the option does, swaps the columns and rows before tiling. The old option `-h` is still accepted as an alias for `-swap`.
* Add options to order the windows beyond the default order using the WindowList. These are `-order_name`, `-order_icon`, `-order_class`, `-order_resource`, `-order_xy`, `-order_yx`, `-order_hw`, and `-order_wh`.
* Format FvwmRearrange.c's code.
* Make FvwmRearrange use an event loop to deal with events instead of waiting for each response. This uses a 10 second timeout (more than enough time) to complete its computation and move/resize windows.