### PR TITLE
FvwmMFL: start by default

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -79,7 +79,6 @@ AddToFunc   StartFunction
 + I Test (Init) InitBackground
 + I Module FvwmButtons RightPanel
 + I Module FvwmEvent EventNewDesk
-+ I Module FvwmMFL
 
 # Function to set background when fvwm starts
 DestroyFunc InitBackground

--- a/doc/FvwmMFL.adoc
+++ b/doc/FvwmMFL.adoc
@@ -31,10 +31,10 @@ packet has different fields, depending on the type requested.
 == COMMUNICATION
 
 The default unix-domain socket for _FvwmMFL_ is
-_$TMPDIR/fvwmmfl/fvwm_mfl_$DISPLAY.sock_.
+*$TMPDIR/fvwmmfl/fvwm_mfl_$DISPLAY.sock*.
 
-The path for where _fvwm_mfl-$DISPLAY_.sock is created can be changed by
-setting the _FVWMMFL_SOCKET_PATH_ environment variable.  _FvwmMFL_ will create
+The path for where *fvwm_mfl_$DISPLAY.sock* is created can be changed by
+setting the *FVWMMFL_SOCKET_PATH* environment variable.  _FvwmMFL_ will create
 this if it does not exist, and set relevant permissions.
 
 == REGISTERING INTEREST

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1283,6 +1283,7 @@ static void SetRCDefaults(void)
 		{ "ImagePath "FVWM_DATADIR"/default-config/images", "", "" },
 		{ "SetEnv FVWM_DATADIR "FVWM_DATADIR"", "", "" },
 		{ "SetEnv FVWM_IS_FVWM3 1", "", "" },
+		{ "Module FvwmMFL", "", "" },
 		/* The below is historical -- before we had a default
 		 * configuration which defines these and more.
 		 */
@@ -1325,9 +1326,9 @@ static void SetRCDefaults(void)
 		{ "Mouse 1 MI A MenuSelectItem", "", "" },
 		/* Default escape from CusorBarriers */
 		{ "Key D A CS CursorBarrier destroy", "", "" },
+		{ "Read "FVWM_DATADIR"/ConfigFvwmDefaults", "", "" },
 		/* don't add anything below */
 		{ RC_DEFAULTS_COMPLETE, "", "" },
-		{ "Read "FVWM_DATADIR"/ConfigFvwmDefaults", "", "" },
 		{ NULL, NULL, NULL }
 	};
 


### PR DESCRIPTION
Make FVWM responsible for starting this module unconditionally.
    
If a user wishes to change where FvwmMFL puts its socket, the env var `FVWMMFL_SOCKET_PATH` must now be set before FVWM starts up.  It won't be enough to set this in `~/.fvwm/config`, unless one issues a `KillModule FvwmMFL` first.