### PR TITLE
Add Maximize keepgrowing flag.

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -4473,8 +4473,8 @@ first, then horizontally to find space. Instead of the horizontal
 "grow" argument, "_growleft_" or "_growright_" can be used
 respectively "_growup_" and "_growdown_". The optional _flags_
 argument is a space separated list containing the following key words:
-_fullscreen_, _ewmhiwa_, _growonwindowlayer_, _growonlayers_ and
-_screen_. _fullscreen_ causes the window to become fullscreened if the
+_fullscreen_, _ewmhiwa_, _growonwindowlayer_, _growonlayers_, _keepgrowing_,
+and _screen_. _fullscreen_ causes the window to become fullscreened if the
 appropriate EWMH hint is set. _ewmhiwa_ causes fvwm to ignore the EWMH
 working area. _growonwindowlayer_ causes the various grow methods to
 ignore windows with a layer other than the current layer of the window
@@ -4482,7 +4482,9 @@ which is maximized. The _growonlayers_ option must have two integer
 arguments. The first one is the minimum layer and the second one the
 maximum layer to use. Windows that are outside of this range of layers
 are ignored by the grow methods. A negative value as the first or
-second argument means to assume no minimum or maximum layer. _screen_
+second argument means to assume no minimum or maximum layer. _keepgrowing_
+will allow the window to keep growing beyond any window it is currently
+touching until it grows into the next closest window boundary. _screen_
 must have an argument which specifies the screen on which to operate.
 +
 Here are some examples. The following adds a title-bar button to

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -5157,6 +5157,7 @@ void CMD_Maximize(F_CMD_ARGS)
 	Bool is_screen_given = False;
 	Bool ignore_working_area = False;
 	Bool do_fullscreen = False;
+	bool consider_touching = true;
 	int layers[2] = { -1, -1 };
 	Bool global_flag_parsed = False;
 	rectangle scr;
@@ -5214,6 +5215,11 @@ void CMD_Maximize(F_CMD_ARGS)
 					layers[0] = -1;
 					layers[1] = -1;
 				}
+			}
+			else if (StrEquals(token, "keepgrowing"))
+			{
+				consider_touching = false;
+				action = taction;
 			}
 			else if (StrEquals(token, "fullscreen"))
 			{
@@ -5433,7 +5439,7 @@ void CMD_Maximize(F_CMD_ARGS)
 					page.y + scr.y + scr.height - bound.y;
 			}
 			grow_to_closest_type(fw, &new_g, bound, layers,
-				SNAP_NONE, true);
+				SNAP_NONE, consider_touching);
 		}
 		else if (val2 > 0)
 		{
@@ -5454,7 +5460,7 @@ void CMD_Maximize(F_CMD_ARGS)
 					page.x + scr.x + scr.width - bound.x;
 			}
 			grow_to_closest_type(fw, &new_g, bound, layers,
-				SNAP_NONE, true);
+				SNAP_NONE, consider_touching);
 		}
 		else if (val1 >0)
 		{


### PR DESCRIPTION
Add new `keepgrowing` flag to the Maximize function, which when growing windows will allow the window to grow beyond any window it is currently touching. This can be used similar to `Move shuffle` to grow windows to the next closest window boundary if currently touching a window.

Windows with size hint increments don't always work the best with this since they may not grow into the full space, thus won't be touching the next window and cannot grow beyond them. `Move shuffle` the window to touch before growing could help with this, though is clunky.