### PR TITLE
IconMan: suppress `-Wformat-overflow=`

### DIFF
--- a/modules/FvwmIconMan/winlist.c
+++ b/modules/FvwmIconMan/winlist.c
@@ -113,8 +113,11 @@ static int matches_string (NameType type, char *pattern, char *tname,
 
   ConsoleDebug (WINLIST, "matches_string: type: 0x%x pattern: %s\n",
 		type, pattern);
-  ConsoleDebug (WINLIST, "\tstrings: %s:%s %s:%s\n", tname, iname,
-		rname, cname);
+  ConsoleDebug (WINLIST, "\tstrings: %s:%s %s:%s\n",
+                tname ? tname : "(null)",
+                iname ? iname : "(null)",
+                rname ? rname : "(null)",
+                cname ? cname : "(null)");
 
   if (tname && (type == ALL_NAME || type == TITLE_NAME)) {
     ans |= matchWildcards (pattern, tname);


### PR DESCRIPTION
The compiler is unable to determine if these values are never null. Although it's unlikely to be encountered, provide fallback values in the call to ConsoleDebug that uses them directly.
