### PR TITLE
Add XFixes support and CusorBarrier command.

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -4329,6 +4329,53 @@ MoveToDesk 0 n
 
 === Focus & Mouse Movement
 
+*CursorBarrier* [destroy] [options] [_left_ _top_ _right_ _bottom_]::
+	A cursor barrier is a box that the cursor cannot be moved outside of
+	(unless warped with _CursorMove_ or _WarpToWindow_). The _left_, _top_,
+	_right_, and _bottom_ values give the percent distance the box is placed
+	from each of the corresponding edges of the desktop. If the values end
+	with a _p_, they are interpreted as pixel amounts instead. If the option
+	_coords_ is given, the values are interpreted as the left/top and
+	right/bottom coordinates of the box's corners. If the option
+	_screen RandRname_ is given, the positions are computed relative to the
+	specified monitor. Use _screen c_ to place the barrier on the current
+	monitor.
++
+Multiple barriers can be created by calling _CursorBarrier_ multiple times.
+This allows creating multiple regions to confine the cursor to (such as each
+monitor in a multi-monitor setup), then use _CursorMove_ or _WarpToWindow_
+to move the cursor between the barriers. If the command _destroy_ is included,
+all barriers are destroyed allowing free movement of the mouse again. If
+_destroy_ is followed by an integer _N_, only that barrier is destroyed
+(barriers are numbered in the order they are created starting at 0). If the
+integer is negative, this counts backwards, such as "-1" is the most recent
+created barrier, "-2" is the second most recent, and so on. When a barrier
+is destroyed, this renumbers all barriers after it. In practice this is
+best used with _destroy -1_ to destroy the most recent barrier without
+affecting any previously created barriers.
++
+By default the key binding ctrl+shift+D will destroy all cursor barriers
+by calling _CursorBarrier destroy_.
++
+Here are some examples:
++
+....
+# A barrier 15% from left/right and 10% from top/bottom.
+CursorBarrier 15 10 15 10
+
+# A barrier to confine the mouse to the current monitor.
+CursorBarrier screen c
+
+# A barrier to confine the mouse to a selected window
+Pick CursorBarrier coords $[w.x]p $[w.y]p \
+    $[math.+.$[w.x],$[w.width]]p $[math.+.$[w.y],$[w.height]]p
+
+# Destroy all barriers
+CursorBarrier destroy
+....
++
+_CursorBarrier_ only works if fvwm is complied with the XFixes extension.
+
 *CursorMove* _horizontal_[p] _vertical_[p]::
 	Moves the mouse pointer by _horizontal_ pages in the X direction and
 	_vertical_ pages in the Y direction. Either or both entries may be

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -40,6 +40,7 @@ enum
 	F_CONFIG_LIST,
 	F_COPY_MENU_STYLE,
 	F_CURRENT,
+	F_CURSOR_BARRIER,
 	F_CURSOR_STYLE,
 	F_DESCHEDULE,
 	F_DESKTOP_CONFIGURATION,
@@ -225,6 +226,7 @@ void CMD_ColormapFocus(F_CMD_ARGS);
 void CMD_Colorset(F_CMD_ARGS);
 void CMD_CopyMenuStyle(F_CMD_ARGS);
 void CMD_Current(F_CMD_ARGS);
+void CMD_CursorBarrier(F_CMD_ARGS);
 void CMD_CursorMove(F_CMD_ARGS);
 void CMD_CursorStyle(F_CMD_ARGS);
 void CMD_DefaultFont(F_CMD_ARGS);

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -146,6 +146,9 @@ const func_t func_table[] =
 	CMD_ENT("current", CMD_Current, F_CURRENT, 0, 0),
 	/* - Operate on the currently focused window */
 
+	CMD_ENT("cursorbarrier", CMD_CursorBarrier, F_CURSOR_BARRIER, 0, 0),
+	/* - Manage barriers the cursor cannot moved out of unless warped */
+
 	CMD_ENT("cursormove", CMD_CursorMove, F_MOVECURSOR, 0, 0),
 	/* - Move the cursor pointer non interactively */
 

--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1250,6 +1250,9 @@ static void setVersionInfo(void)
 #ifdef HAVE_XFT
 	strlcat(support_str, " XFT,", sizeof(support_str));
 #endif
+#ifdef HAVE_XFIXES
+	strlcat(support_str, " XFixes,", sizeof(support_str));
+#endif
 #ifdef HAVE_NLS
 	strlcat(support_str, " NLS,", sizeof(support_str));
 #endif
@@ -1320,6 +1323,8 @@ static void SetRCDefaults(void)
 		{ "Key Up M A MenuMoveCursor -1", "", "" },
 		{ "Key Down M A MenuMoveCursor 1", "", "" },
 		{ "Mouse 1 MI A MenuSelectItem", "", "" },
+		/* Default escape from CusorBarriers */
+		{ "Key D A CS CursorBarrier destroy", "", "" },
 		/* don't add anything below */
 		{ RC_DEFAULTS_COMPLETE, "", "" },
 		{ "Read "FVWM_DATADIR"/ConfigFvwmDefaults", "", "" },

--- a/meson.build
+++ b/meson.build
@@ -348,6 +348,12 @@ if xcursor.found()
     conf.set10('HAVE_XCURSOR', true)
 endif
 
+xfixes = dependency('xfixes', required: get_option('xfixes'))
+if xfixes.found()
+    all_found_deps += xfixes
+    conf.set10('HAVE_XFIXES', true)
+endif
+
 xkbcommon = dependency('xkbcommon', required: get_option('xkbcommon'))
 if xkbcommon.found()
     all_found_deps += xkbcommon
@@ -568,6 +574,7 @@ featurevals = {
     'Shaped Windows': xext.found() ? xext : false,
     'SVG support': librsvg.found() ? librsvg : false,
     'Xcursor': xcursor.found() ? xcursor : false,
+    'XFixes': xfixes.found() ? xfixes : false,
     'xkbcommon': xkbcommon.found() ? xkbcommon : false,
     'XPM support': xpm.found() ? xpm : false,
     'XRender': xrender.found() ? xrender : false,

--- a/meson.options
+++ b/meson.options
@@ -89,6 +89,12 @@ option(
     description: 'Enable Xcursor support',
 )
 option(
+    'xfixes',
+    type: 'feature',
+    value: 'auto',
+    description: 'Enable XFixes support',
+)
+option(
     'xkbcommon',
     type: 'feature',
     value: 'auto',


### PR DESCRIPTION
CursorBarrier is a command to create a PointerBarrier using the XFixes extension. This barrier can be used to confine mouse movement to any rectangle on the desktop. This first adds XFixes as an optional dependency, and if XFixes is included, the CursorBarrier option can be used to create PointerBarriers.

CursorBarrier can be use to both create and destroy barriers. Currently `MAX_BARRIERS` is set at 16, so only up to 16 barriers can be created at a single time. The use of CursorBarrier is documented in the manual page.

The main intent of this is to allow a toggle to confine the mouse to a specific monitor (often the current monitor) using `CursorBarrier screen c` and `CursorBarrier destroy`, as mentioned requested in #603. This can also be used to confine the mouse to any specified rectangle or screen on the desktop, define multiple barriers, and use CursorMove or WarpToWindow to move between them.

I almost added a `window` option to specify a barrier to a specific window, but opted not to at this time. The following will confine the mouse to a selected window already (the only thing a `window` option would provide is computing coordinates relative to the windows position and size).

```
Pick CursorBarrier coords $[w.x]p $[w.y]p $[math.+.$[w.x],$[w.width]]p $[math.+.$[w.y],$[w.height]]p
```