### PR TITLE
configargsnew: fix module packet

### DIFF
--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -320,7 +320,7 @@ action_flags *_get_allowed_actions(const FvwmWindow *fw)
 		&(*(_fw))->Desk,			\
 		(unsigned long)(0),			\
 		&(*(_fw))->m->si->rr_output,		\
-		(unsigned long)(sizeof(unsigned long)),\
+		(unsigned long)(0),			\
 		&(*(_fw))->layer,			\
 		(unsigned long)(0),			\
 		&(*(_fw))->hints.base_width,		\


### PR DESCRIPTION
Correctly pad the fields in the struct used to send over a window
packet.  This was a hold-over from a previous fix.
