### PR TITLE
add_window: force style lookup

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2355,6 +2355,9 @@ FvwmWindow *AddWindow(
 		/****** layer ******/
 		setup_layer(fw, &style);
 
+		/* Lookup the window style. */
+		lookup_style(fw, &style);
+
 		/****** window placement ******/
 		attr_g.x = wattr.x;
 		attr_g.y = wattr.y;


### PR DESCRIPTION
When a window is about to be mapped, for a style lookup on that window.

This fixes an issue seen where restored Chrome windows aren't having
their styles picked up properly.  This is most likely due to class-hints
not being set appropriately, but this lookup doesn't affect anything
else, so there's little harm in adding it.
