### PR TITLE
FvwmPager: Use ULONG_MAX to identify a non configured Pixel.

### DIFF
--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -183,9 +183,9 @@ void initialize_desks_and_monitors(void)
 	default_style->bg = GetSimpleColor("white");
 	default_style->hi_fg = GetSimpleColor("black");
 	default_style->hi_bg = GetSimpleColor("grey");
-	default_style->win_fg = None; /* Use fvwm pixel unless defined. */
+	default_style->win_fg = ULONG_MAX; /* Use fvwm pixel unless defined. */
 	default_style->win_bg = None;
-	default_style->focus_fg = None;
+	default_style->focus_fg = ULONG_MAX;
 	default_style->focus_bg = None;
 	default_style->balloon_fg = None;
 	default_style->balloon_bg = None;

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -2055,7 +2055,7 @@ void setup_balloon_window(PagerWindow *t)
 	Balloon.cs = style->balloon_cs;
 
 	fg = (style->balloon_fg) ? style->balloon_fg :
-	     (style->win_fg) ? style->win_fg : t->text;
+	     (style->win_fg < ULONG_MAX) ? style->win_fg : t->text;
 	XSetForeground(dpy, Balloon.gc, fg);
 
 	XUnmapWindow(dpy, Scr.balloon_w);

--- a/modules/FvwmPager/x_update.c
+++ b/modules/FvwmPager/x_update.c
@@ -294,10 +294,10 @@ void do_label_window(PagerWindow *t, Window w, rectangle r)
 	DeskStyle *style = FindDeskStyle(t->desk);
 
 	if (t == FocusWin) {
-		pix = (style->focus_fg) ? style->focus_fg : Scr.focus_win_fg;
+		pix = (style->focus_fg < ULONG_MAX) ? style->focus_fg : Scr.focus_win_fg;
 		cs = style->focus_cs;
 	} else {
-		pix = (style->win_fg) ? style->win_fg : t->text;
+		pix = (style->win_fg < ULONG_MAX) ? style->win_fg : t->text;
 		cs = style->win_cs;
 	}
 	XSetForeground(dpy, Scr.NormalGC, pix);
@@ -453,7 +453,7 @@ void do_border_window(PagerWindow *t, Window w, rectangle r)
 	}
 
 	if (t == FocusWin) {
-		if (style->focus_fg)
+		if (style->focus_fg < ULONG_MAX)
 			XSetForeground(dpy,
 				style->focus_hi_gc, style->focus_fg);
 		else
@@ -464,7 +464,7 @@ void do_border_window(PagerWindow *t, Window w, rectangle r)
 				style->focus_hi_gc, style->focus_hi_gc,
 				WindowBorderWidth);
 	} else {
-		if (style->win_fg)
+		if (style->win_fg < ULONG_MAX)
 			XSetForeground(dpy,
 				style->win_hi_gc, style->win_fg);
 		else


### PR DESCRIPTION
The black pixel is 0, so if a user configures the window foreground or focus foreground to be black, when testing if the pixel has been configured, the test fails and the pager falls back to using the pixel provided by fvwm. Instead use ULONG_MAX to identify if the window foreground and focus foreground pixel has been defined by the user or not.

This fixes #1105.