### PR TITLE
FvwmEvent pass monitor ID with new_page and new_desk.

### DIFF
--- a/default-config/config
+++ b/default-config/config
@@ -166,7 +166,7 @@ AddToFunc   ChangeDesk
 + I SendToModule FvwmButtons ChangeButton desk1 Colorset 10
 + I SendToModule FvwmButtons ChangeButton desk2 Colorset 10
 + I SendToModule FvwmButtons ChangeButton desk3 Colorset 10
-+ I SendToModule FvwmButtons ChangeButton desk$0 Colorset 11
++ I SendToModule FvwmButtons ChangeButton desk$[monitor.$0.desk] Colorset 11
 
 
 #############

--- a/doc/FvwmEvent.adoc
+++ b/doc/FvwmEvent.adoc
@@ -105,9 +105,11 @@ setting
 *FvwmEvent: PassId::
   Specifies that the event action will have an ID parameter added to the
   end of the command line. Most events will have the windowID of the
-  window that the event refers to, new_desk will have the new desk
-  number. The windowID is a hexadecimal string preceded by 0x, desk
-  numbers are decimal.
+  window that the event refers to, new_page and new_desk will have the
+  RandR output ID of the monitor (which can be used to get the current
+  desk or page with $[monitor.$0.desk], $[monitor.$0.pagex], or
+  $[monitor.$0.pagey]). The windowID is a hexadecimal string preceded by
+  0x, RandR output IDs are decimal.
 
 *FvwmEvent: window-manager-event action-or-filename::
   Binds particular actions to window manager events.

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -1569,17 +1569,22 @@ $[pointer.screen]::
 +
 This is deprecated; use $[monitor.current] instead.
 
-$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width], $[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.prev_primary], $[monitor.current], $[monitor.prev] $[monitor.output], $[monitor.number] $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
+$[monitor.<n>.x], $[monitor.<n>.y], $[monitor.<n>.width], $[monitor.<n>.height], $[monitor.<n>.desk], $[monitor.<n>.pagex], $[monitor.<n>.pagey] $[monitor.primary], $[monitor.prev_primary], $[monitor.current], $[monitor.prev] $[monitor.<n>.output], $[monitor.<n>.number] $[monitor.count], $[monitor.<n>.prev_desk], $[monitor.<n>.prev_pagex], $[monitor.<n>.prev_pagey]::
 	Returns information about the selected monitor. These can be nested, for
 	example: $[monitor.$[monitor.primary].width]
 +
-<n> should be a valid xrandr(1) output name.
+<n> can be the monitor's RandR name, the monitor's number (see "number"
+below), or the monitor's output (see "output" below).
 +
 "x" returns the monitor's x position; "y" returns the monitor's y
 position; "width" returns the monitor's width (in pixels); "height"
 returns the monitor's height (in pixels)
 +
+"name" returns the monitor's RandR name. See xrandr(1).
++
 "number" returns the monitor's position within the tree.  See RANDR SUPPORT.
++
+"output" returns the monitor's RandR output ID number.
 +
 "current" is the same as the deprecated $[screen.pointer] variable; the
 monitor which has the mouse pointer.

--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -252,8 +252,21 @@ monitor_resolve_name(const char *scr)
 	 * information we have.
 	 */
 	pos = strtonum(scr, 0, INT_MAX, &errstr);
-	if (errstr == NULL)
-		return (monitor_by_number(pos));
+	if (errstr == NULL) {
+		m = monitor_by_number(pos);
+
+		if (m != NULL)
+			return (m);
+
+		/* This number may refer to an output ID, check that. */
+		m = monitor_by_output(pos);
+
+		/* The above may have returned a fallback monitor. */
+		if (m->si->rr_output == pos)
+			return (m);
+		else
+			return (NULL);
+	}
 
 	/* "@g" is for the global screen. */
 	if (strcmp(scr, "g") == 0) {

--- a/modules/FvwmEvent/FvwmEvent.c
+++ b/modules/FvwmEvent/FvwmEvent.c
@@ -101,8 +101,8 @@ static char *audio_play_dir = NULL;
 #define EVENT_ENTRY(name,action_arg) { name, action_arg, {NULL} }
 static event_entry message_event_table[] =
 {
-	EVENT_ENTRY( "new_page", -1 ),
-	EVENT_ENTRY( "new_desk", 0 | ARG_NO_WINID ),
+	EVENT_ENTRY( "new_page", 7 | ARG_NO_WINID ),
+	EVENT_ENTRY( "new_desk", 1 | ARG_NO_WINID ),
 	EVENT_ENTRY( "old_add_window", 0 ),
 	EVENT_ENTRY( "raise_window", 0 ),
 	EVENT_ENTRY( "lower_window", 0 ),


### PR DESCRIPTION
First, update `monitor_resolve_name()` to allow looking up monitors by their RandR output ID, so `$[monitor.outputID.foo]` can be used to get info about a monitor from its RandR output ID.

Second, when FvwmEvent sends a `new_page` or `new_desk` event, pass the monitor's output ID if `PassId` is used. This way the event's function can find information about the monitor that was changed using `$[monitor.$0.desk]`, `$[monitor.$0.pagex]`, and `$[monitor.$0.pagey]`.

This is a breaking change as the `new_desk` event no longer sends the desk, so configs will have to be updated to use `$[monitor.$0.desk]` to get the desk instead.