### PR TITLE
Remove obsoleted commands.

### DIFF
--- a/bin/fvwm-convert-2.6.in
+++ b/bin/fvwm-convert-2.6.in
@@ -42,17 +42,17 @@ sub __convert_conditionals
 {
     my( $cond ) = @_;
     my( $line ) = $cond->[-1];
-	my $condition_cmds = 
+	my $condition_cmds =
 		qr/(all|current|direction|next|none|prev|pick|thiswindow|windowid)/;
 
     # Take the last component.  We no longer care for "[*]" as conditional
     # command parameters.  But we shouldn't really put another conditional
     # in its place, so we'll just remove it.
     $line =~ s/\[\*\]//;
-    
+
     # And convert over Next [$1] syntax.
     $line =~ s/$condition_cmds\s*\[(.*?)\]/\($1\)/io;
-    
+
     $line = "$1 ". join( ', ', split( /[^,](\s+)[^,]/, $2 ) ) . " $3" if $line =~
     /$condition_cmds\s*(\(.*?\))(.*)/io;
 
@@ -72,7 +72,7 @@ sub process_files
 
         warn "Following:  Read $s...\n" if $process_read;
 
-        if( !defined $d or $d eq '' ) 
+        if( !defined $d or $d eq '' )
         {
             my $fbasename = basename( $s );
             $d = "$cwd_path/$fbasename.converted";
@@ -86,7 +86,7 @@ sub process_files
             "Unable to open source file:  $!\n";
 
         while( <$in_file> )
-        {  
+        {
             chomp;
 
             # We have to handle continuation lines here, such as:
@@ -100,7 +100,7 @@ sub process_files
             }
             dispatch_line($_);
         }
-        
+
         write_out_file($d);
         @converted_lines = ();
         %converted_funcs = ();
@@ -153,14 +153,81 @@ sub handle_modulepath
     push( @converted_lines, "# Commented out by fvwm-convert-2.6:  $line" );
 }
 
+# Convert pixmappath/Iconpath to ImagePath
+sub convert_pixmappath
+{
+    my( $line ) = @_;
+
+    $line =~ s/^\s*(?:pixmappath|iconpath)/ImagePath/i;
+
+    push @converted_lines, $line;
+}
+
+# Convert gnomebutton/gnomeshowdesk/colorlimit/etc
+sub convert_obsolete
+{
+    my( $line ) = @_;
+
+    push( @converted_lines, "# Obsolete, does nothing: $line" );
+}
+
+# Convert HilightColorset
+sub convert_hilightcolorset
+{
+    my( $line ) = @_;
+
+    $line =~ s/hilightcolorset/Style \* HilightColorset/i;
+
+    push( @converted_lines, $line );
+}
+
+# Convert HideGeometryWindow -> GeometryWindowHide
+sub convert_hidegeometrywindow
+{
+    my( $line ) = @_;
+
+    $line =~ s/hidegeometrywindow/GeometryWindow hide/i;
+
+    push( @converted_lines, $line );
+}
+
+# Convert Desk -> GotoDesk
+sub convert_desk
+{
+    my( $line ) = @_;
+
+    $line =~ s/^\s*desk/GotoDesk/i;
+
+    push( @converted_lines, $line);
+}
+
 # This should have happened in the fvwm-2.4 convert script, but handle it
 # here anyway.
 sub convert_windowshadesteps
 {
     my( $line ) = @_;
-    $line =~ /(\d+)p?/ ? 
-        $line = "Style * WindowShadeSteps $1" : 
-        $line = "Style * " . $line;
+
+    $line =~ /(\d+)p?/ and $line = "Style * WindowShadeSteps $1";
+
+    push( @converted_lines, $line );
+}
+
+# Convert WindowFont
+sub convert_windowfont
+{
+    my( $line ) = @_;
+
+    $line =~ s/windowfont/Style Font \*/i;
+
+    push( @converted_lines, $line );
+}
+
+# Convert IconFont
+sub convert_iconfont
+{
+    my( $line ) = @_;
+
+    $line =~ s/iconfont/Style IconFont \*/i;
 
     push( @converted_lines, $line );
 }
@@ -174,7 +241,7 @@ sub convert_edge_resistance
     #
     # We could only ever have had two numbers as arguments to
     # EdgeResistance.
-    my( $edge_res_arg, $move_res_arg ) = 
+    my( $edge_res_arg, $move_res_arg ) =
         ( $line =~ /edgeresistance\s*(\d+)\s*(\d+)/i );
 
     push( @converted_lines,
@@ -227,8 +294,8 @@ sub handle_read_file
 {
     my( $line ) = @_;
     my @read_parts = split( /\s+/, $line );
-    
-    push( @converted_lines, $line );    
+
+    push( @converted_lines, $line );
 
     # Crudely try and work out if the file is readable, and if it is add it
     # to the list of further files to convert.
@@ -242,7 +309,7 @@ sub handle_read_file
     if( -e $fname )
     {
         push( @additional_files, [$fname] );
-        
+
         # We're done.
         return;
     }
@@ -255,9 +322,9 @@ sub handle_read_file
     #
     # Read $./foo
     #
-    # Then we assume FVWM_USERDIR ("$HOME/.fvwm/"), and if that file can't 
+    # Then we assume FVWM_USERDIR ("$HOME/.fvwm/"), and if that file can't
     # be found there, try CWD, and if that fails we just give up.
-    
+
     # Canonicalise the starting point by removing "$." -- we can guess what
     # it ought to be replaced with.
     $fname =~ s/^\$\.\/?//;
@@ -303,7 +370,7 @@ sub check_func_definition
     # Ensure we run it all through __convert_conditionals()
     my @func_parts = split( /(\s+)/, $line, 4 );
     __convert_conditionals( \@func_parts );
-    
+
     push( @converted_lines, join '', @func_parts );
 
 }
@@ -350,7 +417,7 @@ sub convert_restartfunc
 {
     my( $line ) = @_;
     $last_func_ref = "convert_restartfunc";
-    
+
     # We treat this exactly like startfunction.
     if( $line =~ /addtofunc\s+restartfunction\s+\"??[icmhd]{1}\"??\s+.*/i )
     {
@@ -361,13 +428,13 @@ sub convert_restartfunc
     }
 
     $line =~ s/addtofunc\s+restartfunction\s*//i;
-    
+
     return if $line eq '';
 
     # Remove the continuation prefix as we can add this in when writing out
-    # the function definitions later. 
+    # the function definitions later.
     $line =~ s/^\s*\+//;
-    
+
     my @func_cmd = split( /\s+/, $line, 2 );
     $func_cmd[1] =~ s/\"//g;
 
@@ -400,13 +467,13 @@ sub convert_startfunc
         $line =~ s/addtofunc\s+startfunction\s*//i;
     }
     $line =~ s/addtofunc\s+startfunction\s*//i;
-    
+
     # Remove the continuation prefix as we can add this in when writing out
-    # the function definitions later. 
+    # the function definitions later.
     $line =~ s/^\s*\+//;
 
     return if !defined $line || $line eq '';
-    
+
     my @func_cmd = split( /\s+/, $line, 2 );
     $func_cmd[1] =~ s/\"//g;
 
@@ -425,9 +492,9 @@ sub write_out_file
 
     # If we had any continuation lines, preserve them as best we can.
     @converted_lines = map {
-        join "\\\n", split /\\/, $_ 
+        join "\\\n", split /\\/, $_
     } @converted_lines;
-    
+
     print $f join( "\n", @converted_lines );
 
     # Write out the functions.
@@ -437,7 +504,7 @@ sub write_out_file
         print $f qq|\n\nDestroyFunc StartFunction\nAddToFunc StartFunction\n|;
 
         # Put the Init stuff before anything else.
-        for( @{ $converted_funcs{initfunction} }, 
+        for( @{ $converted_funcs{initfunction} },
             @{ $converted_funcs{startfunction } } )
         {
             print $f "+ $_\n";
@@ -458,8 +525,12 @@ sub dispatch_line
         convert_fvwmtheme($line);
     } elsif( $line =~ /^\s*modulepath\s*/i ) {
         handle_modulepath( $line );
-    } elsif( $line =~ /^\s*windowshadesteps.*/i ) {
+    } elsif( $line =~ /^\s*windowshade(?:steps|animate).*/i ) {
         convert_windowshadesteps($line);
+    } elsif( $line =~ /^\s*windowfont.*/i ) {
+        convert_windowfont( $line );
+    } elsif( $line =~ /^\s*iconfont.*/i ) {
+        convert_iconfont( $line );
     } elsif( $line =~ /^\s*module(?:synchronous)?.*?fvwmtheme$/i ) {
         convert_fvwmtheme($line);
     } elsif( $line =~ /^\s*edgeresistance\s*\d+\s*\d+/i ) {
@@ -476,6 +547,16 @@ sub dispatch_line
         convert_restartfunc( $line );
     } elsif( $line =~ /^\s*addtofunc\s+\w+.*/i ) {
         check_func_definition( $line );
+    } elsif( $line =~ /^\s*pixmappath|iconpath\s+\w+.*/i ) {
+        convert_pixmappath( $line );
+    } elsif( $line =~ /^\s*colorlimit|(?:gnome(?:button|showdesks))\s+\w+.*/i ) {
+        convert_obsolete( $line );
+    } elsif( $line =~ /^\s*desk\s*\w+.*/i ) {
+        convert_desk( $line );
+    } elsif( $line =~ /^\s*hilightcolorset\s*/i ) {
+        convert_hilightcolorset( $line );
+    } elsif( $line =~ /^\s*hidegeometrywindow\s*/i ) {
+        convert_hidegeometrywindow( $line );
     } elsif( $line =~ /^\s*\+\s*\"??[ichmd]{1}\s*\"??\s+.*/i ) {
         handle_continuation( $line );
     } elsif( $line =~ /^\s*read\s*[\/\w]+/i ) {

--- a/dev-docs/COMMANDS
+++ b/dev-docs/COMMANDS
@@ -23,7 +23,6 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   CleanupColorsets      - Reset all used colorsets with the default gray colors
   ClickTime             - Set a time in milliseconds for click and double click
   Close                 - Try to Delete a window, if this fails, Destroy it
-  ColorLimit            - Set limit on colors used (obsolete)
   ColormapFocus         - Change the colormap behaviour for low-depth X servers
   Colorset              - Manage colors used like fg, bg, image bg, gradient bg
   CopyMenuStyle         - Copy the existing menu style to new or existing one
@@ -35,7 +34,6 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   DefaultLayers         - Set StaysOnBottom, StaysPut, StaysOnTop layer numbers
   Delete                - Try to delete a window using the X delete protocol
   Deschedule            - Remove commands scheduled earlier using Schedule
-  Desk                  - (obsolete, use GotoDesk instead)
   DesktopName           - Define the desktop names used in WindowList, modules
   DesktopSize           - Set virtual desktop size in units of physical pages
   Destroy               - Kill a window without any warning to an application
@@ -66,21 +64,15 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   Focus                 - Give focus to a window
   FocusStyle            - Configure focus and raise policy for windows
   Function              - Execute a user defined function, see AddToFunc
-  GnomeButton           - Pass mouse button presses on root to GNOME program
-  GnomeShowDesks        - Limit GNOME pager to the number of desks
   GotoDesk              - Switch viewport to another desk same page
   GotoDeskAndPage       - Switch viewport to another desk and page
   GotoPage              - Switch viewport to another page same desk
-  HideGeometryWindow    - Hide/show the position/size window
-  HilightColorset       - (obsolete, use Style * HighlightColorset)
-  IconFont              - (obsolete, use Style * IconFont)
   Iconify               - Change iconification status of a window (minimize)
-  IconPath              - (obsolete, use ImagePath instead)
   IgnoreModifiers       - Modifiers to ignore on mouse and key bindings
   ImagePath             - Directories to search for images
   InfoStoreAdd          - Adds an entry (key/value pairs) to the infostore
   InfoStoreRemove       - Removes an entry from the infostore
-  - KeepRc              - Do not modify the previous command return code
+  KeepRc                - Do not modify the previous command return code
   Key                   - Bind or unbind a key to an fvwm action
   KillModule            - Stops an fvwm module
   Layer                 - Change the layer of a window
@@ -107,7 +99,6 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   OpaqueMoveSize        - Set maximum size window fvwm should move opaquely
   Pick                  - Prefix to force a window context, prompted if needed
   PipeRead              - Exec system command interpret output as fvwm commands
-  PixmapPath            - (obsolete, use ImagePath instead)
   PlaceAgain            - Replace a window using initial window placement logic
   PointerKey            - Bind an action to a key based on pointer not focus
   PointerWindow         - Operate on window under pointer if it meets conditions
@@ -147,8 +138,6 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   SetAnimation          - Control animated moves and menus
   SetEnv                - Set an environment variable
   Silent                - Suppress errors on command, avoid window selection
-  SnapAttraction        - Control attraction of windows during move
-  SnapGrid              - Control grid used with SnapAttraction
   State                 - Control user defined window states
   Stick                 - Change window stickyness
   StickAcrossDesks      - Change window stickyness on a desk basis
@@ -165,11 +154,9 @@ The recognized commands for fvwm 2.6.6 (from cvs) as of 09-Sep-2014:
   UpdateStyles          - Cause styles to update while still in a function
   Wait                  - Pause until a matching window appears
   WarpToWindow          - Warp the pointer to a window
-  WindowFont            - (obsolete, use Style * Font)
   WindowId              - Execute command for window matching the windowid
   WindowList            - Display the window list as a menu to select a window
   WindowShade           - Shade/unshade a window
-  WindowShadeAnimate    - (obsolete, use Style * WindowShadeSteps)
   WindowStyle           - Set styles on the selected window
   Xinerama              - Control Xinerama support
   XineramaPrimaryScreen - Identify Xinerama primary screen

--- a/dev-docs/PARSING.md
+++ b/dev-docs/PARSING.md
@@ -1045,9 +1045,6 @@ PAGECOORD = INT
 PAGESUFFIX = "p"
 ```
 ```
-CMD_HILIGHTCOLORSET = "HilightColorset" [COLORSET_NUM]
-```
-```
 CMD_ICONIFY = "Iconify" BOOL_OR_TOGGLE
 ```
 ```
@@ -1790,24 +1787,12 @@ STRING_COMMA_TERMINATED = *(STRING_UNQ_NO_COMMA / STRING_Q_PAIR / 1*WSC)
 ```
 ;; !!! obsolete commands removed in mvwm
 
-CMD_GNOMEBUTTON = "GnomeButton"
-CMD_GNOMESHOWDESKS = "GnomeShowDesks"
 CMD_SAVESESSION = "SaveSession"
 CMD_SAVEQUITSESSION = "SaveQuitSession"
 CMD_QUITSESSION = "QuitSession"
 
 ;; !!! obsolete commands in fvwm2
 
-CMD_COLORLIMIT = "ColorLimit"
-CMD_WINDOWFONT = "WindowFont" ; Style * Font ...
-CMD_WINDOWSHADEANIMATE = "WindowShadeAnimate" ; Style * WindowShadeSteps
-CMD_WINDOWSDESK = "WindowsDesk" ; See 'MoveToDesk'
-CMD_DESK = "Desk" ; See 'Gotodesk'
+;; Not fully obsolete, still used for EdgeScroll resistance.
 CMD_EDGERESISTANCE = "EdgeResistance" ; Style * EdgeMoveDelay, EdgeMoveResistance
-CMD_HIDEGEOMETRYWINDOW = "HideGeometryWindow" ; GeometryWindow Hide
-CMD_ICONFONT = "IconFont" FONTNAME ; Style
-CMD_ICONPATH = "IconPath" ; ImagePath
-CMD_PIXMAPPATH = "PixmapPath" ; ImagePath
-CMD_SNAPATTRACTION = "SnapAttraction" ; Style * SnapAttraction
-CMD_SNAPGRID = "SnapGrid" ; Style * SnapGrid
 ```

--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -3062,9 +3062,6 @@ default root cursor, you must set your root cursor with the
 ClickTime also specifies the delay between two clicks to be interpreted as a
 double-click.
 
-*ColorLimit* _limit_::
-	This command is obsolete. See the *--color-limit* option to fvwm.
-
 *ColormapFocus* FollowsMouse | FollowsFocus::
 	By default, fvwm installs the colormap of the window that the cursor
 	is in. If you use
@@ -3323,32 +3320,6 @@ WindowId 0x3800002 FakeKeypress press A
 +
 Note: all command names can be abbreviated with their first letter.
 
-*HilightColorset* [_num_]::
-	This command is obsoleted by the *Style* option _HilightColorset_.
-	Please use
-+
-
-....
-Style * HilightColorset num
-....
-
-+
-instead.
-
-*IconFont* [_fontname_]::
-	This command is obsoleted by the *Style* option _IconFont_. Please use
-+
-
-....
-Style * IconFont fontname
-....
-
-+
-instead.
-
-*IconPath* _path_::
-	This command is obsolete. Please use *ImagePath* instead.
-
 *ImagePath* _path_::
 	Specifies a colon separated list of directories in which to search for
 	images (both monochrome and pixmap). To find an image given by a
@@ -3446,9 +3417,6 @@ for string translation. It is out of the scope of this discussion to
 explain how to build locale catalogs. Please refer to the GNU gettext
 documentation.
 
-*PixmapPath* _path_::
-	This command is obsolete. Please use *ImagePath* instead.
-
 *PrintInfo* _subject_ [_verbose_]::
 	Print information on _subject_ to debug log file, which defaults to
 	_$HOME/.fvwm/fvwm3-output.log_ . Environment variables _$FVWM_USERDIR_
@@ -3533,15 +3501,6 @@ Use the *Deschedule* command to stop periodic commands.
 	argument. "True" sets the given state, while "False" clears it. Using "toggle"
 	switches to the opposite state. If the _bool_ argument is not given, the state
 	is toggled.
-
-*WindowFont* [_fontname_]::
-	This command is obsoleted by the *Style* option _Font_. Please use
-+
-....
-Style * Font fontname
-....
-+
-instead.
 
 *WindowList* [(_conditions_)] [_position_] [_options_] [_double-click-action_]::
 	Generates a pop-up menu (and pops it up) in which the title and
@@ -3805,10 +3764,6 @@ GeometryWindow Hide
 ....
 
 
-*HideGeometryWindow* [Never | Move | Resize]::
-	This command has been depreciated and is now obsolete. Use
-        *GeometryWindow Hide* instead.
-
 *Layer* [_arg1_ _arg2_] | [default]::
 	Puts the current window in a new layer. If _arg1_ is non zero then the
 	next layer is the current layer number plus _arg1_. If _arg1_ is zero
@@ -4007,8 +3962,7 @@ See also the *AnimatedMove* command.
 *MoveToDesk* [prev | _arg1_ [_arg2_] [_min_ _max_]]::
 	Moves the selected window to another desktop. The arguments are the
 	same as for the *GotoDesk* command. Without any arguments, the window
-	is moved to the current desk. *MoveToDesk* is a replacement for the
-	obsolete *WindowsDesk* command, which can no longer be used.
+	is moved to the current desk.
 
 *MoveThreshold* [_pixels_]::
 	When the user presses a mouse button upon an object fvwm waits to see
@@ -4287,37 +4241,6 @@ positions of the 16 frames of the animation motion. Negative values
 are allowed, and in particular can be used to make the motion appear
 more cartoonish, by briefly moving slightly in the opposite direction
 of the main motion. The above settings are the default.
-
-*SnapAttraction* [_proximity_ [_behaviour_] [Screen]]::
-	The *SnapAttraction* command is obsolete. It has been replaced by the
-	*Style* command option _SnapAttraction_.
-
-*SnapGrid* [_x-grid-size_ _y-grid-size_]::
-	The *SnapGrid* command is obsolete. It has been replaced by the
-	*Style* command option _SnapGrid_.
-
-*WindowsDesk* _arg1_ [_arg2_]::
-	Moves the selected window to another desktop.
-+
-This command has been removed and must be replaced by *MoveToDesk*,
-the arguments for which are the same as for the *GotoDesk* command.
-+
-*Important*
-You cannot simply change the name of the command: the syntax has
-changed. If you used:
-+
-
-....
-WindowsDesk n
-....
-
-+
-to move a window to desk n, you have to change it to:
-+
-
-....
-MoveToDesk 0 n
-....
 
 *XorPixmap* [_pixmap_]::
 	Selects the pixmap with which bits are xor'ed when doing rubber-band
@@ -4667,10 +4590,6 @@ shaded in the direction of the title bar.
 For backward compatibility, the optional argument may also be 1 to
 signify "on", and 2 to signify "off". Note that this syntax is
 obsolete, and will be removed in the future.
-
-*WindowShadeAnimate* [_steps_ [p]]::
-	This command is obsolete. Please use the _WindowShadeSteps_ option of
-	the *Style* command instead.
 
 === Mouse & Key Bindings
 
@@ -5441,7 +5360,6 @@ The _Font_ and _IconFont_ options take the name of a font as their
 sole argument. This font is used in the window or icon title. By
 default the font given in the *DefaultFont* command is used. To
 revert back to the default, use the style without the name argument.
-These styles replace the older *WindowFont* and _IconFont_ commands.
 +
 The deprecated _IndexedWindowName_ style causes fvwm to use window
 titles in the form
@@ -6752,10 +6670,7 @@ or for the descriptions of available styles and flags, see the
 Add or divert commands to the decor named _decor_. A decor is a name
 given to the set of commands which affect button styles, title-bar
 styles and border styles. If _decor_ does not exist it is created;
-otherwise the existing _decor_ is modified. Note: Earlier versions
-allowed to use the *HilightColorset* and *WindowFont* commands in decors.
-This is no longer possible. Please use the *Style* command with the
-_Hilight..._ and _Font_ options.
+otherwise the existing _decor_ is modified.
 +
 New decors start out exactly like the "default" decor without any
 style definitions. A given decor may be applied to a set of windows
@@ -6780,7 +6695,7 @@ AddToDecor FlatDecor
 + BorderStyle -- HiddenHandles NoInset
 
 Style FlatStyle \
-	UseDecor FlatDecor, HandleWidth 4, Colorset 0, HilightColorset 1
+	UseDecor FlatDecor, HandleWidth 4, Colorset 0
 
 Style xterm UseStyle FlatStyle
 ....
@@ -7397,9 +7312,6 @@ Specifying an invalid decor results in all windows being updated.
 endif::[]
 
 === Controlling the Virtual Desktop
-
-*Desk* [screen _RANDRNAME_] _arg1_ [_arg2_] [_min_ _max_]::
-	This command has been renamed. Please see *GotoDesk* command.
 
 *DesktopName* _desk_ _name_::
 	Defines the name of the desktop number _desk_ to _name_. This name is

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2835,18 +2835,6 @@ void CMD_ImagePath(F_CMD_ARGS)
 	return;
 }
 
-void CMD_IconPath(F_CMD_ARGS)
-{
-	fvwm_debug(__func__,
-	    "IconPath is deprecated; use ImagePath instead.");
-}
-
-void CMD_PixmapPath(F_CMD_ARGS)
-{
-	fvwm_debug(__func__,
-	    "PixmapPath is deprecated; use ImagePath instead." );
-}
-
 void CMD_LocalePath(F_CMD_ARGS)
 {
 	FGettextSetLocalePath( action );
@@ -2872,31 +2860,6 @@ void CMD_ModuleTimeout(F_CMD_ARGS)
 	if (GetIntegerArguments(action, NULL, &timeout, 1) == 1 && timeout > 0)
 	{
 		moduleTimeout = timeout;
-	}
-
-	return;
-}
-
-void CMD_HilightColorset(F_CMD_ARGS)
-{
-	char *newaction;
-
-	if (Scr.cur_decor && Scr.cur_decor != &Scr.DefaultDecor)
-	{
-		fvwm_debug(__func__,
-			   "Decors do not support the HilightColorset command "
-			   "anymore. Please use "
-			   "'Style <stylename> HilightColorset <colorset>'"
-			   " instead. Sorry for the inconvenience.");
-		return;
-	}
-
-	if (action)
-	{
-		xasprintf(&newaction, "* HilightColorset %s", action);
-		action = newaction;
-		CMD_Style(F_PASS_ARGS);
-		free(newaction);
 	}
 
 	return;
@@ -3026,54 +2989,6 @@ void CMD_DefaultFont(F_CMD_ARGS)
 	/* set flags to indicate that the font has changed */
 	Scr.flags.do_need_window_update = 1;
 	Scr.flags.has_default_font_changed = 1;
-
-	return;
-}
-
-void CMD_IconFont(F_CMD_ARGS)
-{
-	char *newaction;
-
-	if (Scr.cur_decor && Scr.cur_decor != &Scr.DefaultDecor)
-	{
-		fvwm_debug(__func__,
-			   "Decors do not support the IconFont command anymore."
-			   " Please use 'Style <stylename> IconFont <fontname>'"
-			   " instead.  Sorry for the inconvenience.");
-		return;
-	}
-
-	if (action)
-	{
-		xasprintf(&newaction, "* IconFont %s", action);
-		action = newaction;
-		CMD_Style(F_PASS_ARGS);
-		free(newaction);
-	}
-
-	return;
-}
-
-void CMD_WindowFont(F_CMD_ARGS)
-{
-	char *newaction;
-
-	if (Scr.cur_decor && Scr.cur_decor != &Scr.DefaultDecor)
-	{
-		fvwm_debug(__func__,
-			   "Decors do not support the WindowFont command anymore."
-			   " Please use 'Style <stylename> Font <fontname>'"
-			   " instead.  Sorry for the inconvenience.");
-		return;
-	}
-
-	if (action)
-	{
-		xasprintf(&newaction, "* Font %s", action);
-		action = newaction;
-		CMD_Style(F_PASS_ARGS);
-		free(newaction);
-	}
 
 	return;
 }
@@ -3632,15 +3547,6 @@ void CMD_Emulate(F_CMD_ARGS)
 
 	return;
 }
-
-void CMD_ColorLimit(F_CMD_ARGS)
-{
-	fvwm_debug(__func__, "ColorLimit is obsolete,\n\tuse the "
-		   "fvwm -color-limit option");
-
-	return;
-}
-
 
 /* set animation parameters */
 void CMD_SetAnimation(F_CMD_ARGS)

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -74,10 +74,6 @@ enum
 	F_GOTO_DESK,
 	F_GOTO_PAGE,
 	F_HICOLOR,
-	F_HICOLORSET,
-	F_HIDEGEOMWINDOW,
-	F_ICONFONT,
-	F_ICON_PATH,
 	F_IGNORE_MODIFIERS,
 	F_IMAGE_PATH,
 	F_INFOSTOREADD,
@@ -100,7 +96,6 @@ enum
 	F_NONE,
 	F_OPAQUE,
 	F_PICK,
-	F_PIXMAP_PATH,
 	F_POINTERKEY,
 	F_POINTERWINDOW,
 	F_POPUP,
@@ -122,10 +117,7 @@ enum
 	F_SET_MASK,
 	F_SET_NOGRAB_MASK,
 	F_SET_SYNC_MASK,
-	F_SHADE_ANIMATE,
 	F_SILENT,
-	F_SNAP_ATT,
-	F_SNAP_GRID,
 	F_STAYSUP,
 	F_STATUS,
 	F_STYLE,
@@ -138,7 +130,6 @@ enum
 	F_TOGGLE_PAGE,
 	F_UPDATE_STYLES,
 	F_WAIT,
-	F_WINDOWFONT,
 	F_WINDOWLIST,
 	F_XOR,
 	F_XSYNC,
@@ -151,7 +142,6 @@ enum
 	F_ANIMATED_MOVE,
 	F_BORDERSTYLE,
 	F_CHANGE_DECOR,
-	F_COLOR_LIMIT,
 	F_DELETE,
 	F_DESTROY,
 	F_DESTROY_DECOR,
@@ -221,7 +211,6 @@ void CMD_ChangeMenuStyle(F_CMD_ARGS);
 void CMD_CleanupColorsets(F_CMD_ARGS);
 void CMD_ClickTime(F_CMD_ARGS);
 void CMD_Close(F_CMD_ARGS);
-void CMD_ColorLimit(F_CMD_ARGS);
 void CMD_ColormapFocus(F_CMD_ARGS);
 void CMD_Colorset(F_CMD_ARGS);
 void CMD_CopyMenuStyle(F_CMD_ARGS);
@@ -234,7 +223,6 @@ void CMD_DefaultIcon(F_CMD_ARGS);
 void CMD_DefaultLayers(F_CMD_ARGS);
 void CMD_Delete(F_CMD_ARGS);
 void CMD_Deschedule(F_CMD_ARGS);
-void CMD_Desk(F_CMD_ARGS);
 void CMD_DesktopConfiguration(F_CMD_ARGS);
 void CMD_DesktopName(F_CMD_ARGS);
 void CMD_DesktopSize(F_CMD_ARGS);
@@ -270,11 +258,7 @@ void CMD_GeometryWindow(F_CMD_ARGS);
 void CMD_GotoDesk(F_CMD_ARGS);
 void CMD_GotoDeskAndPage(F_CMD_ARGS);
 void CMD_GotoPage(F_CMD_ARGS);
-void CMD_HideGeometryWindow(F_CMD_ARGS);
-void CMD_HilightColorset(F_CMD_ARGS);
-void CMD_IconFont(F_CMD_ARGS);
 void CMD_Iconify(F_CMD_ARGS);
-void CMD_IconPath(F_CMD_ARGS);
 void CMD_IgnoreModifiers(F_CMD_ARGS);
 void CMD_ImagePath(F_CMD_ARGS);
 void CMD_InfoStoreAdd(F_CMD_ARGS);
@@ -307,7 +291,6 @@ void CMD_NoWindow(F_CMD_ARGS);
 void CMD_OpaqueMoveSize(F_CMD_ARGS);
 void CMD_Pick(F_CMD_ARGS);
 void CMD_PipeRead(F_CMD_ARGS);
-void CMD_PixmapPath(F_CMD_ARGS);
 void CMD_PlaceAgain(F_CMD_ARGS);
 void CMD_PointerKey(F_CMD_ARGS);
 void CMD_PointerWindow(F_CMD_ARGS);
@@ -346,8 +329,6 @@ void CMD_set_sync_mask(F_CMD_ARGS);
 void CMD_SetAnimation(F_CMD_ARGS);
 void CMD_SetEnv(F_CMD_ARGS);
 void CMD_Silent(F_CMD_ARGS);
-void CMD_SnapAttraction(F_CMD_ARGS);
-void CMD_SnapGrid(F_CMD_ARGS);
 void CMD_State(F_CMD_ARGS);
 void CMD_Stick(F_CMD_ARGS);
 void CMD_StickAcrossDesks(F_CMD_ARGS);
@@ -365,11 +346,9 @@ void CMD_UpdateDecor(F_CMD_ARGS);
 void CMD_UpdateStyles(F_CMD_ARGS);
 void CMD_Wait(F_CMD_ARGS);
 void CMD_WarpToWindow(F_CMD_ARGS);
-void CMD_WindowFont(F_CMD_ARGS);
 void CMD_WindowId(F_CMD_ARGS);
 void CMD_WindowList(F_CMD_ARGS);
 void CMD_WindowShade(F_CMD_ARGS);
-void CMD_WindowShadeAnimate(F_CMD_ARGS);
 void CMD_WindowStyle(F_CMD_ARGS);
 void CMD_XorPixmap(F_CMD_ARGS);
 void CMD_XorValue(F_CMD_ARGS);

--- a/fvwm/functable.c
+++ b/fvwm/functable.c
@@ -131,9 +131,6 @@ const func_t func_table[] =
 		FUNC_NEEDS_WINDOW, CRS_DESTROY),
 	/* - Try to Delete a window, if this fails, Destroy it */
 
-	CMD_ENT("colorlimit", CMD_ColorLimit, F_COLOR_LIMIT, 0, 0),
-	/* - Set limit on colors used (obsolete) */
-
 	CMD_ENT("colormapfocus", CMD_ColormapFocus, F_COLORMAP_FOCUS, 0, 0),
 	/* - Change the colormap behaviour for low-depth X servers */
 
@@ -170,9 +167,6 @@ const func_t func_table[] =
 
 	CMD_ENT("deschedule", CMD_Deschedule, F_DESCHEDULE, 0, 0),
 	/* - Remove commands sheduled earlier using Schedule */
-
-	CMD_ENT("desk", CMD_Desk, F_GOTO_DESK, 0, 0),
-	/* - (obsolete, use GotoDesk instead) */
 
 	CMD_ENT("desktopconfiguration", CMD_DesktopConfiguration,
 		F_DESKTOP_CONFIGURATION, 0, 0),
@@ -220,7 +214,7 @@ const func_t func_table[] =
 
 	CMD_ENT("echofuncdefinition", CMD_EchoFuncDefinition,
 		F_ECHO_FUNC_DEFINITION, 0, 0),
-	/* - Print the definion of a function */
+	/* - Print the definition of a function */
 
 	CMD_ENT("edgecommand", CMD_EdgeCommand, F_EDGE_COMMAND, 0, 0),
 	/* - Bind one or another screen edge to an fvwm action */
@@ -290,22 +284,9 @@ const func_t func_table[] =
 	CMD_ENT("gotopage", CMD_GotoPage, F_GOTO_PAGE, 0, 0),
 	/* - Switch viewport to another page same desk */
 
-	CMD_ENT("hidegeometrywindow", CMD_HideGeometryWindow,
-		F_HIDEGEOMWINDOW, 0, 0),
-	/* - (obsolete, use GeometryWindow Hide instead) */
-
-	CMD_ENT("hilightcolorset", CMD_HilightColorset, F_HICOLORSET, 0, 0),
-	/* - (obsolete, use Style * HighlightColorset) */
-
-	CMD_ENT("iconfont", CMD_IconFont, F_ICONFONT, 0, 0),
-	/* - (obsolete, use Style * IconFont) */
-
 	CMD_ENT("iconify", CMD_Iconify, F_ICONIFY,
 		FUNC_NEEDS_WINDOW, CRS_SELECT),
 	/* - Change iconification status of a window (minimize) */
-
-	CMD_ENT("iconpath", CMD_IconPath, F_ICON_PATH, 0, 0),
-	/* - (obsolete, use ImagePath instead) */
 
 	CMD_ENT("ignoremodifiers", CMD_IgnoreModifiers, F_IGNORE_MODIFIERS,
 		0, 0),
@@ -412,9 +393,6 @@ const func_t func_table[] =
 
 	CMD_ENT("piperead", CMD_PipeRead, F_READ, 0, 0),
 	/* - Exec system command interpret output as fvwm commands */
-
-	CMD_ENT("pixmappath", CMD_PixmapPath, F_PIXMAP_PATH, 0, 0),
-	/* - (obsolete, use ImagePath instead) */
 
 	CMD_ENT("placeagain", CMD_PlaceAgain, F_PLACEAGAIN,
 		FUNC_NEEDS_WINDOW, CRS_SELECT),
@@ -537,12 +515,6 @@ const func_t func_table[] =
 	CMD_ENT(PRE_SILENT, CMD_Silent, F_SILENT, 0, 0),
 	/* Silent - Suppress errors on command, avoid window selection */
 
-	CMD_ENT("snapattraction", CMD_SnapAttraction, F_SNAP_ATT, 0, 0),
-	/* - Control attraction of windows during move */
-
-	CMD_ENT("snapgrid", CMD_SnapGrid, F_SNAP_GRID, 0, 0),
-	/* - Control grid used with SnapAttraction */
-
 	CMD_ENT("state", CMD_State, F_STATE,
 		FUNC_NEEDS_WINDOW, CRS_SELECT),
 	/* - Control user defined window states */
@@ -600,9 +572,6 @@ const func_t func_table[] =
 		CRS_SELECT),
 	/* - Warp the pointer to a window */
 
-	CMD_ENT("windowfont", CMD_WindowFont, F_WINDOWFONT, 0, 0),
-	/* - (obsolete, use Style * Font) */
-
 	CMD_ENT("windowid", CMD_WindowId, F_WINDOWID, 0, 0),
 	/* - Execute command for window matching the windowid */
 
@@ -612,10 +581,6 @@ const func_t func_table[] =
 	CMD_ENT("windowshade", CMD_WindowShade, F_WINDOW_SHADE,
 		FUNC_NEEDS_WINDOW, CRS_SELECT),
 	/* - Shade/unshade a window */
-
-	CMD_ENT("windowshadeanimate", CMD_WindowShadeAnimate, F_SHADE_ANIMATE,
-		0, 0),
-	/* - (obsolete, use Style * WindowShadeSteps) */
 
 	CMD_ENT("windowstyle", CMD_WindowStyle, F_WINDOW_STYLE,
 		FUNC_NEEDS_WINDOW, CRS_SELECT),

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -53,10 +53,6 @@
 
 extern int nColorsets;  /* in libs/Colorset.c */
 
-/* do not send ColorLimit, it is not used anymore but maybe by non
- * "official" modules */
-#define DISABLE_COLORLIMIT_CONFIG_INFO 1
-
 #define MODULE_CONFIG_DELIM ':'
 
 struct moduleInfoList
@@ -321,20 +317,6 @@ static void send_image_path(fmodule *module)
 	return;
 }
 
-static void send_color_limit(fmodule *module)
-{
-	if (DISABLE_COLORLIMIT_CONFIG_INFO)
-	{
-		char msg[64];
-
-		snprintf(msg, sizeof(msg),
-			"ColorLimit %d\n", Scr.ColorLimit);
-		SendName(module, M_CONFIG_INFO, 0, 0, 0, msg);
-	}
-
-	return;
-}
-
 static void send_colorsets(fmodule *module)
 {
 	int n;
@@ -400,7 +382,6 @@ void CMD_Send_ConfigInfo(F_CMD_ARGS)
 	send_monitor_list(mod);
 	/* send ImagePath and ColorLimit first */
 	send_image_path(mod);
-	send_color_limit(mod);
 	BroadcastDesktopConfiguration(mod);
 	send_colorsets(mod);
 	send_click_time(mod);

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -3435,46 +3435,6 @@ void CMD_GeometryWindow(F_CMD_ARGS)
 	}
 }
 
-void CMD_HideGeometryWindow(F_CMD_ARGS)
-{
-	char *cmd;
-
-	fvwm_debug(__func__, "HideGeometryWindow is deprecated.  "
-	    "Converting to use: GeometryWindow hide %s", action);
-
-	xasprintf(&cmd, "GeometryWindow hide %s", action);
-	execute_function_override_window(NULL, NULL, cmd, NULL, 0, NULL);
-	free(cmd);
-}
-
-void CMD_SnapAttraction(F_CMD_ARGS)
-{
-	char *cmd;
-
-	xasprintf(&cmd, "Style * SnapAttraction %s", action);
-	fvwm_debug(__func__,
-		   "The command SnapAttraction is obsolete. Please use the"
-		   " following command instead:\n\n%s", cmd);
-	execute_function(cond_rc, exc, cmd, pc, FUNC_DONT_EXPAND_COMMAND);
-	free(cmd);
-
-	return;
-}
-
-void CMD_SnapGrid(F_CMD_ARGS)
-{
-	char *cmd;
-
-	xasprintf(&cmd, "Style * SnapGrid %s", action);
-	fvwm_debug(__func__,
-		   "The command SnapGrid is obsolete. Please use the following"
-		   " command instead:\n\n%s", cmd);
-	execute_function(cond_rc, exc, cmd, pc, FUNC_DONT_EXPAND_COMMAND);
-	free(cmd);
-
-	return;
-}
-
 static Pixmap XorPixmap = None;
 
 void CMD_XorValue(F_CMD_ARGS)

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2528,13 +2528,6 @@ void CMD_GotoDesk(F_CMD_ARGS)
 	goto_desk(new_desk, m);
 }
 
-void CMD_Desk(F_CMD_ARGS)
-{
-	CMD_GotoDesk(F_PASS_ARGS);
-
-	return;
-}
-
 /*
  *
  * Move to a new desktop and page at the same time.

--- a/fvwm/windowshade.c
+++ b/fvwm/windowshade.c
@@ -223,24 +223,3 @@ void CMD_WindowShade(F_CMD_ARGS)
 	SetFocusWindow(fw, True, FOCUS_SET_FORCE);
 	return;
 }
-
-/* set the number or size of shade animation steps, N => steps, Np => pixels */
-void CMD_WindowShadeAnimate(F_CMD_ARGS)
-{
-	char *buf;
-
-	if (!action)
-	{
-		action = "";
-	}
-	fvwm_debug(__func__,
-		   "The WindowShadeAnimate command is obsolete. "
-		   "Please use 'Style * WindowShadeSteps %s' instead.",
-		   action);
-	xasprintf(&buf, "* WindowShadeSteps %s", action);
-	action = buf;
-	CMD_Style(F_PASS_ARGS);
-	free(buf);
-
-	return;
-}

--- a/modules/FvwmScript/Scripts/FvwmScript-BaseConfig
+++ b/modules/FvwmScript/Scripts/FvwmScript-BaseConfig
@@ -254,28 +254,28 @@ Init
 
    Set $pos=(Add $pos 1)
    Set $HIDEGEO=(GetOutput $CAT $pos -1)
-   If $HIDEGEO=={HideGeometryWindow Never} Then
+   If $HIDEGEO=={GeometryWindow Hide Never} Then
     Begin
     Set $HIDEMOVE={NO}
     Set $HIDERESIZE={NO}
     ChangeValue 52 0
     ChangeValue 53 0
     End
-   If $HIDEGEO=={HideGeometryWindow Resize} Then
+   If $HIDEGEO=={GeometryWindow Hide Resize} Then
     Begin
     Set $HIDEMOVE={NO}
     Set $HIDERESIZE={YES}
     ChangeValue 52 0
     ChangeValue 53 1
     End
-   If $HIDEGEO=={HideGeometryWindow Move} Then
+   If $HIDEGEO=={GeometryWindow Hide Move} Then
     Begin
     Set $HIDEMOVE={YES}
     Set $HIDERESIZE={NO}
     ChangeValue 52 1
     ChangeValue 53 0
     End
-   If $HIDEGEO=={HideGeometryWindow} Then
+   If $HIDEGEO=={GeometryWindow Hide} Then
     Begin
     Set $HIDEMOVE={YES}
     Set $HIDERESIZE={YES}
@@ -384,7 +384,7 @@ Init
    ChangeValue 50 1
    Set $RESIZEOPAQ={Style * ResizeOutline}
 
-   Set $HIDEGEO={HideGeometryWindow Never}
+   Set $HIDEGEO={GeometryWindow Hide Never}
    Set $HIDEMOVE={NO}
    Set $HIDERESIZE={NO}
    ChangeValue 52 0
@@ -582,7 +582,7 @@ Main
    ChangeValue 50 1
    Set $RESIZEOPAQ={Style * ResizeOutline}
 
-   Set $HIDEGEO={HideGeometryWindow Never}
+   Set $HIDEGEO={GeometryWindow Hide Never}
    Set $HIDEMOVE={NO}
    Set $HIDERESIZE={NO}
    ChangeValue 52 0
@@ -1255,18 +1255,18 @@ Main
     ChangeValue 52 0
     Set $HIDEMOVE={NO}
     If $HIDERESIZE=={YES} Then
-     Set $HIDEGEO={HideGeometryWindow Resize}
+     Set $HIDEGEO={GeometryWindow Hide Resize}
     Else
-     Set $HIDEGEO={HideGeometryWindow Never}
+     Set $HIDEGEO={GeometryWindow Hide Never}
     End
    Else
     Begin
     ChangeValue 52 1
     Set $HIDEMOVE={YES}
     If $HIDERESIZE=={YES} Then
-     Set $HIDEGEO={HideGeometryWindow}
+     Set $HIDEGEO={GeometryWindow Hide}
     Else
-     Set $HIDEGEO={HideGeometryWindow Move}
+     Set $HIDEGEO={GeometryWindow Hide Move}
     End
   End
 End
@@ -1287,18 +1287,18 @@ Main
     ChangeValue 53 0
     Set $HIDERESIZE={NO}
     If $HIDEMOVE=={YES} Then
-     Set $HIDEGEO={HideGeometryWindow Move}
+     Set $HIDEGEO={GeometryWindow Hide Move}
     Else
-     Set $HIDEGEO={HideGeometryWindow Never}
+     Set $HIDEGEO={GeometryWindow Hide Never}
     End
    Else
     Begin
     ChangeValue 53 1
     Set $HIDERESIZE={YES}
     If $HIDEMOVE=={YES} Then
-     Set $HIDEGEO={HideGeometryWindow}
+     Set $HIDEGEO={GeometryWindow Hide}
     Else
-     Set $HIDEGEO={HideGeometryWindow Resize}
+     Set $HIDEGEO={GeometryWindow Hide Resize}
     End
   End
 End

--- a/perllib/FVWM/Commands.pm
+++ b/perllib/FVWM/Commands.pm
@@ -147,12 +147,6 @@ $TIME = 1410306754;
 		descr => q{Try to Delete a window, if this fails, Destroy it},
 	},
 	{
-		name => 'ColorLimit',
-		cursor => '',
-		window => 0,
-		descr => q{Set limit on colors used (obsolete)},
-	},
-	{
 		name => 'ColormapFocus',
 		cursor => '',
 		window => 0,
@@ -229,12 +223,6 @@ $TIME = 1410306754;
 		cursor => '',
 		window => 0,
 		descr => q{Remove commands sheduled earlier using Schedule},
-	},
-	{
-		name => 'Desk',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use GotoDesk instead)},
 	},
 	{
 		name => 'DesktopName',
@@ -417,18 +405,6 @@ $TIME = 1410306754;
 		descr => q{Execute a user defined function, see AddToFunc},
 	},
 	{
-		name => 'GnomeButton',
-		cursor => '',
-		window => 0,
-		descr => q{Pass mouse button presses on root to GNOME program},
-	},
-	{
-		name => 'GnomeShowDesks',
-		cursor => '',
-		window => 0,
-		descr => q{Limit GNOME pager to the number of desks},
-	},
-	{
 		name => 'GotoDesk',
 		cursor => '',
 		window => 0,
@@ -447,34 +423,10 @@ $TIME = 1410306754;
 		descr => q{Switch viewport to another page same desk},
 	},
 	{
-		name => 'HideGeometryWindow',
-		cursor => '',
-		window => 0,
-		descr => q{Hide/show the position/size window},
-	},
-	{
-		name => 'HilightColorset',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use Style * HighlightColorset)},
-	},
-	{
-		name => 'IconFont',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use Style * IconFont)},
-	},
-	{
 		name => 'Iconify',
 		cursor => 'SELECT',
 		window => 1,
 		descr => q{Change iconification status of a window (minimize)},
-	},
-	{
-		name => 'IconPath',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use ImagePath instead)},
 	},
 	{
 		name => 'IgnoreModifiers',
@@ -661,12 +613,6 @@ $TIME = 1410306754;
 		cursor => '',
 		window => 0,
 		descr => q{Exec system command interpret output as fvwm commands},
-	},
-	{
-		name => 'PixmapPath',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use ImagePath instead)},
 	},
 	{
 		name => 'PlaceAgain',
@@ -903,18 +849,6 @@ $TIME = 1410306754;
 		descr => q{Suppress errors on command, avoid window selection},
 	},
 	{
-		name => 'SnapAttraction',
-		cursor => '',
-		window => 0,
-		descr => q{Control attraction of windows during move},
-	},
-	{
-		name => 'SnapGrid',
-		cursor => '',
-		window => 0,
-		descr => q{Control grid used with SnapAttraction},
-	},
-	{
 		name => 'State',
 		cursor => 'SELECT',
 		window => 1,
@@ -1011,12 +945,6 @@ $TIME = 1410306754;
 		descr => q{Warp the pointer to a window},
 	},
 	{
-		name => 'WindowFont',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use Style * Font)},
-	},
-	{
 		name => 'WindowId',
 		cursor => '',
 		window => 0,
@@ -1033,12 +961,6 @@ $TIME = 1410306754;
 		cursor => 'SELECT',
 		window => 1,
 		descr => q{Shade/unshade a window},
-	},
-	{
-		name => 'WindowShadeAnimate',
-		cursor => '',
-		window => 0,
-		descr => q{(obsolete, use Style * WindowShadeSteps)},
 	},
 	{
 		name => 'WindowStyle',


### PR DESCRIPTION
The following commands have been obsolete for a while, and have been removed.

ColorLimit, Desk, HideGeometryWindow, HilightColorset, IconFont, IconPath, PixmapPath, SnapAttraction, SnapGrid, WindowFont, and WindowShadeAnimate.