### PR TITLE
Convert InfoStore to TAILQ.

### DIFF
--- a/fvwm/infostore.h
+++ b/fvwm/infostore.h
@@ -11,13 +11,15 @@
 
 /* ---------------------------- type definitions --------------------------- */
 
-typedef struct MetaInfo
+typedef struct meta_info
 {
     char *key;
     char *value;
 
-    struct MetaInfo *next;
+    TAILQ_ENTRY(meta_info) entry;
 } MetaInfo;
+TAILQ_HEAD(meta_infos, meta_info);
+extern struct meta_infos meta_info_q;
 
 /* ---------------------------- forward declarations ----------------------- */
 
@@ -25,11 +27,8 @@ typedef struct MetaInfo
 
 /* ---------------------------- interface functions ------------------------ */
 
-MetaInfo *new_metainfo(void);
 void insert_metainfo(char *, char *);
 char *get_metainfo_value(const char *);
-int get_metainfo_length(void);
-MetaInfo *get_metainfo(void);
 void print_infostore(void);
 
 #endif /* FVWM_INFOSTORE_H */

--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -177,13 +177,13 @@ SaveGlobalState(FILE *f)
 		f, "  [STYLE] %i %i\n", Scr.gs.do_emulate_mwm,
 		Scr.gs.do_emulate_win);
 
-	if (get_metainfo_length() > 0) {
-		MetaInfo *mi = get_metainfo(), *mi_i;
+	if (!TAILQ_EMPTY(&meta_info_q)) {
+		MetaInfo *mi;
 
 		fprintf(f, "  [INFOSTORE]\n");
-		for (mi_i = mi; mi_i; mi_i = mi_i->next) {
-			fprintf(f, "    [KEY] %s\n", mi_i->key);
-			fprintf(f, "    [VALUE] %s\n", mi_i->value);
+		TAILQ_FOREACH(mi, &meta_info_q, entry) {
+			fprintf(f, "    [KEY] %s\n", mi->key);
+			fprintf(f, "    [VALUE] %s\n", mi->value);
 		}
 	}
 


### PR DESCRIPTION
Use TAILQ instead of a linked list for InfoStore. This also reduces looping over the list multiple times in some situations.

This fixes #993.