### PR TITLE
infostore: move non-error case out of error block

### DIFF
--- a/fvwm/infostore.c
+++ b/fvwm/infostore.c
@@ -150,13 +150,9 @@ void CMD_InfoStoreAdd(F_CMD_ARGS)
 error:
 	if (key == NULL || value == NULL) {
 		fvwm_debug(__func__, "Bad arguments given.");
-		goto out;
 	}
-out:
 	free(key);
 	free(value);
-
-	return;
 }
 
 void CMD_InfoStoreRemove(F_CMD_ARGS)

--- a/fvwm/infostore.c
+++ b/fvwm/infostore.c
@@ -145,12 +145,13 @@ void CMD_InfoStoreAdd(F_CMD_ARGS)
 		goto error;
 	value = fxstrdup(token);
 
+	insert_metainfo(key, value);
+
 error:
 	if (key == NULL || value == NULL) {
 		fvwm_debug(__func__, "Bad arguments given.");
 		goto out;
 	}
-	insert_metainfo(key, value);
 out:
 	free(key);
 	free(value);


### PR DESCRIPTION
Don't hide the non-error case of adding the string to the InfoStore if
we're also suggesting the goto block is an error.
