### PR TITLE
get_page_arguments: remove fw field

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2157,7 +2157,7 @@ static void _move_window(F_CMD_ARGS, Bool do_animate, int mode)
 		get_absolute_geometry(fw, &t, &r);
 		get_page_offset_rectangle(fw, &page.x, &page.y, &t);
 
-		if (!get_page_arguments(fw, action, &page.x, &page.y, &m))
+		if (!get_page_arguments(action, &page.x, &page.y, &m))
 		{
 			m = fw->m;
 			page.x = m->virtual_scr.Vx;

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -1768,9 +1768,8 @@ void do_move_window_to_desk(FvwmWindow *fw, int desk)
 	return;
 }
 
-Bool get_page_arguments(
-	FvwmWindow *fw, char *action, int *page_x, int *page_y,
-	struct monitor **mret)
+Bool get_page_arguments(char *action, int *page_x, int *page_y,
+    struct monitor **mret)
 {
 	int val[2];
 	int suffix[2];
@@ -2672,7 +2671,7 @@ void CMD_GotoPage(F_CMD_ARGS)
 
 	x = m->virtual_scr.Vx;
 	y = m->virtual_scr.Vy;
-	if (!get_page_arguments(fw, action, &x, &y, &mpa))
+	if (!get_page_arguments(action, &x, &y, &mpa))
 	{
 		fvwm_debug(__func__,
 			   "GotoPage: invalid arguments: %s", action);

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -18,7 +18,7 @@ void goto_desk(int desk, struct monitor *);
 void do_move_window_to_desk(FvwmWindow *fw, int desk);
 void unmap_window(FvwmWindow *t);
 void map_window(FvwmWindow *t);
-Bool get_page_arguments(FvwmWindow *, char *action, int *page_x, int *page_y,
+Bool get_page_arguments(char *action, int *page_x, int *page_y,
     struct monitor **);
 char *GetDesktopName(struct monitor *, int desk);
 


### PR DESCRIPTION
The FvwmWindow field is no longer used and can be removed from the
function signature.
