### PR TITLE
meson: add check for xtrans

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -189,7 +189,7 @@ all_found_deps = []
 
 # Required dependencies, we can easily iterate over these.
 summary_depvals = {}
-all_req_deps = ['fontconfig', 'ice', 'libevent', 'x11', 'xft', 'xrandr', 'xt']
+all_req_deps = ['fontconfig', 'ice', 'libevent', 'x11', 'xft', 'xrandr', 'xt', 'xtrans']
 foreach rd : all_req_deps
     this_dep = dependency(rd, required: true)
     summary_depvals += {rd: this_dep}


### PR DESCRIPTION
It seems some linux packagers treat xtrans as separate from X11.  Not
all do though.

It's a required dependency -- so we should check for it.
