### PR TITLE
FvwmPager: Update current desk correctly during init.

### DIFF
--- a/modules/FvwmPager/messages.c
+++ b/modules/FvwmPager/messages.c
@@ -454,7 +454,7 @@ void process_new_desk(unsigned long *body)
 		monitor_assign_virtual(fp->m);
 
 	/* If always tracking current desk. Update Desks[0]. */
-	if (fAlwaysCurrentDesk && oldDesk != newDesk)
+	if (fAlwaysCurrentDesk && (oldDesk != newDesk || desk1 != newDesk))
 	{
 		PagerWindow *t;
 


### PR DESCRIPTION
When FvwmPager is tracking the current desk and is run on any desk except desk 0, the current desk isn't updated during initialization because the monitor update is sent before the desk update, so the pager didn't realize the desk has changed.

This ensures that the pager updates the current desk if either the desk changes or the new desk is not the same as the current desk to also catch updates during pager initialization.

Fixes #1122