### PR TITLE
Replace deprecated AM_CONFIG_HEADER with AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_CONFIG_AUX_DIR(etc)
 AC_CONFIG_LIBOBJ_DIR(libs)
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_SILENT_RULES([yes])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 VERSIONINFO=m4_esyscmd([./utils/fvwm-version-str.sh])
 


### PR DESCRIPTION
Replace long-time deprecated AM_CONFIG_HEADER with recommended AC_CONFIG_HEADERS macro.   AM_CONFIG_HEADER was [deprecated in 2002 and completely removed in 2012](https://lists.gnu.org/archive/html/automake/2012-12/msg00038.html).
