### PR TITLE
Fixes for C99 compatibility

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -208,7 +208,7 @@ if test "$ac_cv_func_select" = yes; then
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif],
-[extern select ($ac_cv_type_fd_set_size_t,
+[extern int select ($ac_cv_type_fd_set_size_t,
  $ac_cv_type_fd_set *,	$ac_cv_type_fd_set *, $ac_cv_type_fd_set *,
  $ac_type_timeval *);],
 [ac_found=yes ; break 3],ac_found=no)


### PR DESCRIPTION
Do not check that the compiler supports implicit ints without errors.  See fvwmorg/fvwm#100.

Related to:

 * https://fedoraproject.org/wiki/Changes/PortingToModernC
 * https://fedoraproject.org/wiki/Toolchain/PortingToModernC