### PR TITLE
FvwmPager: Fix SolidSeparators option

### DIFF
--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -567,18 +567,16 @@ void initialize_desk_style_gcs(DeskStyle *style)
 	/* create the virtual page boundary GC */
 	gcv.foreground = style->fg;
 	gcv.line_width = 1;
-	gcv.line_style = (use_dashed_separators) ? LineOnOffDash : LineSolid;
+	gcv.line_style = LineOnOffDash;
 	style->dashed_gc = fvwmlib_XCreateGC(dpy,
 		Scr.pager_w, GCForeground | GCLineStyle | GCLineWidth, &gcv);
-	if (use_dashed_separators) {
-		/* Although this should already be the default for a freshly
-		 * created GC, some X servers do not draw properly dashed
-		 * lines if the dash style is not set explicitly.
-		 */
-		dash_list[0] = 4;
-		dash_list[1] = 4;
-		XSetDashes(dpy, style->dashed_gc, 0, dash_list, 2);
-	}
+	/* Although this should already be the default for a freshly
+	 * created GC, some X servers do not draw properly dashed
+	 * lines if the dash style is not set explicitly.
+	 */
+	dash_list[0] = 4;
+	dash_list[1] = 4;
+	XSetDashes(dpy, style->dashed_gc, 0, dash_list, 2);
 
 	/* Window borders. */
 	gcv.foreground = (style->win_cs) ?

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -825,7 +825,8 @@ void draw_desk_grid(int desk)
 		x1 = (x * desk_w) / fp->virtual_scr.VWidth;
 		if (!use_no_separators)
 		{
-			XDrawLine(dpy, Desks[desk].w, style->dashed_gc,
+			XDrawLine(dpy, Desks[desk].w, (use_dashed_separators)
+				  ? style->dashed_gc : style->label_gc,
 				  x1, y1, x1, y2);
 		}
 		x += fpmonitor_get_all_widths();
@@ -838,7 +839,8 @@ void draw_desk_grid(int desk)
 		y1 = (y * desk_h) / fp->virtual_scr.VHeight;
 		if (!use_no_separators)
 		{
-			XDrawLine(dpy, Desks[desk].w, style->dashed_gc,
+			XDrawLine(dpy, Desks[desk].w, (use_dashed_separators)
+				  ? style->dashed_gc : style->label_gc,
 				  x1, y1, x2, y1);
 		}
 		y += fpmonitor_get_all_heights();
@@ -972,11 +974,13 @@ void draw_icon_grid(int erase)
 	rec.width = icon.width / rec.x;
 	rec.height = icon.height / rec.y;
 	if (!use_no_separators) {
+		GC gc = (use_dashed_separators) ? style->dashed_gc : style->label_gc;
+
 		for(i = 1; i < rec.x; i++)
-			XDrawLine(dpy, Scr.icon_w, style->dashed_gc,
+			XDrawLine(dpy, Scr.icon_w, gc,
 				i * rec.width, 0, i * rec.width, icon.height);
 		for(i = 1; i < rec.y; i++)
-			XDrawLine(dpy, Scr.icon_w, style->dashed_gc,
+			XDrawLine(dpy, Scr.icon_w, gc,
 				0, i * rec.height, icon.width, i * rec.height);
 	}
 


### PR DESCRIPTION
The dashed line GC is set before user options are parsed, so only newly created DeskStyles will have the dashed_gc set to a solid line. This means that when showing multiple desks, no desks will have a solid line, or when showing the current desk, the initial desk will not have a solid line, but other desks will.

The label_gc uses the same fg color as dashed_gc, and can be used to create solid lines. So instead of relying on dashed_gc to know if solid lines should be used or not, use either label_gc or dashed_gc to draw the separators depending on if the option SolidSeparators is used or not.

Fixes #1138