### PR TITLE
man: Fix formatting in Style definition

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -5051,7 +5051,7 @@ styles starting with "Application".
 	other than the default or to set the window manager default styles.
 +
 _stylename_ can be a window's name, class, visible name, or resource
-string. It may contain the wildcards '*' and '?', which are matched in
+string. It may contain the wildcards '{asterisk}' and '?', which are matched in
 the usual Unix filename manner. Multiple style options in a single
 *Style* command are read from left to right as if they were issued one
 after each other in separate commands. A given style always overrides


### PR DESCRIPTION
The '*' was interacting with a later one in the paragraph making the section bold instead of correctly just showing an asterisk.

before:
```
It may contain the wildcards '' and '?', which are matched in the usual Unix filename manner. Multiple style options in a single *Style command are read from left to right as if they were issued one after each other in separate commands.
```

after:
```
 It may contain the wildcards '*' and '?', which are matched in the usual Unix filename manner. Multiple style options in a single *Style* command are read from left to right as if they were issued one after each other in separate commands.
```
