### PR TITLE
In IconSwitchPage char command[34] is not enough

### DIFF
--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1267,7 +1267,7 @@ send_cmd:
 void IconSwitchPage(XEvent *Event)
 {
   int vx, vy;
-  char command[34];
+  char command[64];
   struct fpmonitor *fp = fpmonitor_this(NULL);
 
   if (fp == NULL) {


### PR DESCRIPTION
In IconSwitchPage char command[34] is not enough, some commands gettng truncated with long screen names, increasing to 64

Fixes issue #1146

(and thus as @somiaj claimed it is not an int16 truncation problem, it is a command truncation problem)