### PR TITLE
CI: release: consider internal-improvements

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,6 +10,8 @@ changelog:
       labels:
         - "type:enhancement"
         - "type:new-feature"
+    - title: Internal Improvements
+        - "type:internal-improvements"
     - title: Bug Fixes
         - "type:bug"
     - title: Other Changes


### PR DESCRIPTION
When generating the changelog for the release notes, ensure the
type:internal-improvements tag is considered as its own section.
