### PR TITLE
expand: introduce $[desk.count]

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -1470,6 +1470,9 @@ $[wa.x] $[wa.y] $[wa.width] $[wa.height]::
 $[dwa.x] $[dwa.y] $[dwa.width] $[dwa.height]::
 	Either coordinate or the width or height of the dynamic EWMH working area.
 
+$[desk.count]::
+	The number of desktops defined with the *DesktopName* command.
+
 $[desk.n]::
 	The current desk number.
 

--- a/fvwm/expand.c
+++ b/fvwm/expand.c
@@ -85,6 +85,7 @@ static char *function_vars[] =
 	"cw.x",
 	"cw.y",
 	"debuglog.state",
+	"desk.count",
 	"desk.height",
 	"desk.n",
 	"desk.pagesx",
@@ -177,6 +178,7 @@ enum
 	VAR_CW_X,
 	VAR_CW_Y,
 	VAR_DEBUG_LOG_STATE,
+	VAR_DESK_COUNT,
 	VAR_DESK_HEIGHT,
 	VAR_DESK_N,
 	VAR_DESK_PAGESX,
@@ -730,6 +732,10 @@ static signed int expand_vars_extended(
 	/* only exact matches for all other variables */
 	switch ((i = GetTokenIndex(var_name, function_vars, 0, &rest)))
 	{
+	case VAR_DESK_COUNT:
+		is_numeric = True;
+		val = number_of_desktops(m);
+		break;
 	case VAR_DESK_N:
 		is_numeric = True;
 		val = m->virtual_scr.CurrentDesk;

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -116,7 +116,6 @@
  * 2 is the default.
  */
 static void store_desktop_cmd(int, char *);
-static int number_of_desktops(struct monitor *);
 static void init_one_panframe(PanFrame *, int, int, int, int, int);
 static void parse_edge_leave_command(char *, int);
 static void broadcast_new_desk_monitor(struct monitor *);
@@ -2800,7 +2799,7 @@ void CMD_Scroll(F_CMD_ARGS)
 	return;
 }
 
-static int
+int
 number_of_desktops(struct monitor *m)
 {
 	DesktopsInfo	*d;

--- a/fvwm/virtual.h
+++ b/fvwm/virtual.h
@@ -21,6 +21,7 @@ void map_window(FvwmWindow *t);
 Bool get_page_arguments(char *action, int *page_x, int *page_y,
     struct monitor **);
 char *GetDesktopName(struct monitor *, int desk);
+int number_of_desktops(struct monitor *);
 
 struct desktop_cmd {
 	int				 desk;


### PR DESCRIPTION
This allows for the expansion to determine how many desktops have been
defined with the `DesktopName` command.
