### PR TITLE
ResizeMove: Make Warp imply WarpToWindow

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -1529,9 +1529,8 @@ static Bool resize_move_window(F_CMD_ARGS)
 	}
 	if (fWarp)
 	{
-		FWarpPointer(
-			dpy, None, None, 0, 0, 0, 0,
-			final_pos.x - p.x, final_pos.y - p.y);
+		char *cmd = "WarpToWindow 50 50";
+		execute_function_override_window(NULL, exc, cmd, NULL, 0, fw);
 	}
 	if (IS_MAXIMIZED(fw))
 	{


### PR DESCRIPTION
When asking for the pointer to be moved via the ResizeMove command, use
the WarpToWindow command to move the pointer centrally instead, rather
than the relative offset.

Fixes #1160
