### PR TITLE
Style syntax matching: Class, Name, Resource, Icon, WindowID

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -3451,8 +3451,6 @@ fvwm used. _verbose_ can be 1 or 2.
 +
 _nls_ which prints information on the locale catalogs that fvwm used
 +
-_style_ which prints information on fvwm styles. _verbose_ can be 1.
-+
 _bindings_ which prints information on all the bindings fvwm has: key
 and mouse bindings. _verbose_ has no effect with this option.
 +
@@ -4941,6 +4939,55 @@ ifdef::fvwm3all[]
 For readability, the commands in this section are not sorted
 alphabetically. The description of the *Style* command can be found at
 the end of this section.
+
+The commands: *FocusStyle*, *Style*, and *WindowStyle* can accept optional
+conditional components to match some properties of a window.
+
+For example:
+
+....
+Style (Name mc) Sticky
+....
+
+Will make a window whose name matched 'mc' _Sticky_.
+
+....
+Style (Name mc, Class XTerm) StartIconic
+....
+
+This example will start an xterm(1) window whose WM_CLASS matches 'XTerm' and
+name is 'mc'.
+
+A valid list of properties to test against are:
+
+* Resource
+* Class
+* Name
+* Icon
+* WindowID
+
+The matching of the properties specified for any *Style* line are ANDed
+together, and for styles to be applied, *all* properties must match.
+
+**NOTE**: To destroy a style line with window properties, *DestroyStyle*
+should be used.  For example:
+
+....
+DestroyStyle (Name mc, Class XTerm)
+....
+
+It is not required to specify the style arguments when destroying a style,
+only the property components are required.
+
+Existing *Style* lines in the form:
+
+....
+Style Application* Sticky, StartIconic
+....
+
+are still supported, and their behaviour remains unchanged.
+
+'''
 
 *FocusStyle* _stylename_ _options_::
 	works exactly like the *Style* command, but accepts only the focus

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -2651,10 +2651,6 @@ void CMD_PrintInfo(F_CMD_ARGS)
 	{
 		FGettextPrintLocalePath(verbose);
 	}
-	else if (StrEquals(subject, "style"))
-	{
-		print_styles(verbose);
-	}
 	else if (StrEquals(subject, "ImageCache"))
 	{
 		PicturePrintImageCache(verbose);

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -570,15 +570,24 @@ typedef struct style_flags
 	unsigned initial_placement_done : 1;
 } style_flags;
 
+typedef struct style_id_flags
+{
+	unsigned has_name:1;
+	unsigned has_window_id:1;
+	unsigned has_class:1;
+	unsigned has_resource:1;
+	unsigned has_icon:1;
+	unsigned is_compatibility_mode:1;
+} style_id_flags;
+
 typedef struct style_id_t
 {
-	char *name;
 	XID window_id;
-	struct
-	{
-		unsigned has_name:1;
-		unsigned has_window_id:1;
-	} flags;
+	style_id_flags flags;
+	char *name;
+	char *class;
+	char *resource;
+	char *icon;
 } style_id_t;
 
 typedef struct snap_attraction_t
@@ -678,6 +687,14 @@ typedef struct window_style
 	unsigned has_title_format_string : 1;
 	unsigned has_icon_title_format_string : 1;
 } window_style;
+
+typedef struct window_style_list
+{
+	struct window_style_list	*next;
+	style_id_t			 flags;
+	window_style			*first_style;
+	window_style			*last_style;
+} window_style_list;
 
 typedef struct window_g
 {

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -367,6 +367,31 @@
 #define S_SET_EWMH_MAXIMIZE_MODE(c,x) \
 	((c).s.ewmh_maximize_mode = (x))
 
+#define SID_GET_RESOURCE(id) \
+	((id).resource)
+#define SID_SET_RESOURCE(id,x) \
+	((id).resource = (x))
+#define SID_GET_CLASS(id) \
+	((id).class)
+#define SID_SET_CLASS(id,x) \
+	((id).class = (x))
+#define SID_GET_ICON(id) \
+	((id).icon)
+#define SID_SET_ICON(id,x) \
+	((id).icon = (x))
+#define SID_GET_NAME(id) \
+	((id).name)
+#define SID_SET_NAME(id,x) \
+	((id).name = (x))
+#define SID_GET_WINDOW_ID(id) \
+	((id).window_id)
+#define SID_SET_WINDOW_ID(id,x) \
+	((id).window_id = (x))
+#define SID_SET_IS_COMPATIBILITY_MODE(id,x) \
+        ((id).flags.is_compatibility_mode = !!(x))
+#define SID_GET_IS_COMPATIBILITY_MODE(id) \
+        ((id).flags.is_compatibility_mode)
+
 /* access to style_id */
 #define SID_GET_NAME(id) \
 	((id).name)
@@ -384,6 +409,18 @@
 	((id).flags.has_window_id = !!(x))
 #define SID_GET_HAS_WINDOW_ID(id) \
 	((id).flags.has_window_id)
+#define SID_GET_HAS_RESOURCE(id) \
+	((id).flags.has_resource)
+#define SID_SET_HAS_RESOURCE(id,x) \
+	((id).flags.has_resource = (x))
+#define SID_GET_HAS_CLASS(id) \
+	((id).flags.has_class)
+#define SID_SET_HAS_CLASS(id,x) \
+	((id).flags.has_class = (x))
+#define SID_GET_HAS_ICON(id) \
+	((id).flags.has_icon)
+#define SID_SET_HAS_ICON(id,x) \
+	((id).flags.has_icon = (x))
 
 /* access to other parts of a style (call with the style itself) */
 #define SGET_NEXT_STYLE(s) \
@@ -662,6 +699,12 @@
 	((s).icon_title_format_string)
 #define SSET_ICON_TITLE_FORMAT_STRING(s,x) \
 	((s).icon_title_format_string = (x))
+
+/* access to style lists */
+#define SLGET_NEXT_LIST(s) \
+	((s).next)
+#define SLSET_NEXT_LIST(s,x) \
+	((s).next = (x))
 
 /* function prototypes */
 void lookup_style(FvwmWindow *fw, window_style *styles);


### PR DESCRIPTION
Historically, there was always a demand to do something radical with Styles.  This change takes a small step to that by conditionally including matches on a window for its:

- Name `(WM_NAME)`
- Class `(WM_CLASS)`
- Resource `(WM_CLASS)`
- Icon
- WindowID

Hence with this change it's now possible to do:

```
Style (Class XTerm, Name FvwmPrompt) StartShaded
Style XTerm StartIconic
```

Here, if a window whose Class matches XTerm, **AND** its Name matched FvwmPrompt, then it would be started shaded.

If any other window just had a name/class/resource of XTerm, then it would be started iconic.