### PR TITLE
build: macos: ignore case-sensitive filename warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ endif
 
 if host_machine.system() == 'darwin'
     conf.set10('HOST_MACOS', true)
+    add_project_arguments(['-Wno-nonportable-include-path'], language: 'c')
 endif
 
 # Set static configuration.


### PR DESCRIPTION
When compiling on MacOS, don't treat case-sensitivity the same.  On MacOS, ignore it.