### PR TITLE
build: macos: fix path to fribidi

### DIFF
--- a/libs/BidiJoin.h
+++ b/libs/BidiJoin.h
@@ -14,7 +14,11 @@
 
 #ifdef HAVE_BIDI
 
+#if !defined(HOST_MACOS)
 #include <fribidi/fribidi.h>
+#else
+#include <fribidi.h>
+#endif
 
 /*
  * Shape/Join a passed-in visual string

--- a/libs/FBidi.c
+++ b/libs/FBidi.c
@@ -27,7 +27,12 @@
 
 #include "safemalloc.h"
 #include "BidiJoin.h"
+#if !defined(HOST_MACOS)
 #include <fribidi/fribidi.h>
+#else
+#include <fribidi.h>
+#endif
+
 #include <stdio.h>
 
 Bool FBidiIsApplicable(const char *charset)


### PR DESCRIPTION
On MacOS, it seems that fribidi.h isn't in its own subfolder of fribidi/ -- therefore, elide this if the compiling host is MacOS.