### PR TITLE
FvwmRearrange: Add -win_cmd COMMAND option.

### DIFF
--- a/doc/FvwmRearrange.adoc
+++ b/doc/FvwmRearrange.adoc
@@ -214,6 +214,13 @@ stretched or resized.
   When rearranging windows, make the calculation ignore the working area,
   such as _EwmhBaseStruts_; by default, FvwmRearrange will honour the
   working area. This option may place windows outside of the current monitor.
+-win_cmd _COMMAND_::
+  Runs the fvwm _COMMAND_ in the context of every window that is rearranged.
+  This can be used to set the state of all affected windows with the _COMMAND_
+  "State n" so they can be matched using the "State n" conditional. The
+  _COMMAND_ is sent after the window is moved/resized, so any change in
+  window's size, adding removing title bars, etc, will not be used in
+  computing the new position/size of the window.
 
 === RESIZING OPTIONS
 

--- a/modules/FvwmRearrange/FvwmRearrange.c
+++ b/modules/FvwmRearrange/FvwmRearrange.c
@@ -90,6 +90,7 @@ fd_set_size_t	   fd_width;
 window_list	   wins = NULL, wins_tail = NULL;
 int		   wins_count = 0;
 FILE		  *console;
+char		  *win_cmd = NULL;
 
 static void	   Loop(int *);
 static void	   process_message(unsigned long, unsigned long *);
@@ -142,6 +143,7 @@ void
 free_resources(void)
 {
 	free_window_list(wins);
+	free(win_cmd);
 
 	if (console != stderr)
 		fclose(console);
@@ -453,6 +455,8 @@ move_resize_raise_window(window_item *wi, int x, int y, int w, int h)
 		SendText(fd, msg, wi->frame);
 	}
 
+	if (win_cmd)
+		SendText(fd, win_cmd, wi->frame);
 	if (raise_window)
 		SendText(fd, "Raise", wi->frame);
 }
@@ -740,6 +744,10 @@ parse_args(int argc, char *argv[], int argi)
 			do_animate = 1;
 		} else if (StrEquals(argv[argi], "-ewmhiwa")) {
 			do_ewmhiwa = 1;
+		} else if (StrEquals(argv[argi], "-win_cmd")
+			   && ((argi + 1) < argc)) {
+			free(win_cmd);
+			win_cmd = fxstrdup(argv[++argi]);
 
 		/* Resizing options */
 		} else if (StrEquals(argv[argi], "-noresize")) {


### PR DESCRIPTION
This adds an option to run an fvwm command in the context of all windows rearranged by FvwmRearrange. This was added to allow setting the state of all windows via `-win_cmd "State n"` to allow matching them with conditionals. A general option was added to allow users to run any fvwm command in all window's context.