### PR TITLE
FvwmPager: correct fonts and balloons initialization

### DIFF
--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -96,6 +96,7 @@ bool	HilightDesks = true;
 bool	HilightLabels = true;
 bool	error_occured = false;
 bool	use_desk_label = true;
+bool	use_window_label = true;
 bool	WindowBorders3d = false;
 bool	HideSmallWindows = false;
 bool	SendCmdAfterMove = false;

--- a/modules/FvwmPager/FvwmPager.h
+++ b/modules/FvwmPager/FvwmPager.h
@@ -221,6 +221,7 @@ extern bool	HilightDesks;
 extern bool	HilightLabels;
 extern bool	error_occured;
 extern bool	use_desk_label;
+extern bool	use_window_label;
 extern bool	WindowBorders3d;
 extern bool	HideSmallWindows;
 extern bool	SendCmdAfterMove;


### PR DESCRIPTION
Prevent some weird FvwmPager crashes and balloons not showing up because fonts and boolean flags are not initialized an start. Also restore the functionallity of "Balloons" option without parameters.

Sometimes (and almost always when swallowed by FvwmButtons) FvwmPager silently crashes. Debugging has shown that this happens in do_label_window() function because Scr.winFfont is uninitialized. Also balloons are not always shown in FvwmPager because Balloon.show_in_pager and Balloon.show_in_icon boolean flags are undetermined, and
Balloons with no parameters has no effect. This has been corrected.
