### PR TITLE
build: remove go-1.14.0 check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fvwmorg/fvwm3-build:latest
 #FROM docker.pkg.github.com/fvwmorg/fvwm3/fvwm3-build:latest
 
-ENV GOROOT="/usr/lib/go-1.14/"
+ENV GOROOT="/usr/lib/go/"
 ENV PATH="$GOROOT/bin:$PATH"
 ENV GO111MODULE="on"
 

--- a/meson.build
+++ b/meson.build
@@ -231,8 +231,7 @@ if golang.found()
     if gover.version_compare('<1.20.0')
         error(
             '''A version of Go >= 1.20.0 is required to use the FVWM3 meson build Go modules.
-               Either disable Go for this build (`-Dgolang=disabled`) or upgrade Go to a version >= 1.20.0.
-               The Autotools build can use Go 1.14.0, this is another option if upgrading is not feasible.''',
+               Either disable Go for this build (`-Dgolang=disabled`) or upgrade Go to a version >= 1.20.0.''',
         )
     endif
 else


### PR DESCRIPTION
The need for go-1.14 was only needed for autotools, so this check can be
removed.

Additionally, go-1.14 was released over five years ago so the chances
are a newer version is likely ubiquitous.
