### PR TITLE
fvwm-version-str.sh source is not POSIX, so use . instead.

### DIFF
--- a/utils/fvwm-version-str.sh
+++ b/utils/fvwm-version-str.sh
@@ -14,7 +14,7 @@ VERSION="released"
 
 [ -d ".git" ] || { echo "$VERSION" && exit 0 ; }
 
-[ -e "./.release-status" ] && source "./.release-status"
+[ -e "./.release-status" ] && . "./.release-status"
 
 [ -z "$ISRELEASED" ] && { echo "UNKNOWN" && exit 0 ; }
 


### PR DESCRIPTION
`source file` is not POSIX and an alias only used in some shells. POSIX is just a dot, so use `. file` instead. This will ensure the version string is not `UNKOWN` when using a shell that doesn't have the `source` alias.

Fixes #1199