### PR TITLE
fvwm: allow rounded corners for application windows and menus

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -2519,7 +2519,9 @@ using the *ChangeMenuStyle*. See also *DestroyMenuStyle*. When using
 monochrome color options are ignored.
 +
 _options_ is a comma separated list containing some of the keywords
-Fvwm / Mwm / Win, BorderWidth, HilightBack / !HilightBack, HilightTitleBack,
+Fvwm / Mwm / Win, BorderWidth, RoundedCorners / !RoundedCorners,
+SlightlyRoundedCorners / !SlightlyRoundedCorners,
+HilightBack / !HilightBack, HilightTitleBack,
 ActiveFore / !ActiveFore, MenuColorset, ActiveColorset, GreyedColorset,
 TitleColorset, Hilight3DThick / Hilight3DThin / Hilight3DOff,
 Hilight3DThickness, Animation / !Animation, Font, TitleFont,
@@ -2577,6 +2579,12 @@ SubmenusRight, BorderWidth 2, UniqueHotkeyActivatesImmediate,
 _BorderWidth_ takes the thickness of the border around the menus in
 pixels. It may be zero to 50 pixels. The default is 2. Using an
 invalid value reverts the border width to the default.
++
+_RoundedCorners_ makes all corners of menus rounded, with the radii
+equal to 9 pixels. _!RoundedCorners_ restores the default (sharp corners).
++
+_SlightlyRoundedCorners_ is analogous but the radii are equal to
+4 pixels. There is _!SlightlyRoundedCorners_ as well.
 +
 _HilightBack_ and _!HilightBack_ switch hilighting the background of
 the selected menu item on and off. The _ActiveColorset_ background
@@ -5060,14 +5068,17 @@ style.
 _options_ is a comma separated list containing one or more of the
 following keywords. Each group of style names is separated by slashes
 ('/'). The last style in these groups is the default. _BorderWidth_,
-_HandleWidth_, _CornerLength_, _!Icon_ / _Icon_, _MiniIcon_,
+_HandleWidth_, _CornerLength_, _RoundedCorners_ / _!RoundedCorners_,
+_RoundedCornersTop_ / _!RoundedCornersTop_, _RoundedCornersBottom_ /
+_!RoundedCornersBottom_, _SlightlyRoundedCorners_ /
+_!SlightlyRoundedCorners_, _!Icon_ / _Icon_, _MiniIcon_,
 _IconBox_, _IconGrid_, _IconFill_, _IconSize_, _!Title_ / _Title_,
 _TitleAtBottom_ / _TitleAtLeft_ / _TitleAtRight_ /
 _TitleAtTop_, _LeftTitleRotatedCW_ / _LeftTitleRotatedCCW_,
 _RightTitleRotatedCCW_ / _RightTitleRotatedCW_,
 _TopTitleRotated_ / _TopTitleNotRotated_, _BottomTitleRotated_ /
-_BottomTitleNotRotated_, _!UseTitleDecorRotation_ /
-_UseTitleDecorRotation_, _StippledTitle_ / _!StippledTitle_,
+_BottomTitleNotRotated_, _!UseTitleDecorRotation_ / _UseTitleDecorRotation_,
+_RotateShadows_ / _!RotateShadows_, _StippledTitle_ / _!StippledTitle_,
 _StippledIconTitle_ / _!StippledIconTitle_, _IndexedWindowName_ /
 _ExactWindowName_, _IndexedIconName_ / _ExactIconName_, _TitleFormat_
 / _IconTitleFormat_ / _!Borders_ / _Borders_, _!Handles_ / _Handles_,
@@ -5353,6 +5364,10 @@ previous paragraph). This can be disabled by using the
 !_UseTitleDecorRotation_ style. _UseTitleDecorRotation_ reverts back
 to the default.
 +
+If the title text is rotated, all shadows can be rotated accordingly
+by _RotateShadows_ style. _!RotateShadows_ disables this and
+restores the default.
++
 With the _StippledTitle_ style, titles are drawn with the same
 effect that is usually reserved for windows with the _Sticky_,
 _StickyAcrossPages_ or _StickyAcrossDesks_ style. _!StippledTitle_
@@ -5546,9 +5561,22 @@ _HandleWidth_ takes a numeric argument which is the width of the
 border to place the window if it does have resize-handles. Using
 _HandleWidth_ without an argument restores the default.
 +
-_CornerLength_ takes a single numeric argument which is the length,
-in pixels, of the corner handles. The default is the title height.
-Using _CornerLength_ without an argument restores the default.
+_CornerLength_ takes one to four numeric arguments which are the lengths,
+in pixels, of the corner handles, in the order NW, NE, SE, and SW.
+The defaults are the title height. If less than four arguments
+are supplied, they are reasonably repeated. Using _CornerLength_
+without an argument restores the defaults.
++
+_RoundedCorners_ takes one to four numeric arguments which are the radii,
+in pixels, of circle quarters at the corners (NW, NE, SE, and SW).
+Less than four arguments can also be supplied similarly to _CornerLength_.
+_RoundedCorners_ with no arguments means the default which is 9 pixels, and
+_!RoundedCorners_ means sharp corners (all radii are 0).
+There is also _SlightlyRoundedCorners_ that sets the radii to 4 pixels.
++
+_RoundedCornersTop_ and _RoundedCornersBottom_ take zero to two numeric
+arguments and apply to the top corners only and to the bottom corners only,
+respectively.
 +
 _BorderWidth_ takes a numeric argument which is the width of the
 border to place the window if it does not have resize-handles. It is

--- a/fvwm/borders.h
+++ b/fvwm/borders.h
@@ -61,7 +61,8 @@ int border_is_using_border_style(
 int border_context_to_parts(
 	int context);
 void border_get_part_geometry(
-	FvwmWindow *fw, window_parts part, rectangle *sidebar_g,
+	FvwmWindow *fw, window_parts part,
+	rectangle *lb_sidebar_g, rectangle *rt_sidebar_g,
 	rectangle *ret_g, Window *ret_w);
 int get_button_number(int context);
 void border_draw_decorations(

--- a/fvwm/frame.h
+++ b/fvwm/frame.h
@@ -4,6 +4,7 @@
 #define FVWM_FRAME_H
 
 /* ---------------------------- included header files ---------------------- */
+#include "borders.h"
 #include "fvwm.h"
 #include "screen.h"
 
@@ -57,7 +58,8 @@ void frame_get_titlebar_dimensions(
 	frame_title_layout_t *title_layout);
 void frame_get_sidebar_geometry(
 	FvwmWindow *fw, DecorFaceStyle *borderstyle, rectangle *frame_g,
-	rectangle *ret_g, Bool *ret_has_x_marks, Bool *ret_has_y_marks);
+	rectangle *lb_ret_g, rectangle *rt_ret_g, rectangle *rnd_ret_g,
+	Bool *ret_has_x_marks, Bool *ret_has_y_marks);
 int frame_window_id_to_context(
 	FvwmWindow *fw, Window w, int *ret_num);
 void frame_move_resize(
@@ -73,5 +75,12 @@ void frame_force_setup_window(
 	Bool do_send_configure_notify);
 void frame_setup_shape(
 	FvwmWindow *fw, int w, int h, int shape_mode);
+void frame_make_rounded_corners(FvwmWindow *fw);
+void correct_rounded_subwindow(Window win, Window outer,
+	int *width, int *height,
+	int *nw_corner, int *sw_corner, int *se_corner, int *ne_corner);
+void draw_rounded_mask(Window win, Window outer,
+	int nw_corner, int sw_corner, int se_corner, int ne_corner,
+	window_parts draw_parts, int col);
 
 #endif /* FVWM_FRAME_H */

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -230,6 +230,7 @@ typedef struct
 		unsigned do_not_show_on_map : 1;
 		unsigned do_raise_transient : 1;
 		unsigned do_resize_opaque : 1;
+		unsigned do_rotate_shadows : 1;
 		unsigned do_shrink_windowshade : 1;
 		unsigned do_stack_transient_parent : 1;
 		unsigned do_window_list_skip : 1;
@@ -275,6 +276,8 @@ typedef struct
 #define WINDOWSHADE_LAZY_MASK   0x3
 		unsigned windowshade_laziness : 2;
 		unsigned use_title_decor_rotation : 1;
+		unsigned has_rounded_corners_top : 1;
+		unsigned has_rounded_corners_bottom : 1;
 		focus_policy_t focus_policy;
 	} s;
 } common_flags_t;
@@ -647,7 +650,9 @@ typedef struct window_style
 	short border_width;
 	/* resize handle width */
 	short handle_width;
-	short corner_length;
+	/* nw, ne, se, sw */
+	short corner_length[4];
+	short rounded_corner[4];
 	int layer;
 	int start_desk;
 	int start_page_x;
@@ -783,7 +788,9 @@ typedef struct FvwmWindow
 	 * CONFIGARGSNEW macro in module_interface.c, libs/vpacket.h too! */
 	short boundary_width;
 	short unshaped_boundary_width;
-	short corner_length;
+	/* nw, ne, se, sw */
+	short corner_length[4];
+	short rounded_corner[4];
 
 	/* title font */
 	FlocaleFont *title_font;

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -136,6 +136,7 @@ static int menustyle_get_styleopt_index(char *option)
 		"VerticalMargins",
 		"UniqueHotkeyActivatesImmediate",
 		"Translucent",
+		"RoundedCorners", "SlightlyRoundedCorners",
 		NULL
 	};
 
@@ -1082,6 +1083,13 @@ MenuStyle *menustyle_parse_style(F_CMD_ARGS)
 			} else {
 				ST_TRANSLUCENT_PERCENT(tmpms) = *val;
 			}
+			break;
+
+		case 56: /* RoundedCorners */
+			ST_HAS_ROUNDED_CORNERS(tmpms) = on;
+			break;
+		case 57: /* SlightlyRoundedCorners */
+			ST_HAS_SLIGHTLY_ROUNDED_CORNERS(tmpms) = on;
 			break;
 
 #if 0

--- a/fvwm/menustyle.h
+++ b/fvwm/menustyle.h
@@ -22,6 +22,10 @@
 /* look */
 #define ST_DO_HILIGHT_BACK(s)         ((s)->look.flags.do_hilight_back)
 #define MST_DO_HILIGHT_BACK(m)        ((m)->s->ms->look.flags.do_hilight_back)
+#define ST_HAS_ROUNDED_CORNERS(s)     ((s)->look.flags.has_rounded_corners)
+#define MST_HAS_ROUNDED_CORNERS(m)    ((m)->s->ms->look.flags.has_rounded_corners)
+#define ST_HAS_SLIGHTLY_ROUNDED_CORNERS(s)     ((s)->look.flags.has_slightly_rounded_corners)
+#define MST_HAS_SLIGHTLY_ROUNDED_CORNERS(m)    ((m)->s->ms->look.flags.has_slightly_rounded_corners)
 #define ST_DO_HILIGHT_FORE(s)         ((s)->look.flags.do_hilight_fore)
 #define MST_DO_HILIGHT_FORE(m)        ((m)->s->ms->look.flags.do_hilight_fore)
 #define ST_DO_HILIGHT_TITLE_BACK(s)   ((s)->look.flags.do_hilight_title_back)
@@ -240,6 +244,8 @@ typedef struct MenuLook
 		unsigned triangles_use_fore : 1;
 		unsigned do_hilight_title_back : 1;
 		unsigned using_default_titlefont : 1;
+		unsigned has_rounded_corners : 1;
+		unsigned has_slightly_rounded_corners : 1;
 	} flags;
 	unsigned char ReliefThickness;
 	unsigned char TitleUnderlines;

--- a/fvwm/style.h
+++ b/fvwm/style.h
@@ -194,6 +194,10 @@
 	((c).s.do_resize_opaque)
 #define S_SET_DO_RESIZE_OPAQUE(c,x) \
 	((c).s.do_resize_opaque = !!(x))
+#define S_DO_ROTATE_SHADOWS(c) \
+	((c).s.do_rotate_shadows)
+#define S_SET_DO_ROTATE_SHADOWS(c,x) \
+	((c).s.do_rotate_shadows = !!(x))
 #define S_DO_SHRINK_WINDOWSHADE(c) \
 	((c).s.do_shrink_windowshade)
 #define S_SET_DO_SHRINK_WINDOWSHADE(c,x) \
@@ -334,6 +338,14 @@
 	((c).s.use_title_decor_rotation)
 #define S_SET_USE_TITLE_DECOR_ROTATION(c,x) \
 	((c).s.use_title_decor_rotation = !!(x))
+#define S_HAS_ROUNDED_CORNERS_TOP(c) \
+	((c).s.has_rounded_corners_top)
+#define S_SET_HAS_ROUNDED_CORNERS_TOP(c,x) \
+	((c).s.has_rounded_corners_top = !!(x))
+#define S_HAS_ROUNDED_CORNERS_BOTTOM(c) \
+	((c).s.has_rounded_corners_bottom)
+#define S_SET_HAS_ROUNDED_CORNERS_BOTTOM(c,x) \
+	((c).s.has_rounded_corners_bottom = !!(x))
 #define S_DO_EWMH_MINI_ICON_OVERRIDE(c) \
 	((c).s.do_ewmh_mini_icon_override)
 #define S_SET_DO_EWMH_MINI_ICON_OVERRIDE(c,x) \
@@ -507,10 +519,14 @@
 	((s).handle_width)
 #define SSET_HANDLE_WIDTH(s,x) \
 	((s).handle_width = (x))
-#define SGET_CORNER_LENGTH(s) \
-	((s).corner_length)
-#define SSET_CORNER_LENGTH(s,x) \
-	((s).corner_length = (x))
+#define SGET_CORNER_LENGTH(s,i) \
+	((s).corner_length[i])
+#define SSET_CORNER_LENGTH(s,i,x) \
+	((s).corner_length[i] = (x))
+#define SGET_ROUNDED_CORNER(s,i) \
+	((s).rounded_corner[i])
+#define SSET_ROUNDED_CORNER(s,i,x) \
+	((s).rounded_corner[i] = (x))
 #define SGET_LAYER(s) \
 	((s).layer)
 #define SSET_LAYER(s,x) \

--- a/fvwm/window_flags.h
+++ b/fvwm/window_flags.h
@@ -21,6 +21,8 @@
 	((fw)->flags.common.s.do_raise_transient)
 #define DO_RESIZE_OPAQUE(fw) \
 	((fw)->flags.common.s.do_resize_opaque)
+#define DO_ROTATE_SHADOWS(fw) \
+	((fw)->flags.common.s.do_rotate_shadows)
 #define DO_SHRINK_WINDOWSHADE(fw) \
 	((fw)->flags.common.s.do_shrink_windowshade)
 #define SET_DO_SHRINK_WINDOWSHADE(fw,x) \
@@ -312,18 +314,30 @@
 	(fw)->flags.common.s.is_bottom_title_rotated = !!(x)
 #define SETM_IS_BOTTOM_TITLE_ROTATED(fw,x) \
 	(fw)->flag_mask.common.s.is_bottom_title_rotated = !!(x)
-#define IS_BOTTOM_TITLE_ROTATED(fw) \
-	((fw)->flags.common.s.is_bottom_title_rotated)
-#define SET_IS_BOTTOM_TITLE_ROTATED(fw,x) \
-	(fw)->flags.common.s.is_bottom_title_rotated = !!(x)
-#define SETM_IS_BOTTOM_TITLE_ROTATED(fw,x) \
-	(fw)->flag_mask.common.s.is_bottom_title_rotated = !!(x)
+#define IS_TOP_TITLE_ROTATED(fw) \
+	((fw)->flags.common.s.is_top_title_rotated)
+#define SET_IS_TOP_TITLE_ROTATED(fw,x) \
+	(fw)->flags.common.s.is_top_title_rotated = !!(x)
+#define SETM_IS_TOP_TITLE_ROTATED(fw,x) \
+	(fw)->flag_mask.common.s.is_top_title_rotated = !!(x)
 #define USE_TITLE_DECOR_ROTATION(fw) \
 	((fw)->flags.common.s.use_title_decor_rotation)
 #define SET_USE_TITLE_DECOR_ROTATION(fw,x) \
 	(fw)->flags.common.s.use_title_decor_rotation = !!(x)
 #define SETM_USE_TITLE_DECOR_ROTATION(fw,x) \
 	(fw)->flag_mask.common.s.use_title_decor_rotation = !!(x)
+#define HAS_ROUNDED_CORNERS_TOP(fw) \
+	((fw)->flags.common.s.has_rounded_corners_top)
+#define SET_HAS_ROUNDED_CORNERS_TOP(fw,x) \
+	(fw)->flags.common.s.has_rounded_corners_top = !!(x)
+#define SETM_HAS_ROUNDED_CORNERS_TOP(fw,x) \
+	(fw)->flag_mask.common.s.has_rounded_corners_top = !!(x)
+#define HAS_ROUNDED_CORNERS_BOTTOM(fw) \
+	((fw)->flags.common.s.has_rounded_corners_bottom)
+#define SET_HAS_ROUNDED_CORNERS_BOTTOM(fw,x) \
+	(fw)->flags.common.s.has_rounded_corners_bottom = !!(x)
+#define SETM_HAS_ROUNDED_CORNERS_BOTTOM(fw,x) \
+	(fw)->flag_mask.common.s.has_rounded_corners_bottom = !!(x)
 
 /* access to the special flags of a window */
 #define DO_REUSE_DESTROYED(fw) \

--- a/fvwm/windowshade.c
+++ b/fvwm/windowshade.c
@@ -212,6 +212,7 @@ void CMD_WindowShade(F_CMD_ARGS)
 	border_draw_decorations(
 		fw, PART_TITLEBAR, (fw == get_focus_window()) ? True : False,
 		0, CLEAR_BUTTONS, NULL, NULL);
+	frame_make_rounded_corners(fw);
 	/* update hints and inform modules */
 	BroadcastConfig(M_CONFIGURE_WINDOW, fw);
 	BroadcastPacket(

--- a/libs/Graphics.h
+++ b/libs/Graphics.h
@@ -2,22 +2,26 @@
 #define FVWMLIB_GRAPHICS_H
 #include "fvwm_x11.h"
 
-void do_relieve_rectangle(
-	Display *dpy, Drawable d, int x, int y, int w, int h,
-	GC ReliefGC, GC ShadowGC, int line_width, Bool use_alternate_shading);
+void do_rounded_angle_with_rotation(
+	Display *dpy, Drawable d,
+	GC LeftGC, GC RightGC, int vx, int vy,
+	int sides, int radius, int line_width, int rotation, Bool diag_right);
 
-void do_relieve_rectangle_with_rotation(
+void do_relieve_rectangle_rounded_with_rotation(
 	Display *dpy, Drawable d, int x, int y, int w, int h,
-	GC ReliefGC, GC ShadowGC, int line_width, Bool use_alternate_shading,
-	int rotation);
+	GC ReliefGC, GC ShadowGC, int line_width,
+	int nw_radius, int ne_radius, int se_radius, int sw_radius,
+	Bool diag_right, int rotation);
 
 #define RelieveRectangle(dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width) \
-	do_relieve_rectangle( \
-		dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width, False)
+	do_relieve_rectangle_rounded_with_rotation( \
+		dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width, \
+		0, 0, 0, 0, False, 0)
 
-#define RelieveRectangle2(dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width) \
-	do_relieve_rectangle( \
-		dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width, True)
+#define RelieveRectangleRounded(dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width, nw_radius, ne_radius, se_radius, sw_radius) \
+	do_relieve_rectangle_rounded_with_rotation( \
+		dpy, d, x, y, w, h, ReliefGC, ShadowGC, line_width, \
+		nw_radius, ne_radius, se_radius, sw_radius, False, 0)
 
 Pixmap CreateStretchXPixmap(
 	Display *dpy, Pixmap src, int src_width, int src_height, int src_depth,


### PR DESCRIPTION
New features and styles are introduced, mainly to get rounded corners for window borders, buttons, menus etc. To achieve this, the code that draws relief rectangles has been heavily modified, mainly to provide correct junctions when two arms of an angle or two halves of an arc are drawn with different GCs. Bresenham algorithm is applied to construct arcs, both for drawing and for making windows shaped at corners using XShape (no antialising, hence some jagging is present, it is up to user whether to round corners or not).

Another distinctive feature is the possibility to specify different radii and corner lengths (handle lengths) for all corners of a window by `CornerLength` and `RoundedCorners` styles.

Decor elements are correctly rounded and rotated if `TitleAt{TOP,Left,Bottom,Right}` with `XXXTitleRotated{CW,CCW}` is used. An option `RotateShadows` to rotate shadows together with title text is also introduced.

![screenshot-rounded](https://github.com/user-attachments/assets/286c651f-a2a5-49a7-9119-29758eb34cdb)

