### PR TITLE
setup_visible_names: don't ignore when both set

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -1562,6 +1562,10 @@ int setup_visible_names(FvwmWindow *fw, int what_changed)
 
 	changed_names = (what_changed & 3);
 	changed_styles = ((what_changed >> 2) & 3);
+
+	if (changed_styles == 0 && changed_names > 0)
+		changed_styles = 3;
+
 	force_update = changed_styles;
 	if (fw->visible_name == NULL)
 	{


### PR DESCRIPTION
When updating the visible_name or icon_name of a window, don't miss
anything.

Fixes #1202
