### PR TITLE
FvwmForm: process UTF-8 input and paste request in input fields

### DIFF
--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -122,11 +122,13 @@ static void SetupTimer(void)
 static char *CopyQuotedString (char *cp)
 {
   char *dp, *bp, c;
-  bp = dp = fxmalloc(strlen(cp) + 1);
+  const char *tp;
+  tp = _(cp);
+  bp = dp = fxmalloc(strlen(tp) + 1);
   while (1) {
-    switch (c = *(cp++)) {
+    switch (c = *(tp++)) {
     case '\\':
-      *(dp++) = *(cp++);
+      *(dp++) = *(tp++);
       break;
     case '\"':
     case '\n':
@@ -947,7 +949,7 @@ static void ct_Input(char *cp)
   item->input.blanks = fxmalloc(item->input.width);
   for (j = 0; j < item->input.width; j++)
     item->input.blanks[j] = ' ';
-  item->input.buf = strlen(item->input.init_value) + 1; /* room for init value */
+  item->input.buf = strlen(item->input.init_value) + 1;
   item->input.value = fxmalloc(item->input.buf);
   item->input.value[0] = 0;		/* avoid reading unitialized data */
   item->input.size = 0;			/* value is empty */
@@ -1054,15 +1056,12 @@ static void PutDataInForm(char *cp)
 	c += len;
 	var_len = (int)(c - cp);
 	free(item->input.init_value);
-	item->input.init_value = fxmalloc(var_len + 1);
-	strncpy(item->input.init_value, cp, var_len); /* new initial value */
-	item->input.init_value[var_len] = '\0';
+	item->input.init_value = strndup(cp, var_len + 1); /* new initial value */
 	free(item->input.value);
 	item->input.n = num+1;
 	item->input.buf = var_len+1;
 	item->input.size = var_len;
-	item->input.value = fxmalloc(item->input.buf);
-	strcpy(item->input.value, item->input.init_value); /* new value */
+	item->input.value = fxstrdup(item->input.init_value); /* new value */
 	free(var_name);			/* goto's have their uses */
 	return;
       }
@@ -2769,6 +2768,8 @@ int main (int argc, char **argv)
 #endif
 
   FlocaleInit(LC_CTYPE, "", "", "FvwmForm");
+
+  FGettextInit("fvwm3", LOCALEDIR, "FvwmForm");
 
   module = ParseModuleArgs(argc,argv,1); /* allow an alias */
   if (module == NULL)

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -1056,7 +1056,8 @@ static void PutDataInForm(char *cp)
 	c += len;
 	var_len = (int)(c - cp);
 	free(item->input.init_value);
-	item->input.init_value = strndup(cp, var_len + 1); /* new initial value */
+	item->input.init_value = fxmalloc(var_len + 1);
+	strlcpy(item->input.init_value, cp, var_len + 1); /* new initial value */
 	free(item->input.value);
 	item->input.n = num+1;
 	item->input.buf = var_len+1;

--- a/modules/FvwmForm/FvwmForm.c
+++ b/modules/FvwmForm/FvwmForm.c
@@ -947,10 +947,11 @@ static void ct_Input(char *cp)
   item->input.blanks = fxmalloc(item->input.width);
   for (j = 0; j < item->input.width; j++)
     item->input.blanks[j] = ' ';
-  item->input.buf = strlen(item->input.init_value) + 1;
+  item->input.buf = strlen(item->input.init_value) + 1; /* room for init value */
   item->input.value = fxmalloc(item->input.buf);
   item->input.value[0] = 0;		/* avoid reading unitialized data */
   item->input.size = 0;			/* value is empty */
+  item->input.n = 0;			/* and contains 0 chars */
 
   item->header.size_x = item->header.dt_ptr->dt_Ffont->height * item->input.width / 2
 			+ 2 * TEXT_SPC + 2 * BOX_SPC;
@@ -1057,6 +1058,7 @@ static void PutDataInForm(char *cp)
 	strncpy(item->input.init_value, cp, var_len); /* new initial value */
 	item->input.init_value[var_len] = '\0';
 	free(item->input.value);
+	item->input.n = num+1;
 	item->input.buf = var_len+1;
 	item->input.size = var_len;
 	item->input.value = fxmalloc(item->input.buf);

--- a/modules/FvwmForm/FvwmForm.h
+++ b/modules/FvwmForm/FvwmForm.h
@@ -92,7 +92,8 @@ typedef union _item {
     char *value;           /* input string */
     char *init_value;      /* default string */
     char *blanks;          /* blank string */
-    int size;              /* input field size */
+    int size;              /* value size in bytes */
+    int width;             /* input field width */
     int left;              /* position of the left-most displayed char */
     union _item *next_input;            /* a ring of input fields */
     union _item *prev_input;            /* for tabbing */
@@ -263,7 +264,10 @@ void DoCommand (Item *cmd);              /* FvwmForm.c */
 int FontWidth (XFontStruct *xfs);        /* FvwmForm.c */
 void RedrawFrame (XEvent *pev);          /* FvwmForm.c */
 char * ParseCommand (int, char *, char, int *, char **s); /* ParseCommand.c */
+char* find_nth_UTF8_char(char *str, char *before,
+	int *num, int *len);             /* FvwmForm.c */
 
 RETSIGTYPE DeadPipe(int nonsense);            /* FvwmForm.c */
 
 #endif
+char* find_nth_UTF8_char(char *str, char *before, int *num, int *len);

--- a/modules/FvwmForm/FvwmForm.h
+++ b/modules/FvwmForm/FvwmForm.h
@@ -270,4 +270,3 @@ char* find_nth_UTF8_char(char *str, char *before,
 RETSIGTYPE DeadPipe(int nonsense);            /* FvwmForm.c */
 
 #endif
-char* find_nth_UTF8_char(char *str, char *before, int *num, int *len);

--- a/modules/FvwmForm/FvwmForm.h
+++ b/modules/FvwmForm/FvwmForm.h
@@ -11,6 +11,7 @@
  */
 
 #include "libs/Flocale.h"               /* for font definition stuff */
+#include "libs/FGettext.h"              /* for localization of messages */
 /*
  * This next stuff should be more specific and customizable.
  * For example padVText (above) was one of the things TXT_SPC

--- a/modules/FvwmForm/ReadXServer.c
+++ b/modules/FvwmForm/ReadXServer.c
@@ -468,23 +468,24 @@ void ReadXServer (void)
 	      char *bstr, *estr;
 
 	      cn = item->input.left;
-	      bstr = find_nth_UTF8_char(CF.cur_input->input.value, NULL, &cn, NULL);
+	      bstr = estr = find_nth_UTF8_char(CF.cur_input->input.value, NULL, &cn, NULL);
 
 	      for (CF.abs_cursor = 0; CF.abs_cursor < item->input.width - 1; CF.abs_cursor++)
 	      {
-		cn = CF.abs_cursor;
-		estr = find_nth_UTF8_char(bstr, NULL, &cn, NULL);
+		cn = 0; /* take one char */
+		estr = find_nth_UTF8_char(estr, NULL, &cn, &ln);
 		if (FlocaleTextWidth(item->header.dt_ptr->dt_Ffont,
 				     bstr, (int)(estr - bstr)) >=
 				event.xbutton.x - BOX_SPC - TEXT_SPC)
 		{
 		  if (CF.abs_cursor > 0) {
-		    CF.abs_cursor--;
+		    CF.abs_cursor--; /* mouse click left behind, so move one step back */
 		  }
 		  break;
 		}
-		if (cn < CF.abs_cursor)
+		if (cn < 0) /* end of the line */
 		    break;
+		estr += ln;
 	      }
 	    }
 	    CF.rel_cursor = CF.abs_cursor + item->input.left;

--- a/modules/FvwmForm/ReadXServer.c
+++ b/modules/FvwmForm/ReadXServer.c
@@ -703,7 +703,7 @@ static void process_paste_request (XEvent *event, Item *item) {
     if (actual_type != XA_STRING) {     /* if something other than text */
       return;                           /* give up */
     }
-    len = 1; c = (char*)data;
+    c = (char*)data;
     while (num = 0, c = find_nth_UTF8_char(c, (char*)data + nitems, &num, &len), len > 0) {
       /* each multibyte character */
       switch (c[0]) {


### PR DESCRIPTION
To make FvwmForm input fields UTF-8 aware, input.size field is duplicated as input.width, the first one containing size in bytes and the latter width in multibyte chars. To allow walking along a string with chars of different lengths (1 to 4 bytes), e.g., for pasting or moving a cursor by arrow keys or by a mouse click, a helper function find_nth_UTF8_char() is introduced.

Fixes #1211
