### PR TITLE
Fvwm: Add configuration option to set FVWM_USERDIR

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1729,7 +1729,7 @@ int main(int argc, char **argv)
 	{
 		char *s;
 
-		xasprintf(&fvwm_userdir, "%s/.fvwm", home_dir);
+		xasprintf(&fvwm_userdir, "%s/" FVWM_USERDIR, home_dir);
 		/* Put the user directory into the environment so it can be used
 		 * later everywhere. */
 		xasprintf(&s, "FVWM_USERDIR=%s", fvwm_userdir);

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ conf.set_quoted('VERSION', meson.project_version())
 conf.set_quoted('VERSIONINFO', fvwm_vcs_versioninfo)
 conf.set_quoted('PACKAGE', meson.project_name())
 conf.set_quoted('FVWM2RC', '.fvwm2rc')
+conf.set_quoted('FVWM_USERDIR', '.fvwm' / get_option('userdir'))
 conf.set_quoted('FVWM_CONFIG', 'config')
 conf.set_quoted(
     'FVWM_IMAGEPATH',

--- a/meson.options
+++ b/meson.options
@@ -29,6 +29,11 @@ option(
     description: 'Build Golang modules',
 )
 option(
+    'userdir',
+    type: 'string',
+    description: 'Subdirectory of HOME to keep user local config',
+)
+option(
     'docdir',
     type: 'string',
     description: 'Directory to install documentation',

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -88,7 +88,7 @@ void setFvwmUserDir(void)
   FvwmUserDir = getenv("FVWM_USERDIR");
   if (FvwmUserDir == NULL)
   {
-    xasprintf(&FvwmUserDir, "%s/.fvwm", home_dir);
+    xasprintf(&FvwmUserDir, "%s/" FVWM_USERDIR, home_dir);
   }
 }
 


### PR DESCRIPTION
Currently $HOME/.fvwm user dir can be changed with FVWM_USERDIR environment variable. It is convenient to change it at compille time, say, to $HOME/.fvwm3, to simplify peaceful coexistence of FVWM2 and FVWM3.
