### PR TITLE
FvwmPager: Allow translation of "Desk %d" label via Gettext

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -1729,7 +1729,7 @@ int main(int argc, char **argv)
 	{
 		char *s;
 
-		xasprintf(&fvwm_userdir, "%s/.fvwm", home_dir);
+		xasprintf(&fvwm_userdir, "%s/" FVWM_USERDIR, home_dir);
 		/* Put the user directory into the environment so it can be used
 		 * later everywhere. */
 		xasprintf(&s, "FVWM_USERDIR=%s", fvwm_userdir);

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ conf.set_quoted('VERSION', meson.project_version())
 conf.set_quoted('VERSIONINFO', fvwm_vcs_versioninfo)
 conf.set_quoted('PACKAGE', meson.project_name())
 conf.set_quoted('FVWM2RC', '.fvwm2rc')
+conf.set_quoted('FVWM_USERDIR', '.fvwm' / get_option('userdir'))
 conf.set_quoted('FVWM_CONFIG', 'config')
 conf.set_quoted(
     'FVWM_IMAGEPATH',

--- a/meson.options
+++ b/meson.options
@@ -29,6 +29,11 @@ option(
     description: 'Build Golang modules',
 )
 option(
+    'userdir',
+    type: 'string',
+    description: 'Subdirectory of HOME to keep user local config',
+)
+option(
     'docdir',
     type: 'string',
     description: 'Directory to install documentation',

--- a/modules/FvwmPager/FvwmPager.c
+++ b/modules/FvwmPager/FvwmPager.c
@@ -35,6 +35,7 @@
 #include "libs/Colorset.h"
 #include "libs/FEvent.h"
 #include "libs/Flocale.h"
+#include "libs/FGettext.h"
 #include "libs/FRenderInit.h"
 #include "libs/FShape.h"
 #include "libs/fvwmlib.h"
@@ -416,7 +417,7 @@ DeskStyle *FindDeskStyle(int desk)
 	memcpy(style, default_style, sizeof *style);
 
 	style->desk = desk;
-	xasprintf(&style->label, "Desk %d", desk);
+	xasprintf(&style->label, _("Desk %d"), desk);
 	initialize_desk_style_gcs(style);
 
 	TAILQ_INSERT_TAIL(&desk_style_q, style, entry);

--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -21,6 +21,7 @@
 #include "libs/ColorUtils.h"
 #include "libs/FShape.h"
 #include "libs/FEvent.h"
+#include "libs/FGettext.h"
 #include "fvwm/fvwm.h"
 #include "FvwmPager.h"
 
@@ -60,8 +61,8 @@ void init_fvwm_pager(void)
 
 	/* Run initializations */
 	initialize_mouse_bindings();
-	initialize_desks_and_monitors();
 	initialize_fonts();
+	initialize_desks_and_monitors();
 	parse_options();
 	initialize_colorsets();
 	initialise_common_pager_fragments();
@@ -245,6 +246,9 @@ void initialize_fonts(void)
 {
 	/* Initialize fonts. */
 	FlocaleInit(LC_CTYPE, "", "", "FvwmPager");
+
+	/* Initialize translations. */
+	FGettextInit("fvwm3", LOCALEDIR, "FvwmPager");
 
 	/* load a default font. */
 	Scr.Ffont = FlocaleLoadFont(dpy, NULL, MyName);

--- a/modules/FvwmScript/Instructions.c
+++ b/modules/FvwmScript/Instructions.c
@@ -88,7 +88,7 @@ void setFvwmUserDir(void)
   FvwmUserDir = getenv("FVWM_USERDIR");
   if (FvwmUserDir == NULL)
   {
-    xasprintf(&FvwmUserDir, "%s/.fvwm", home_dir);
+    xasprintf(&FvwmUserDir, "%s/" FVWM_USERDIR, home_dir);
   }
 }
 

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -5,6 +5,7 @@
   '../fvwm/menus.c'
   '../default-config/config'
   '../bin/fvwm-menu-desktop-config.fpl'
+  '../modules/FvwmPager/FvwmPager.c'
   '../modules/FvwmForm/FvwmForm-XDGMenuHelp'
   '../modules/FvwmForm/FvwmForm-XDGOptionsHelp'
   '../default-config/FvwmScript-ConfirmQuit'

--- a/po/fvwmpo.sh
+++ b/po/fvwmpo.sh
@@ -12,7 +12,8 @@ FVWM_FILES="../fvwm/fvwm3.c \
 	../fvwm/expand.c \
 	../fvwm/windowlist.c \
 	../fvwm/virtual.c \
-	../fvwm/menus.c"
+	../fvwm/menus.c \
+	../modules/FvwmPager/FvwmPager.c"
 FVWM_RCFILES="default-config/config \
 	bin/fvwm-menu-desktop-config.fpl \
 	modules/FvwmForm/FvwmForm-XDGMenuHelp \


### PR DESCRIPTION
`"Desk %d"` label at the top of FvwmPager comes always in English, and can be easily localized in *.po (and then *.mo) translation file.
