### PR TITLE
load svg even if no viewport detected

### DIFF
--- a/libs/PictureImageLoader.c
+++ b/libs/PictureImageLoader.c
@@ -301,13 +301,10 @@ Bool PImageLoadSvg(FIMAGE_CMD_ARGS)
 	rsvg_handle_get_intrinsic_dimensions(rsvg, &has_out_w, &out_w,
 		&has_out_h, &out_h, &has_vb, &viewbox);
 
-	if (!has_vb) {
-		fvwm_debug(__func__, "Couldn't determine viewbox");
-		return False;
+	if (has_vb) {
+		dim.width = viewbox.width;
+		dim.height = viewbox.height;
 	}
-
-	dim.width = viewbox.width;
-	dim.height = viewbox.height;
 
 	if (has_out_w)
 		dim.em = out_w.length <= dim.width ? dim.width : out_w.length;


### PR DESCRIPTION
Some icon themes (for example: Papirus) remove viewports on purpose to keep their icons consistent. This PR continues to display svg images when no viewport exists.
 