### PR TITLE
Make screen option of icon boxes work again

### DIFF
--- a/fvwm/icons.c
+++ b/fvwm/icons.c
@@ -1786,18 +1786,22 @@ void AutoPlaceIcon(
     icon_boxes_ptr = NULL;              /* init */
     while(do_all_iconboxes(t, &icon_boxes_ptr))
     {
+      struct monitor *m;
       if (loc_ok == True)
       {
 	/* leave for loop */
 	break;
       }
       /* get the screen dimensions for the icon box */
-      FScreenGetScrRect(fscr, FSCREEN_CURRENT,
-		        &ref.x, &ref.y, &ref.width, &ref.height);
-      dim[1].screen_offset = ref.y;
-      dim[1].screen_dimension = ref.height;
-      dim[2].screen_offset = ref.x;
-      dim[2].screen_dimension = ref.width;
+      m = monitor_resolve_name(icon_boxes_ptr->IconScreen);
+      if (m == NULL)
+      {
+        m = monitor_get_current();
+      }
+      dim[1].screen_offset = ref.y = m->si->y;
+      dim[1].screen_dimension = ref.height = m->si->h;
+      dim[2].screen_offset = ref.x = m->si->x;
+      dim[2].screen_dimension = ref.width = m->si->w;
       /* y amount */
       dim[1].step = icon_boxes_ptr->IconGrid[1];
       /* init start from */
@@ -1940,7 +1944,7 @@ void AutoPlaceIcon(
 	  }
 
 	  /* this may be a good location */
-	  if (FScreenIsRectangleOnScreen(fscr, FSCREEN_XYPOS, &ref))
+	  if (IsRectangleOnThisPage(m, &ref, t->Desk))
 	  {
 	    loc_ok = True;
 	  }
@@ -2035,6 +2039,8 @@ do_all_iconboxes(FvwmWindow *t, icon_boxes **icon_boxes_ptr)
 		global_icon_box_ptr->IconGrid[0] = 80;
 		global_icon_box_ptr->IconGrid[1] = 80;
 		global_icon_box_ptr->IconFlags = ICONFILLHRZ;
+		global_icon_box_ptr->IconScreen = "p";
+		global_icon_box_ptr->do_free_screen = 0;
 	}
 	if (*icon_boxes_ptr == NULL)
 	{

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -1964,7 +1964,7 @@ static char *style_parse_icon_box_style(
 
 	/* otherwise try to parse the icon box */
 	IconBoxes = fxcalloc(1, sizeof(icon_boxes));
-	IconBoxes->IconScreen = "global";
+	IconBoxes->IconScreen = "g";
 	/* init grid x */
 	IconBoxes->IconGrid[0] = 3;
 	/* init grid y */
@@ -1976,7 +1976,9 @@ static char *style_parse_icon_box_style(
 		is_screen_given = True;
 		option = PeekToken(rest, &rest); /* skip screen */
 		option = PeekToken(rest, &rest); /* get the screen spec */
-		IconBoxes->IconScreen = option;
+		/* GetIntegerArguments() below removes screen */
+		IconBoxes->IconScreen = fxstrdup(option);
+		IconBoxes->do_free_screen = 1;
 	}
 
 	/* try for 4 numbers x y x y */


### PR DESCRIPTION
Make IconBox screen option working again even with several monitors.
Compare with issue https://github.com/fvwmorg/fvwm3/issues/1229

* **What does this PR do?**

It fixes issue https://github.com/fvwmorg/fvwm3/issues/1229
Please read comment https://github.com/fvwmorg/fvwm3/issues/1229#issue-3406508348

It also allows the `@' symbol be the prefix character for screen names as the
manual page is not clear here.

In comparision to the attached patch in issue https://github.com/fvwmorg/fvwm3/issues/1229
Ihere is also a change included which should set the `loc_ok` to `True` for a specfic monitor like
my test with `@DVI-1` for my second monitor. 

* **Issue number(s)**

```
Fixes #1229
```