### PR TITLE
fix monitor position conflicts when a monitor is disabled

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -1821,7 +1821,9 @@ static void monitor_update_ewmh(void)
 
 			m->flags &= ~MONITOR_NEW;
 		}
-		EWMH_Init(m);
+
+		if (m->flags & MONITOR_DISABLED)
+			EWMH_Init(m);
 	}
 
 

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -25,6 +25,7 @@
 #include <math.h>
 #include <stdbool.h>
 
+#include "libs/FScreen.h"
 #include "libs/log.h"
 #include "libs/fvwmlib.h"
 #include "libs/Picture.h"
@@ -296,6 +297,8 @@ static void move_to_next_monitor(
 	RB_FOREACH(m, monitors, &monitor_q)
 	{
 		if (fw->m == m)
+			continue;
+		if (m->flags & MONITOR_DISABLED)
 			continue;
 
 		if (ewmh)


### PR DESCRIPTION
If a monitor is disabled, its key in the rbtree should change so that it won't conflict with enabled monitors.

Searching for the next available monitor should skip disabled monitors too.

This PR fixed this issue.
