### PR TITLE
style: fix a null-pointer dereference on successful merge

### DIFF
--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -4796,6 +4796,7 @@ static void _style_command(F_CMD_ARGS, char *prefix, Bool is_window_style)
 			free_style(ps);
 			free(ps);
 			merged = True;
+			break;
 		}
 	}
 	if (!merged)


### PR DESCRIPTION
Fixes a use-after-free introduced in 3f4f035100e4f9c91c71cf8a67bc2e487a765575, where on successful style deduplication the loop would continue, and fail to dereference the style pointer on next iteration, leading to a segfault.

Of note, I can only reproduce this on musl, but the bug was equally present on glibc. AFAICT glibc is a bit more lax with clearing leftovers after using `free()`, so it went unnoticed.