### PR TITLE
build: add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{pkgs ? import <nixpkgs> {}}:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs.buildPackages; [
+    asciidoctor
+    fontconfig
+    freetype
+    fribidi
+    go
+    libevent
+    libpng
+    librsvg
+    libsm
+    libx11
+    libxcursor
+    libxext
+    libxfixes
+    libxft
+    libxi
+    libxkbcommon
+    libxpm
+    libxrandr
+    libxrender
+    libxt
+    ncurses
+    pkg-config
+    readline
+    sharutils
+    xtrans
+  ];
+}


### PR DESCRIPTION
This adds a minimal shell.nix file to enable development via nix.
