### PR TITLE
Add StrMatch test conditional.

### DIFF
--- a/doc/fvwm3_manpage_source.adoc
+++ b/doc/fvwm3_manpage_source.adoc
@@ -8298,10 +8298,10 @@ by specifying _!CirculateHit_ etc. explicitly.
 	_test-conditions_ are keywords with possible arguments from the list
 	below and are separated by commas or whitespace. They include:
 	_Version operator x.y.z_, _EnvIsSet varname_, _EnvMatch varname
-	pattern_, _EdgeHasPointer direction_, _EdgeIsActive direction_,
-	_Start_, _Init_, _Restart_, _Exit_, _Quit_, _ToRestart_, _True_,
-	_False_, _F_, _R_, _W_, _X_ and _I_. A test-condition prefixed with
-	"!" is negated.
+	pattern_, _StrMatch string pattern_, _EdgeHasPointer direction_,
+	_EdgeIsActive direction_, _Start_, _Init_, _Restart_, _Exit_, _Quit_,
+	_ToRestart_, _True_, _False_, _F_, _R_, _W_, _X_ and _I_. A
+	test-condition prefixed with "!" is negated.
 +
 The _Version_ _operator x.y.z_ test-condition is fulfilled if the
 logical condition of the expression is true. Valid _operator_ values
@@ -8321,6 +8321,23 @@ test-condition is true if _pattern_ matches the given environment or
 infostore variable value. (See *InfoStoreAdd*). The pattern may
 contain special "*" and "?" chars. The "varname" is coded without
 the leading dollar sign ($).
++
+The _StrMatch_ _string_ _pattern_ tests if the given _string_ matches
+the given _pattern_, which is a case sensitive string that may contain
+special "*" and "?" characters for wild cards. This can be used in place
+of _EnvMatch_ with different syntax and also allows testing if other
+variable expansions are equal to a certain value. For example to test
+if the current monitor's name is "DP-2" use:
++
+
+....
+Test (StrMatch $[monitor.current] DP-2) Echo True
+
+# StrMatch and EnvMatch have different syntaxes:
+Test (EnvMatch HOME /home/username) ...
+Test (StrMatch $[HOME] /home/username) ...
+....
+
 +
 The _EdgeHasPointer_ [_direction_] test-condition is true if the
 edge in the given direction currently contains the pointer. The

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -2274,6 +2274,20 @@ void CMD_Test(F_CMD_ARGS)
 			}
 			flags_ptr = next;
 		}
+		else if (StrEquals(cond, "StrMatch"))
+		{
+			char *string, *pattern;
+
+			flags_ptr = GetNextSimpleOption(flags_ptr, &string);
+			flags_ptr = GetNextSimpleOption(flags_ptr, &pattern);
+			if (string == NULL || pattern == NULL)
+				error = 1;
+			else
+				match = matchWildcards(pattern, string);
+
+			free(string);
+			free(pattern);
+		}
 		else
 		{
 			/* unrecognized condition */


### PR DESCRIPTION
Add `Test (StrMatch string1 string2)` conditional that tests if the two strings are equal ignoring case. This is useful to test if a variable expansion, such as $[monitor.current] is equal to a specific string, such as "DP-2", without having to use a shell for this test.