### PR TITLE
Improve Send_WindowList Performance

### DIFF
--- a/modules/FvwmRearrange/FvwmRearrange.c
+++ b/modules/FvwmRearrange/FvwmRearrange.c
@@ -942,7 +942,13 @@ main(int argc, char *argv[])
 		| M_RES_NAME
 	);
 
-	SendText(fd, "Send_WindowList", 0);
+	char *scr_name = mon->si->name;
+	char msg[4096];
+
+	if (is_global)
+		scr_name = "";
+	snprintf(msg, sizeof(msg), "Send_WindowList %s", scr_name);
+	SendText(fd, msg, 0);
 
 	/* Tell fvwm we're running */
 	SendFinishedStartupNotification(fd);


### PR DESCRIPTION
This PR tries to improve the performance of the internal `Send_WindowList`
command by allowing a filter at source, to explicitly denote which monitor
should be used.  This is useful for certain modules; currently `FvwmRearrange`
is using this, but `FvwmPager` might benefit from it in the future.

The more connected (and active) monitors there are, the slower this operation
becomes -- although this is always going to be the case where modules are
operating over the `global` monitor.

- **Send_WindowList: allow for optional monitor**

Augments the Send_WindowList to allow for an optional monitor name which can
be used to ignore other monitors.

- **FvwmRearrange: send monitor with Send_WindowList**

Make FvwmRearrange use the opt-in Send_WindowList command to supply a
monitor name.
