### PR TITLE
F_CMD_ARGS and F_PASS_ARGS have been replaced by normal parameter list

### DIFF
--- a/fvwm/add_window.c
+++ b/fvwm/add_window.c
@@ -2503,9 +2503,7 @@ FvwmWindow *AddWindow(
 				exc, &ecc, ECC_FW | ECC_W | ECC_WCONTEXT);
 			SET_STICKY_ACROSS_PAGES(fw, 0);
 			SET_STICKY_ACROSS_DESKS(fw, 0);
-			handle_stick(
-				NULL, exc2, "", NULL, stick_page, stick_desk,
-				1, 0);
+			handle_stick(exc2, "", stick_page, stick_desk, 1, 0);
 			exc_destroy_context(exc2);
 		}
 	}

--- a/fvwm/bindings.c
+++ b/fvwm/bindings.c
@@ -516,7 +516,7 @@ static int ParseBinding(
 	return rc;
 }
 
-static void binding_cmd(F_CMD_ARGS, binding_t type)
+static void binding_cmd(char *action, binding_t type)
 {
 	Binding *b;
 	int count;
@@ -610,30 +610,34 @@ unsigned int GetUnusedModifiers(void)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_Key(F_CMD_ARGS)
+void CMD_Key(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	binding_cmd(F_PASS_ARGS, BIND_KEYPRESS);
+	binding_cmd(action, BIND_KEYPRESS);
 
 	return;
 }
 
-void CMD_PointerKey(F_CMD_ARGS)
+void CMD_PointerKey(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	binding_cmd(F_PASS_ARGS, BIND_PKEYPRESS);
+	binding_cmd(action, BIND_PKEYPRESS);
 
 	return;
 }
 
-void CMD_Mouse(F_CMD_ARGS)
+void CMD_Mouse(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	binding_cmd(F_PASS_ARGS, BIND_BUTTONPRESS);
+	binding_cmd(action, BIND_BUTTONPRESS);
 
 	return;
 }
 
 /* Declares which X modifiers are actually locks and should be ignored when
  * testing mouse/key binding modifiers. */
-void CMD_IgnoreModifiers(F_CMD_ARGS)
+void CMD_IgnoreModifiers(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *token;
 	int mods_unused_old = mods_unused;

--- a/fvwm/borders.c
+++ b/fvwm/borders.c
@@ -5163,7 +5163,8 @@ unsigned int border_get_transparent_decorations_part(FvwmWindow *fw)
  *  Sets the allowed button states
  *
  */
-void CMD_ButtonState(F_CMD_ARGS)
+void CMD_ButtonState(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *token;
 
@@ -5221,7 +5222,8 @@ void CMD_ButtonState(F_CMD_ARGS)
  *  Sets the border style (veliaa@rpi.edu)
  *
  */
-void CMD_BorderStyle(F_CMD_ARGS)
+void CMD_BorderStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *parm;
 	char *prev;

--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -513,7 +513,8 @@ static char *ReadTitleButton(
 }
 
 /* Remove the given decor from all windows */
-static void _remove_window_decors(F_CMD_ARGS, FvwmDecor *d)
+static void _remove_window_decors(cond_rc_t *cond_rc,
+	const exec_context_t *exc, cmdparser_context_t *pc, FvwmDecor *d)
 {
 	const exec_context_t *exc2;
 	exec_context_changes_t ecc;
@@ -540,7 +541,7 @@ static void _remove_window_decors(F_CMD_ARGS, FvwmDecor *d)
 	return;
 }
 
-static void do_title_style(F_CMD_ARGS, Bool do_add)
+static void do_title_style(char *action, Bool do_add)
 {
 	char *parm;
 	char *prev;
@@ -975,7 +976,7 @@ static void SetMWMButtonFlag(
 	return;
 }
 
-static void do_button_style(F_CMD_ARGS, Bool do_add)
+static void do_button_style(char *action, Bool do_add)
 {
 	int i;
 	int multi = 0;
@@ -2114,7 +2115,8 @@ Bool ReadDecorFace(char *s, DecorFace *df, int button, int verbose)
  * Diverts a style definition to an FvwmDecor structure (veliaa@rpi.edu)
  *
  */
-void AddToDecor(F_CMD_ARGS, FvwmDecor *decor)
+void AddToDecor(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc, FvwmDecor *decor)
 {
 	if (!action)
 	{
@@ -2129,7 +2131,7 @@ void AddToDecor(F_CMD_ARGS, FvwmDecor *decor)
 		return;
 	}
 	Scr.cur_decor = decor;
-	execute_function(F_PASS_ARGS, 0);
+	execute_function(cond_rc, exc, action, pc, 0);
 	Scr.cur_decor = NULL;
 
 	return;
@@ -2201,7 +2203,8 @@ void update_fvwm_colorset(int cset)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_Status(F_CMD_ARGS)
+void CMD_Status(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	if ((strcasecmp(action, "on") == 0) && status_fp == NULL) {
 		status_init_pipe();
@@ -2220,24 +2223,28 @@ void CMD_Status(F_CMD_ARGS)
 	status_send();
 }
 
-void CMD_Beep(F_CMD_ARGS)
+void CMD_Beep(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	XBell(dpy, 0);
 
 	return;
 }
 
-void CMD_Nop(F_CMD_ARGS)
+void CMD_Nop(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	return;
 }
 
-void CMD_EscapeFunc(F_CMD_ARGS)
+void CMD_EscapeFunc(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	return;
 }
 
-void CMD_Delete(F_CMD_ARGS)
+void CMD_Delete(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow * const fw = exc->w.fw;
 
@@ -2275,13 +2282,14 @@ void CMD_Delete(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Destroy(F_CMD_ARGS)
+void CMD_Destroy(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow * const fw = exc->w.fw;
 
 	if (IS_TEAR_OFF_MENU(fw))
 	{
-		CMD_Delete(F_PASS_ARGS);
+		CMD_Delete(cond_rc, exc, action, pc);
 		return;
 	}
 	if (!is_function_allowed(F_DESTROY, NULL, fw, True, True))
@@ -2304,13 +2312,14 @@ void CMD_Destroy(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Close(F_CMD_ARGS)
+void CMD_Close(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow * const fw = exc->w.fw;
 
 	if (IS_TEAR_OFF_MENU(fw))
 	{
-		CMD_Delete(F_PASS_ARGS);
+		CMD_Delete(cond_rc, exc, action, pc);
 		return;
 	}
 	if (!is_function_allowed(F_CLOSE, NULL, fw, True, True))
@@ -2340,14 +2349,16 @@ void CMD_Close(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Restart(F_CMD_ARGS)
+void CMD_Restart(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	Done(1, action);
 
 	return;
 }
 
-void CMD_ExecUseShell(F_CMD_ARGS)
+void CMD_ExecUseShell(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *arg=NULL;
 	static char shell_set = 0;
@@ -2376,7 +2387,8 @@ void CMD_ExecUseShell(F_CMD_ARGS)
 	}
 }
 
-void CMD_Exec(F_CMD_ARGS)
+void CMD_Exec(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *cmd=NULL;
 
@@ -2441,14 +2453,16 @@ void CMD_Exec(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Refresh(F_CMD_ARGS)
+void CMD_Refresh(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	refresh_window(Scr.Root, True);
 
 	return;
 }
 
-void CMD_RefreshWindow(F_CMD_ARGS)
+void CMD_RefreshWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmWindow * const fw = exc->w.fw;
 
@@ -2459,7 +2473,8 @@ void CMD_RefreshWindow(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Wait(F_CMD_ARGS)
+void CMD_Wait(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	Bool done = False;
 	Bool redefine_cursor = False;
@@ -2600,14 +2615,16 @@ void CMD_Wait(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Quit(F_CMD_ARGS)
+void CMD_Quit(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	Done(0,NULL);
 
 	return;
 }
 
-void CMD_Echo(F_CMD_ARGS)
+void CMD_Echo(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int len;
 
@@ -2629,7 +2646,8 @@ void CMD_Echo(F_CMD_ARGS)
 	return;
 }
 
-void CMD_PrintInfo(F_CMD_ARGS)
+void CMD_PrintInfo(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int verbose;
 	char *rest, *subject = NULL;
@@ -2675,7 +2693,8 @@ void CMD_PrintInfo(F_CMD_ARGS)
 	return;
 }
 
-void CMD_ColormapFocus(F_CMD_ARGS)
+void CMD_ColormapFocus(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	if (MatchToken(action,"FollowsFocus"))
 	{
@@ -2696,7 +2715,8 @@ void CMD_ColormapFocus(F_CMD_ARGS)
 	return;
 }
 
-void CMD_ClickTime(F_CMD_ARGS)
+void CMD_ClickTime(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int val;
 
@@ -2720,21 +2740,24 @@ void CMD_ClickTime(F_CMD_ARGS)
 }
 
 
-void CMD_ImagePath(F_CMD_ARGS)
+void CMD_ImagePath(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	PictureSetImagePath( action );
 
 	return;
 }
 
-void CMD_LocalePath(F_CMD_ARGS)
+void CMD_LocalePath(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FGettextSetLocalePath( action );
 
 	return;
 }
 
-void CMD_ModulePath(F_CMD_ARGS)
+void CMD_ModulePath(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	static int need_to_free = 0;
 
@@ -2744,7 +2767,8 @@ void CMD_ModulePath(F_CMD_ARGS)
 	return;
 }
 
-void CMD_ModuleTimeout(F_CMD_ARGS)
+void CMD_ModuleTimeout(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int timeout;
 
@@ -2757,9 +2781,10 @@ void CMD_ModuleTimeout(F_CMD_ARGS)
 	return;
 }
 
-void CMD_TitleStyle(F_CMD_ARGS)
+void CMD_TitleStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	do_title_style(F_PASS_ARGS, False);
+	do_title_style(action, False);
 
 	return;
 } /* SetTitleStyle */
@@ -2769,14 +2794,16 @@ void CMD_TitleStyle(F_CMD_ARGS)
  * Appends a titlestyle (veliaa@rpi.edu)
  *
  */
-void CMD_AddTitleStyle(F_CMD_ARGS)
+void CMD_AddTitleStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	do_title_style(F_PASS_ARGS, True);
+	do_title_style(action, True);
 
 	return;
 }
 
-void CMD_PropertyChange(F_CMD_ARGS)
+void CMD_PropertyChange(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char string[256];
 	char *token;
@@ -2830,7 +2857,8 @@ void CMD_PropertyChange(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DefaultIcon(F_CMD_ARGS)
+void CMD_DefaultIcon(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	if (Scr.DefaultIcon)
 	{
@@ -2841,7 +2869,8 @@ void CMD_DefaultIcon(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DefaultFont(F_CMD_ARGS)
+void CMD_DefaultFont(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *font;
 	FlocaleFont *new_font;
@@ -2890,7 +2919,8 @@ void CMD_DefaultFont(F_CMD_ARGS)
  * Changes the window's FvwmDecor pointer (veliaa@rpi.edu)
  *
  */
-void CMD_ChangeDecor(F_CMD_ARGS)
+void CMD_ChangeDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *item;
 	FvwmDecor *decor = &Scr.DefaultDecor;
@@ -2928,7 +2958,8 @@ void CMD_ChangeDecor(F_CMD_ARGS)
  * Destroys an FvwmDecor (veliaa@rpi.edu)
  *
  */
-void CMD_DestroyDecor(F_CMD_ARGS)
+void CMD_DestroyDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *item;
 	FvwmDecor *decor = Scr.DefaultDecor.next;
@@ -2965,7 +2996,7 @@ void CMD_DestroyDecor(F_CMD_ARGS)
 	{
 		if (!do_recreate)
 		{
-			_remove_window_decors(F_PASS_ARGS, found);
+			_remove_window_decors(cond_rc, exc, pc, found);
 		}
 		DestroyFvwmDecor(found);
 		if (do_recreate)
@@ -2998,7 +3029,8 @@ void CMD_DestroyDecor(F_CMD_ARGS)
  * Initiates an AddToDecor (veliaa@rpi.edu)
  *
  */
-void CMD_AddToDecor(F_CMD_ARGS)
+void CMD_AddToDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmDecor *decor;
 	FvwmDecor *found = NULL;
@@ -3044,7 +3076,7 @@ void CMD_AddToDecor(F_CMD_ARGS)
 
 	if (found)
 	{
-		AddToDecor(F_PASS_ARGS, found);
+		AddToDecor(cond_rc, exc, action, pc, found);
 		/* Set + state to last decor */
 		set_last_added_item(ADDED_DECOR, found);
 	}
@@ -3058,7 +3090,8 @@ void CMD_AddToDecor(F_CMD_ARGS)
  * Updates window decoration styles (veliaa@rpi.edu)
  *
  */
-void CMD_UpdateDecor(F_CMD_ARGS)
+void CMD_UpdateDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmWindow *fw2;
 
@@ -3110,9 +3143,10 @@ void CMD_UpdateDecor(F_CMD_ARGS)
 		hilight, PART_ALL, True, True, CLEAR_ALL, NULL, NULL);
 }
 
-void CMD_ButtonStyle(F_CMD_ARGS)
+void CMD_ButtonStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	do_button_style(F_PASS_ARGS, False);
+	do_button_style(action, False);
 
 	return;
 }
@@ -3122,14 +3156,16 @@ void CMD_ButtonStyle(F_CMD_ARGS)
  * Appends a button decoration style (veliaa@rpi.edu)
  *
  */
-void CMD_AddButtonStyle(F_CMD_ARGS)
+void CMD_AddButtonStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	do_button_style(F_PASS_ARGS, True);
+	do_button_style(action, True);
 
 	return;
 }
 
-void CMD_SetEnv(F_CMD_ARGS)
+void CMD_SetEnv(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *szVar = NULL;
 	char *szValue = NULL;
@@ -3161,7 +3197,8 @@ out:
 	return;
 }
 
-void CMD_UnsetEnv(F_CMD_ARGS)
+void CMD_UnsetEnv(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *szVar = NULL;
 
@@ -3175,7 +3212,8 @@ void CMD_UnsetEnv(F_CMD_ARGS)
 	return;
 }
 
-void CMD_BugOpts(F_CMD_ARGS)
+void CMD_BugOpts(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *opt;
 	int toggle;
@@ -3403,7 +3441,8 @@ void CMD_BugOpts(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Emulate(F_CMD_ARGS)
+void CMD_Emulate(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *style;
 
@@ -3441,7 +3480,8 @@ void CMD_Emulate(F_CMD_ARGS)
 }
 
 /* set animation parameters */
-void CMD_SetAnimation(F_CMD_ARGS)
+void CMD_SetAnimation(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *opt;
 	int delay;
@@ -3515,7 +3555,8 @@ static Bool FKeysymToKeycode (Display *disp, KeySym keysym,
 	return False;
 }
 
-static void _fake_event(F_CMD_ARGS, FakeEventType type)
+static void _fake_event(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, FakeEventType type)
 {
 	char *token;
 	char *optlist[] = {
@@ -3776,21 +3817,24 @@ static void _fake_event(F_CMD_ARGS, FakeEventType type)
 	return;
 }
 
-void CMD_FakeClick(F_CMD_ARGS)
+void CMD_FakeClick(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	_fake_event(F_PASS_ARGS, FakeMouseEvent);
+	_fake_event(cond_rc, exc, action, FakeMouseEvent);
 
 	return;
 }
 
-void CMD_FakeKeypress(F_CMD_ARGS)
+void CMD_FakeKeypress(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	_fake_event(F_PASS_ARGS, FakeKeyEvent);
+	_fake_event(cond_rc, exc, action, FakeKeyEvent);
 
 	return;
 }
 
-void CMD_State(F_CMD_ARGS)
+void CMD_State(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	unsigned int state;
 	int toggle;

--- a/fvwm/colorset.c
+++ b/fvwm/colorset.c
@@ -1778,14 +1778,16 @@ void update_root_transparent_colorset(Atom prop)
 
 /* ---------------------------- builtin commands ---------------------------- */
 
-void CMD_ReadWriteColors(F_CMD_ARGS)
+void CMD_ReadWriteColors(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	fvwm_debug(__func__, "ReadWriteColors is obsolete");
 
 	return;
 }
 
-void CMD_Colorset(F_CMD_ARGS)
+void CMD_Colorset(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int n;
 	char *token;
@@ -1808,7 +1810,8 @@ void CMD_Colorset(F_CMD_ARGS)
 	return;
 }
 
-void CMD_CleanupColorsets(F_CMD_ARGS)
+void CMD_CleanupColorsets(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	cleanup_colorsets();
 }

--- a/fvwm/commands.h
+++ b/fvwm/commands.h
@@ -189,170 +189,335 @@ enum
 /* ---------------------------- interface functions ------------------------ */
 
 /* This file contains all command prototypes. */
-void CMD_Plus(F_CMD_ARGS);
-void CMD_AddButtonStyle(F_CMD_ARGS);
-void CMD_AddTitleStyle(F_CMD_ARGS);
-void CMD_AddToDecor(F_CMD_ARGS);
-void CMD_AddToFunc(F_CMD_ARGS);
-void CMD_AddToMenu(F_CMD_ARGS);
-void CMD_Alias(F_CMD_ARGS);
-void CMD_All(F_CMD_ARGS);
-void CMD_AnimatedMove(F_CMD_ARGS);
-void CMD_Any(F_CMD_ARGS);
-void CMD_Beep(F_CMD_ARGS);
-void CMD_Break(F_CMD_ARGS);
-void CMD_BorderStyle(F_CMD_ARGS);
-void CMD_BugOpts(F_CMD_ARGS);
-void CMD_BusyCursor(F_CMD_ARGS);
-void CMD_ButtonState(F_CMD_ARGS);
-void CMD_ButtonStyle(F_CMD_ARGS);
-void CMD_ChangeDecor(F_CMD_ARGS);
-void CMD_ChangeMenuStyle(F_CMD_ARGS);
-void CMD_CleanupColorsets(F_CMD_ARGS);
-void CMD_ClickTime(F_CMD_ARGS);
-void CMD_Close(F_CMD_ARGS);
-void CMD_ColormapFocus(F_CMD_ARGS);
-void CMD_Colorset(F_CMD_ARGS);
-void CMD_CopyMenuStyle(F_CMD_ARGS);
-void CMD_Current(F_CMD_ARGS);
-void CMD_CursorBarrier(F_CMD_ARGS);
-void CMD_CursorMove(F_CMD_ARGS);
-void CMD_CursorStyle(F_CMD_ARGS);
-void CMD_DefaultFont(F_CMD_ARGS);
-void CMD_DefaultIcon(F_CMD_ARGS);
-void CMD_DefaultLayers(F_CMD_ARGS);
-void CMD_Delete(F_CMD_ARGS);
-void CMD_Deschedule(F_CMD_ARGS);
-void CMD_DesktopConfiguration(F_CMD_ARGS);
-void CMD_DesktopName(F_CMD_ARGS);
-void CMD_DesktopSize(F_CMD_ARGS);
-void CMD_Destroy(F_CMD_ARGS);
-void CMD_DestroyDecor(F_CMD_ARGS);
-void CMD_DestroyFunc(F_CMD_ARGS);
-void CMD_DestroyMenu(F_CMD_ARGS);
-void CMD_DestroyMenuStyle(F_CMD_ARGS);
-void CMD_DestroyModuleConfig(F_CMD_ARGS);
-void CMD_DestroyStyle(F_CMD_ARGS);
-void CMD_DestroyWindowStyle(F_CMD_ARGS);
-void CMD_Direction(F_CMD_ARGS);
-void CMD_Echo(F_CMD_ARGS);
-void CMD_EchoFuncDefinition(F_CMD_ARGS);
-void CMD_EdgeCommand(F_CMD_ARGS);
-void CMD_EdgeLeaveCommand(F_CMD_ARGS);
-void CMD_EdgeResistance(F_CMD_ARGS);
-void CMD_EdgeScroll(F_CMD_ARGS);
-void CMD_EdgeThickness(F_CMD_ARGS);
-void CMD_Emulate(F_CMD_ARGS);
-void CMD_EscapeFunc(F_CMD_ARGS);
-void CMD_EwmhBaseStruts(F_CMD_ARGS);
-void CMD_EwmhNumberOfDesktops(F_CMD_ARGS);
-void CMD_Exec(F_CMD_ARGS);
-void CMD_ExecUseShell(F_CMD_ARGS);
-void CMD_FakeClick(F_CMD_ARGS);
-void CMD_FakeKeypress(F_CMD_ARGS);
-void CMD_FlipFocus(F_CMD_ARGS);
-void CMD_Focus(F_CMD_ARGS);
-void CMD_FocusStyle(F_CMD_ARGS);
-void CMD_Function(F_CMD_ARGS);
-void CMD_GeometryWindow(F_CMD_ARGS);
-void CMD_GotoDesk(F_CMD_ARGS);
-void CMD_GotoDeskAndPage(F_CMD_ARGS);
-void CMD_GotoPage(F_CMD_ARGS);
-void CMD_Iconify(F_CMD_ARGS);
-void CMD_IgnoreModifiers(F_CMD_ARGS);
-void CMD_ImagePath(F_CMD_ARGS);
-void CMD_InfoStoreAdd(F_CMD_ARGS);
-void CMD_InfoStoreClear(F_CMD_ARGS);
-void CMD_InfoStoreRemove(F_CMD_ARGS);
-void CMD_KeepRc(F_CMD_ARGS);
-void CMD_Key(F_CMD_ARGS);
-void CMD_KillModule(F_CMD_ARGS);
-void CMD_Layer(F_CMD_ARGS);
-void CMD_LocalePath(F_CMD_ARGS);
-void CMD_Lower(F_CMD_ARGS);
-void CMD_Maximize(F_CMD_ARGS);
-void CMD_Menu(F_CMD_ARGS);
-void CMD_MenuStyle(F_CMD_ARGS);
-void CMD_Module(F_CMD_ARGS);
-void CMD_ModuleListenOnly(F_CMD_ARGS);
-void CMD_ModulePath(F_CMD_ARGS);
-void CMD_ModuleSynchronous(F_CMD_ARGS);
-void CMD_ModuleTimeout(F_CMD_ARGS);
-void CMD_Mouse(F_CMD_ARGS);
-void CMD_Move(F_CMD_ARGS);
-void CMD_MoveThreshold(F_CMD_ARGS);
-void CMD_MoveToDesk(F_CMD_ARGS);
-void CMD_MoveToPage(F_CMD_ARGS);
-void CMD_MoveToScreen(F_CMD_ARGS);
-void CMD_Next(F_CMD_ARGS);
-void CMD_None(F_CMD_ARGS);
-void CMD_Nop(F_CMD_ARGS);
-void CMD_NoWindow(F_CMD_ARGS);
-void CMD_OpaqueMoveSize(F_CMD_ARGS);
-void CMD_Pick(F_CMD_ARGS);
-void CMD_PipeRead(F_CMD_ARGS);
-void CMD_PlaceAgain(F_CMD_ARGS);
-void CMD_PointerKey(F_CMD_ARGS);
-void CMD_PointerWindow(F_CMD_ARGS);
-void CMD_Popup(F_CMD_ARGS);
-void CMD_Prev(F_CMD_ARGS);
-void CMD_PrintInfo(F_CMD_ARGS);
-void CMD_PropertyChange(F_CMD_ARGS);
-void CMD_Quit(F_CMD_ARGS);
-void CMD_QuitSession(F_CMD_ARGS);
-void CMD_Raise(F_CMD_ARGS);
-void CMD_RaiseLower(F_CMD_ARGS);
-void CMD_Read(F_CMD_ARGS);
-void CMD_ReadWriteColors(F_CMD_ARGS);
-void CMD_Refresh(F_CMD_ARGS);
-void CMD_RefreshWindow(F_CMD_ARGS);
-void CMD_Repeat(F_CMD_ARGS);
-void CMD_Resize(F_CMD_ARGS);
-void CMD_ResizeMaximize(F_CMD_ARGS);
-void CMD_ResizeMove(F_CMD_ARGS);
-void CMD_ResizeMoveMaximize(F_CMD_ARGS);
-void CMD_RestackTransients(F_CMD_ARGS);
-void CMD_Restart(F_CMD_ARGS);
-void CMD_SaveQuitSession(F_CMD_ARGS);
-void CMD_SaveSession(F_CMD_ARGS);
-void CMD_ScanForWindow(F_CMD_ARGS);
-void CMD_Schedule(F_CMD_ARGS);
-void CMD_Scroll(F_CMD_ARGS);
-void CMD_Send_ConfigInfo(F_CMD_ARGS);
-void CMD_Send_Reply(F_CMD_ARGS);
-void CMD_Send_WindowList(F_CMD_ARGS);
-void CMD_SendToModule(F_CMD_ARGS);
-void CMD_Status(F_CMD_ARGS);
-void CMD_set_mask(F_CMD_ARGS);
-void CMD_set_nograb_mask(F_CMD_ARGS);
-void CMD_set_sync_mask(F_CMD_ARGS);
-void CMD_SetAnimation(F_CMD_ARGS);
-void CMD_SetEnv(F_CMD_ARGS);
-void CMD_Silent(F_CMD_ARGS);
-void CMD_State(F_CMD_ARGS);
-void CMD_Stick(F_CMD_ARGS);
-void CMD_StickAcrossDesks(F_CMD_ARGS);
-void CMD_StickAcrossPages(F_CMD_ARGS);
-void CMD_Style(F_CMD_ARGS);
-void CMD_TearMenuOff(F_CMD_ARGS);
-void CMD_Test(F_CMD_ARGS);
-void CMD_TestRc(F_CMD_ARGS);
-void CMD_ThisWindow(F_CMD_ARGS);
-void CMD_Title(F_CMD_ARGS);
-void CMD_TitleStyle(F_CMD_ARGS);
-void CMD_Unalias(F_CMD_ARGS);
-void CMD_UnsetEnv(F_CMD_ARGS);
-void CMD_UpdateDecor(F_CMD_ARGS);
-void CMD_UpdateStyles(F_CMD_ARGS);
-void CMD_Wait(F_CMD_ARGS);
-void CMD_WarpToWindow(F_CMD_ARGS);
-void CMD_WindowId(F_CMD_ARGS);
-void CMD_WindowList(F_CMD_ARGS);
-void CMD_WindowShade(F_CMD_ARGS);
-void CMD_WindowStyle(F_CMD_ARGS);
-void CMD_XorPixmap(F_CMD_ARGS);
-void CMD_XorValue(F_CMD_ARGS);
-void CMD_XSync(F_CMD_ARGS);
-void CMD_XSynchronize(F_CMD_ARGS);
+void CMD_Plus(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_AddButtonStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_AddTitleStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_AddToDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_AddToFunc(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_AddToMenu(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Alias(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_All(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_AnimatedMove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Any(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Beep(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Break(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_BorderStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_BugOpts(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_BusyCursor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ButtonState(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ButtonStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ChangeDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ChangeMenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_CleanupColorsets(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ClickTime(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Close(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_ColormapFocus(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Colorset(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_CopyMenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Current(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_CursorBarrier(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_CursorMove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_CursorStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DefaultFont(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DefaultIcon(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DefaultLayers(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Delete(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Deschedule(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DesktopConfiguration(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DesktopName(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DesktopSize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Destroy(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_DestroyDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DestroyFunc(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DestroyMenu(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DestroyMenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DestroyModuleConfig(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DestroyStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_DestroyWindowStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Direction(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Echo(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_EchoFuncDefinition(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EdgeCommand(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EdgeLeaveCommand(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EdgeResistance(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EdgeScroll(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EdgeThickness(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Emulate(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_EscapeFunc(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EwmhBaseStruts(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_EwmhNumberOfDesktops(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Exec(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_ExecUseShell(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_FakeClick(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_FakeKeypress(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_FlipFocus(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Focus(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_FocusStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Function(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_GeometryWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_GotoDesk(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_GotoDeskAndPage(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_GotoPage(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Iconify(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_IgnoreModifiers(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ImagePath(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_InfoStoreAdd(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_InfoStoreClear(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_InfoStoreRemove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_KeepRc(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Key(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_KillModule(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Layer(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_LocalePath(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Lower(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Maximize(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Menu(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_MenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Module(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_ModuleListenOnly(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ModulePath(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ModuleSynchronous(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ModuleTimeout(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Mouse(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Move(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_MoveThreshold(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_MoveToDesk(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_MoveToPage(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_MoveToScreen(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Next(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_None(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Nop(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_NoWindow(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_OpaqueMoveSize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Pick(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_PipeRead(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_PlaceAgain(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_PointerKey(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_PointerWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Popup(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Prev(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_PrintInfo(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_PropertyChange(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Quit(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_QuitSession(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Raise(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_RaiseLower(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Read(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_ReadWriteColors(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Refresh(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_RefreshWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Repeat(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Resize(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_ResizeMaximize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ResizeMove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ResizeMoveMaximize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_RestackTransients(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Restart(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_SaveQuitSession(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_SaveSession(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_ScanForWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Schedule(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Scroll(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Send_ConfigInfo(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Send_Reply(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Send_WindowList(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_SendToModule(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Status(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_set_mask(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_set_nograb_mask(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_set_sync_mask(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_SetAnimation(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_SetEnv(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Silent(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_State(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_Stick(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_StickAcrossDesks(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_StickAcrossPages(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Style(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_TearMenuOff(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Test(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_TestRc(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_ThisWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Title(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_TitleStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Unalias(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_UnsetEnv(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_UpdateDecor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_UpdateStyles(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_Wait(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_WarpToWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_WindowId(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_WindowList(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_WindowShade(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_WindowStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
+void CMD_XorPixmap(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_XorValue(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_XSync(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc);
+void CMD_XSynchronize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc);
 
 #endif /* FVWM_COMMANDS_H */

--- a/fvwm/conditional.c
+++ b/fvwm/conditional.c
@@ -171,9 +171,9 @@ static FvwmWindow *Circulate(
 	return found;
 }
 
-static void circulate_cmd(
-	F_CMD_ARGS, int new_context, int circ_dir, Bool do_use_found,
-	Bool do_exec_on_match)
+static void circulate_cmd(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc, int new_context, int circ_dir,
+	Bool do_use_found, Bool do_exec_on_match)
 {
 	FvwmWindow *found;
 	char *restofline;
@@ -210,7 +210,8 @@ static void circulate_cmd(
 	return;
 }
 
-static void select_cmd(F_CMD_ARGS)
+static void select_cmd(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *restofline;
 	char *flags;
@@ -1156,7 +1157,8 @@ Bool MatchesConditionMask(FvwmWindow *fw, WindowConditionMask *mask)
 	return True;
 }
 
-static void direction_cmd(F_CMD_ARGS, Bool is_scan)
+static void direction_cmd(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc, Bool is_scan)
 {
 	rectangle my_g;
 	rectangle his_g;
@@ -1485,23 +1487,26 @@ static int _rc_matches_rcstring_consume(
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_Prev(F_CMD_ARGS)
+void CMD_Prev(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	circulate_cmd(F_PASS_ARGS, C_WINDOW, -1, True, True);
+	circulate_cmd(cond_rc, exc, action, pc, C_WINDOW, -1, True, True);
 
 	return;
 }
 
-void CMD_Next(F_CMD_ARGS)
+void CMD_Next(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	circulate_cmd(F_PASS_ARGS, C_WINDOW, 1, True, True);
+	circulate_cmd(cond_rc, exc, action, pc, C_WINDOW, 1, True, True);
 
 	return;
 }
 
-void CMD_None(F_CMD_ARGS)
+void CMD_None(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	circulate_cmd(F_PASS_ARGS, C_ROOT, 1, False, False);
+	circulate_cmd(cond_rc, exc, action, pc, C_ROOT, 1, False, False);
 	/* invert return code */
 	switch (cond_rc->rc)
 	{
@@ -1518,47 +1523,53 @@ void CMD_None(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Any(F_CMD_ARGS)
+void CMD_Any(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	circulate_cmd(F_PASS_ARGS, exc->w.wcontext, 1, False, True);
+	circulate_cmd(cond_rc, exc, action, pc, exc->w.wcontext, 1, False, True);
 
 	return;
 }
 
-void CMD_Current(F_CMD_ARGS)
+void CMD_Current(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	circulate_cmd(F_PASS_ARGS, C_WINDOW, 0, True, True);
+	circulate_cmd(cond_rc, exc, action, pc, C_WINDOW, 0, True, True);
 
 	return;
 }
 
-void CMD_PointerWindow(F_CMD_ARGS)
+void CMD_PointerWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	exec_context_changes_t ecc;
 
 	ecc.w.fw = get_pointer_fvwm_window();
 	exc = exc_clone_context(exc, &ecc, ECC_FW);
-	select_cmd(F_PASS_ARGS);
+	select_cmd(cond_rc, exc, action, pc);
 	exc_destroy_context(exc);
 
 	return;
 }
 
-void CMD_ThisWindow(F_CMD_ARGS)
+void CMD_ThisWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	select_cmd(F_PASS_ARGS);
+	select_cmd(cond_rc, exc, action, pc);
 
 	return;
 }
 
-void CMD_Pick(F_CMD_ARGS)
+void CMD_Pick(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	select_cmd(F_PASS_ARGS);
+	select_cmd(cond_rc, exc, action, pc);
 
 	return;
 }
 
-void CMD_All(F_CMD_ARGS)
+void CMD_All(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow *t, **g;
 	char *restofline;
@@ -1685,17 +1696,20 @@ void CMD_All(F_CMD_ARGS)
  * Execute a function to the closest window in the given
  * direction.
  */
-void CMD_Direction(F_CMD_ARGS)
+void CMD_Direction(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	direction_cmd(F_PASS_ARGS,False);
+	direction_cmd(cond_rc, exc, action, pc, False);
 }
 
-void CMD_ScanForWindow(F_CMD_ARGS)
+void CMD_ScanForWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	direction_cmd(F_PASS_ARGS,True);
+	direction_cmd(cond_rc, exc, action, pc, True);
 }
 
-void CMD_WindowId(F_CMD_ARGS)
+void CMD_WindowId(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow *t;
 	char *token;
@@ -1838,7 +1852,8 @@ pc, 					FUNC_IS_UNMANAGED);
 	return;
 }
 
-void CMD_TestRc(F_CMD_ARGS)
+void CMD_TestRc(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *rest;
 
@@ -1858,7 +1873,8 @@ void CMD_TestRc(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Break(F_CMD_ARGS)
+void CMD_Break(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int rc;
 
@@ -1876,7 +1892,8 @@ void CMD_Break(F_CMD_ARGS)
 	return;
 }
 
-void CMD_NoWindow(F_CMD_ARGS)
+void CMD_NoWindow(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	execute_function_override_window(cond_rc, exc, action, pc, 0, NULL);
 
@@ -1965,7 +1982,8 @@ static Bool match_version(char *version, char *operator)
 	return False;
 }
 
-void CMD_Test(F_CMD_ARGS)
+void CMD_Test(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *restofline;
 	char *flags;

--- a/fvwm/cursor.c
+++ b/fvwm/cursor.c
@@ -302,7 +302,8 @@ Cursor *CreateCursors(Display *disp)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_CursorMove(F_CMD_ARGS)
+void CMD_CursorMove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int x, y;
 	int val1, val2;
@@ -349,7 +350,8 @@ void CMD_CursorMove(F_CMD_ARGS)
 	return;
 }
 
-void CMD_CursorStyle(F_CMD_ARGS)
+void CMD_CursorStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *cname=NULL;
 	char *newcursor=NULL;
@@ -676,7 +678,8 @@ void CMD_CursorStyle(F_CMD_ARGS)
 
 /* Defines in which cases fvwm "grab" the cursor during execution of certain
  * functions. */
-void CMD_BusyCursor(F_CMD_ARGS)
+void CMD_BusyCursor(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *option = NULL;
 	char *optstring = NULL;
@@ -780,7 +783,8 @@ void CMD_BusyCursor(F_CMD_ARGS)
 	return;
 }
 
-void CMD_CursorBarrier(F_CMD_ARGS)
+void CMD_CursorBarrier(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val[4] = {0, 0, 0, 0};
 	int x1, y1, x2, y2;

--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -4766,7 +4766,8 @@ Bool is_resizing_event_pending(FvwmWindow *fw)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_XSynchronize(F_CMD_ARGS)
+void CMD_XSynchronize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int toggle;
 
@@ -4776,7 +4777,8 @@ void CMD_XSynchronize(F_CMD_ARGS)
 	return;
 }
 
-void CMD_XSync(F_CMD_ARGS)
+void CMD_XSync(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	XSync(dpy, 0);
 

--- a/fvwm/ewmh_conf.c
+++ b/fvwm/ewmh_conf.c
@@ -96,7 +96,8 @@ Bool EWMH_BugOpts(char *opt, Bool toggle)
 	return False;
 }
 
-void CMD_EwmhNumberOfDesktops(F_CMD_ARGS)
+void CMD_EwmhNumberOfDesktops(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	struct monitor	*m = NULL;
 	char *option;
@@ -137,7 +138,8 @@ void CMD_EwmhNumberOfDesktops(F_CMD_ARGS)
 	}
 }
 
-void CMD_EwmhBaseStruts(F_CMD_ARGS)
+void CMD_EwmhBaseStruts(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	struct monitor *m = NULL;
 	char *option;

--- a/fvwm/focus.c
+++ b/fvwm/focus.c
@@ -616,7 +616,7 @@ static FvwmWindow *_restore_focus_after_unmap(
  *
  */
 static void _activate_window_by_command(
-	F_CMD_ARGS, int is_focus_by_flip_focus_cmd)
+	const exec_context_t *exc, char *action, int is_focus_by_flip_focus_cmd)
 {
 	int cx;
 	int cy;
@@ -1151,22 +1151,25 @@ void refresh_focus(const FvwmWindow *fw)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_FlipFocus(F_CMD_ARGS)
+void CMD_FlipFocus(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	/* Reorder the window list */
-	_activate_window_by_command(F_PASS_ARGS, 1);
+	_activate_window_by_command(exc, action, 1);
 
 	return;
 }
 
-void CMD_Focus(F_CMD_ARGS)
+void CMD_Focus(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	_activate_window_by_command(F_PASS_ARGS, 0);
+	_activate_window_by_command(exc, action, 0);
 
 	return;
 }
 
-void CMD_WarpToWindow(F_CMD_ARGS)
+void CMD_WarpToWindow(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int val1_unit, val2_unit, n;
 	int val1, val2;

--- a/fvwm/functable.h
+++ b/fvwm/functable.h
@@ -21,7 +21,8 @@ typedef struct
 {
 	char *keyword;
 #ifdef __STDC__
-	void (*action)(F_CMD_ARGS);
+	void (*action)(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+		cmdparser_context_t *pc);
 #else
 	void (*action)();
 #endif

--- a/fvwm/functions.c
+++ b/fvwm/functions.c
@@ -714,7 +714,7 @@ static void _execute_command_line(
 		}
 		goto fn_exit;
 	case CP_EXECTYPE_UNKNOWN:
-		if (executeModuleDesperate(func_rc, exc, pc.cline, &pc) ==
+		if (executeModuleDesperate(exc, pc.cline) ==
 		    NULL && *err_func != 0 && !set_silent)
 		{
 			fvwm_debug(__func__, "No such command '%s'", err_func);
@@ -1236,29 +1236,33 @@ void functions_init(void)
 	return;
 }
 
-void execute_function(F_CMD_ARGS, func_flags_t exec_flags)
+void execute_function(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc, func_flags_t exec_flags)
 {
-	_execute_command_line(F_PASS_ARGS, exec_flags, NULL, NULL, False);
+	_execute_command_line(cond_rc, exc, action, pc, exec_flags, NULL, NULL,
+		False);
 
 	return;
 }
 
-void execute_function_override_wcontext(
-	F_CMD_ARGS, func_flags_t exec_flags, int wcontext)
+void execute_function_override_wcontext(cond_rc_t *cond_rc,
+	const exec_context_t *exc, char *action, cmdparser_context_t *pc,
+	func_flags_t exec_flags, int wcontext)
 {
 	const exec_context_t *exc2;
 	exec_context_changes_t ecc;
 
 	ecc.w.wcontext = wcontext;
 	exc2 = exc_clone_context(exc, &ecc, ECC_WCONTEXT);
-	execute_function(F_PASS_ARGS_WITH_EXC(exc2), exec_flags);
+	execute_function(cond_rc, exc2, action, pc, exec_flags);
 	exc_destroy_context(exc2);
 
 	return;
 }
 
-void execute_function_override_window(
-	F_CMD_ARGS, func_flags_t exec_flags, FvwmWindow *fw)
+void execute_function_override_window(cond_rc_t *cond_rc,
+	const exec_context_t *exc, char *action, cmdparser_context_t *pc,
+	func_flags_t exec_flags, FvwmWindow *fw)
 {
 	const exec_context_t *exc2;
 	exec_context_changes_t ecc;
@@ -1286,7 +1290,7 @@ void execute_function_override_window(
 		exc2 = exc_create_context(
 			&ecc, ECC_TYPE | ECC_FW | ECC_W | ECC_WCONTEXT);
 	}
-	execute_function(F_PASS_ARGS_WITH_EXC(exc2), exec_flags);
+	execute_function(cond_rc, exc2, action, pc, exec_flags);
 	exc_destroy_context(exc2);
 
 	return;
@@ -1427,7 +1431,8 @@ void AddToFunction(FvwmFunction *func, char *action)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_DestroyFunc(F_CMD_ARGS)
+void CMD_DestroyFunc(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmFunction *func;
 	char *token;
@@ -1451,7 +1456,8 @@ void CMD_DestroyFunc(F_CMD_ARGS)
 	return;
 }
 
-void CMD_AddToFunc(F_CMD_ARGS)
+void CMD_AddToFunc(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmFunction *func;
 	char *token;
@@ -1476,7 +1482,8 @@ void CMD_AddToFunc(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Plus(F_CMD_ARGS)
+void CMD_Plus(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	if (Scr.last_added_item.type == ADDED_MENU)
 	{
@@ -1497,13 +1504,14 @@ void CMD_Plus(F_CMD_ARGS)
 		{
 			return;
 		}
-		AddToDecor(F_PASS_ARGS, tmp);
+		AddToDecor(cond_rc, exc, action, pc, tmp);
 	}
 
 	return;
 }
 
-void CMD_EchoFuncDefinition(F_CMD_ARGS)
+void CMD_EchoFuncDefinition(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmFunction *func;
 	const func_t *bif;
@@ -1547,8 +1555,13 @@ void CMD_EchoFuncDefinition(F_CMD_ARGS)
 }
 
 /* dummy commands */
-void CMD_Title(F_CMD_ARGS) { }
-void CMD_TearMenuOff(F_CMD_ARGS) { }
-void CMD_KeepRc(F_CMD_ARGS) { }
-void CMD_Silent(F_CMD_ARGS) { }
-void CMD_Function(F_CMD_ARGS) { }
+void CMD_Title(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc) { }
+void CMD_TearMenuOff(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc) { }
+void CMD_KeepRc(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc) { }
+void CMD_Silent(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc) { }
+void CMD_Function(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc) { }

--- a/fvwm/functions.h
+++ b/fvwm/functions.h
@@ -61,10 +61,13 @@ typedef enum
 /* needs to be called before any command line can be executed */
 void functions_init(void);
 void find_func_t(char *action, short *func_t, func_flags_t *flags);
-void execute_function(F_CMD_ARGS, func_flags_t exec_flags);
-void execute_function_override_wcontext(
-	F_CMD_ARGS, func_flags_t exec_flags, int wcontext);
-void execute_function_override_window(
-	F_CMD_ARGS, func_flags_t exec_flags, FvwmWindow *fw);
+void execute_function(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc, func_flags_t exec_flags);
+void execute_function_override_wcontext(cond_rc_t *cond_rc,
+	const exec_context_t *exc, char *action, cmdparser_context_t *pc,
+	func_flags_t exec_flags, int wcontext);
+void execute_function_override_window(cond_rc_t *cond_rc,
+	const exec_context_t *exc, char *action, cmdparser_context_t *pc,
+	func_flags_t exec_flags, FvwmWindow *fw);
 
 #endif /* FVWM_FUNCTIONS_H */

--- a/fvwm/fvwm.h
+++ b/fvwm/fvwm.h
@@ -52,17 +52,19 @@
 
 /* ---------------------------- global macros ------------------------------ */
 
-/*
- * Fvwm trivia: There were 97 commands in the fvwm command table
- * when the F_CMD_ARGS macro was written.
- * dje 12/19/98.
+ /*
+ * Fvwm trivia: On 12/19/1998, there were 97 commands in the FVWM command
+ * table when the F_CMD_ARGS macro was created. Back then, command functions
+ * were written like this to improve maintainability:
+ *     void CMD_foo(F_CMD_ARGS);
+ * However, this came at the cost of readability, which is why the macro was
+ * eventually removed.
+ * 
+ * As of 01/25/2026, there are 160 commands (163 elements in func_table[]).
+ * Functions are now declared with explicit parameter lists, making the code
+ * easier to read and maintain. Fun fact: the original macro no longer exists,
+ * but it's a charming piece of FVWM history. (me)
  */
-
-/* Macro for args passed to fvwm commands... */
-#define F_CMD_ARGS \
-	cond_rc_t *cond_rc, const exec_context_t *exc, char *action, cmdparser_context_t *pc
-#define F_PASS_ARGS cond_rc, exc, action, pc
-#define F_PASS_ARGS_WITH_EXC(new_exc) cond_rc, (new_exc), action, pc
 
 /* access macros */
 #define FW_W_FRAME(fw)        ((fw)->wins.frame)

--- a/fvwm/icons.c
+++ b/fvwm/icons.c
@@ -2636,7 +2636,8 @@ void SetMapStateProp(const FvwmWindow *fw, int state)
 	return;
 }
 
-void CMD_Iconify(F_CMD_ARGS)
+void CMD_Iconify(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int toggle;
 	FvwmWindow * const fw = exc->w.fw;

--- a/fvwm/infostore.c
+++ b/fvwm/infostore.c
@@ -132,7 +132,8 @@ void print_infostore(void)
 /* ---------------------------- interface functions ------------------------ */
 
 /* ---------------------------- builtin commands --------------------------- */
-void CMD_InfoStoreAdd(F_CMD_ARGS)
+void CMD_InfoStoreAdd(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *key = NULL, *value = NULL;
 	char *token;
@@ -155,7 +156,8 @@ error:
 	free(value);
 }
 
-void CMD_InfoStoreRemove(F_CMD_ARGS)
+void CMD_InfoStoreRemove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *token;
 
@@ -172,7 +174,8 @@ void CMD_InfoStoreRemove(F_CMD_ARGS)
 	return;
 }
 
-void CMD_InfoStoreClear(F_CMD_ARGS)
+void CMD_InfoStoreClear(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	MetaInfo	*mi, *mi2;
 

--- a/fvwm/menucmd.c
+++ b/fvwm/menucmd.c
@@ -56,7 +56,8 @@
 
 /* ---------------------------- local functions ---------------------------- */
 
-static void menu_func(F_CMD_ARGS, Bool fStaysUp)
+static void menu_func(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, Bool fStaysUp)
 {
 	struct MenuRoot *menu;
 	char *ret_action = NULL;
@@ -126,22 +127,25 @@ static void menu_func(F_CMD_ARGS, Bool fStaysUp)
 /* ---------------------------- builtin commands --------------------------- */
 
 /* the function for the "Popup" command */
-void CMD_Popup(F_CMD_ARGS)
+void CMD_Popup(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	menu_func(F_PASS_ARGS, False);
+	menu_func(cond_rc, exc, action, False);
 
 	return;
 }
 
 /* the function for the "Menu" command */
-void CMD_Menu(F_CMD_ARGS)
+void CMD_Menu(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	menu_func(F_PASS_ARGS, True);
+	menu_func(cond_rc, exc, action, True);
 
 	return;
 }
 
-void CMD_AddToMenu(F_CMD_ARGS)
+void CMD_AddToMenu(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	MenuRoot *mr;
 	MenuRoot *mrPrior;
@@ -177,7 +181,8 @@ void CMD_AddToMenu(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DestroyMenu(F_CMD_ARGS)
+void CMD_DestroyMenu(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	MenuRoot *mr;
 	MenuRoot *mrContinuation;
@@ -215,7 +220,8 @@ void CMD_DestroyMenu(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DestroyMenuStyle(F_CMD_ARGS)
+void CMD_DestroyMenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	MenuStyle *ms = NULL;
 	char *name = NULL;
@@ -255,7 +261,8 @@ void CMD_DestroyMenuStyle(F_CMD_ARGS)
 	return;
 }
 
-void CMD_ChangeMenuStyle(F_CMD_ARGS)
+void CMD_ChangeMenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *name = NULL;
 	char *menuname = NULL;

--- a/fvwm/menus.c
+++ b/fvwm/menus.c
@@ -5204,9 +5204,6 @@ static void menu_tear_off(MenuRoot *mr_to_copy)
 	exec_context_changes_t ecc;
 	char *buffer;
 	char *action;
-	cond_rc_t *cond_rc = NULL;
-	const exec_context_t *exc = NULL;
-	cmdparser_context_t *pc = NULL;
 
 	/* keep the menu open */
 	if (MR_WINDOW(mr_to_copy) != None)
@@ -5220,7 +5217,7 @@ static void menu_tear_off(MenuRoot *mr_to_copy)
 	/* also dump the menu style */
 	xasprintf(&buffer, "%lu", (unsigned long)mr);
 	action = buffer;
-	ms = menustyle_parse_style(F_PASS_ARGS);
+	ms = menustyle_parse_style(action);
 	if (!ms)
 	{
 		/* this must never happen */

--- a/fvwm/menustyle.c
+++ b/fvwm/menustyle.c
@@ -416,7 +416,7 @@ void menustyle_update(MenuStyle *ms)
 	return;
 }
 
-MenuStyle *menustyle_parse_style(F_CMD_ARGS)
+MenuStyle *menustyle_parse_style(char *action)
 {
 	char *name;
 	char *option = NULL;
@@ -1300,7 +1300,8 @@ void menustyle_copy(MenuStyle *origms, MenuStyle *destms)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_CopyMenuStyle(F_CMD_ARGS)
+void CMD_CopyMenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *origname = NULL;
 	char *destname = NULL;
@@ -1342,7 +1343,7 @@ void CMD_CopyMenuStyle(F_CMD_ARGS)
 		/* create destms menu style */
 		xasprintf(&buffer, "\"%s\"", destname);
 		action = buffer;
-		destms = menustyle_parse_style(F_PASS_ARGS);
+		destms = menustyle_parse_style(action);
 		free(buffer);
 		if (!destms)
 		{
@@ -1380,8 +1381,9 @@ void CMD_CopyMenuStyle(F_CMD_ARGS)
 	return;
 }
 
-void CMD_MenuStyle(F_CMD_ARGS)
+void CMD_MenuStyle(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	(void)menustyle_parse_style(F_PASS_ARGS);
+	(void)menustyle_parse_style(action);
 	return;
 }

--- a/fvwm/menustyle.h
+++ b/fvwm/menustyle.h
@@ -297,7 +297,7 @@ typedef struct MenuStyle
 void menustyle_free(MenuStyle *ms);
 MenuStyle *menustyle_find(char *name);
 void menustyle_update(MenuStyle *ms);
-MenuStyle *menustyle_parse_style(F_CMD_ARGS);
+MenuStyle *menustyle_parse_style(char *action);
 MenuStyle *menustyle_get_default_style(void);
 void menustyle_copy(MenuStyle *origms, MenuStyle *destms);
 

--- a/fvwm/modconf.c
+++ b/fvwm/modconf.c
@@ -190,7 +190,8 @@ fprintf(stderr, "%s: mldata '%s', mlaliaslen %d\n", __func__, this->data, this->
 /*
  * delete from module configuration
  */
-void CMD_DestroyModuleConfig(F_CMD_ARGS)
+void CMD_DestroyModuleConfig(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	struct moduleInfoList *current, *next, *prev;
 	char *info;   /* info to be deleted - may contain wildcards */
@@ -380,7 +381,8 @@ void send_monitor_list(fmodule *module)
 	BroadcastMonitorList(module);
 }
 
-void CMD_Send_ConfigInfo(F_CMD_ARGS)
+void CMD_Send_ConfigInfo(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	struct moduleInfoList *t;
 	/* matching criteria for module cmds */

--- a/fvwm/module_interface.c
+++ b/fvwm/module_interface.c
@@ -818,7 +818,8 @@ void ExecuteCommandQueue(void)
 /*
 ** send an arbitrary string to all instances of a module
 */
-void CMD_SendToModule(F_CMD_ARGS)
+void CMD_SendToModule(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *name,*str;
 	unsigned long data0, data1, data2;
@@ -875,7 +876,8 @@ void CMD_SendToModule(F_CMD_ARGS)
 /*
 ** send an arbitrary string back to the calling module
 */
-void CMD_Send_Reply(F_CMD_ARGS)
+void CMD_Send_Reply(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	unsigned long data0, data1, data2;
 	fmodule *module = exc->m.module;
@@ -910,7 +912,8 @@ void CMD_Send_Reply(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Send_WindowList(F_CMD_ARGS)
+void CMD_Send_WindowList(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmWindow *t;
 	fmodule *mod = exc->m.module;

--- a/fvwm/module_list.c
+++ b/fvwm/module_list.c
@@ -23,11 +23,6 @@
 /* for time(); difftime() */
 #include <time.h>
 
-/* for F_CMD_ARGS */
-#include "fvwm/fvwm.h"
-#include "execcontext.h"
-/* end of for CMD_ARGS */
-
 /*for debug message*/
 #include "fvwm.h"
 #include "misc.h"
@@ -226,8 +221,8 @@ static inline void module_list_destroy(fmodule_list *list)
 	return;
 }
 
-static fmodule *do_execute_module(
-	F_CMD_ARGS, Bool desperate, Bool do_listen_only)
+static fmodule *do_execute_module(const exec_context_t *exc, char *action,
+	Bool desperate, Bool do_listen_only)
 {
 	int fvwm_to_app[2], app_to_fvwm[2];
 	int i, val, nargs = 0;
@@ -501,11 +496,11 @@ static fmodule *do_execute_module(
 	return NULL;
 }
 
-fmodule *executeModuleDesperate(F_CMD_ARGS)
+fmodule *executeModuleDesperate(const exec_context_t *exc, char *action)
 {
 	fmodule *m;
 
-	m = do_execute_module(F_PASS_ARGS, True, False);
+	m = do_execute_module(exc, action, True, False);
 
 	return m;
 }
@@ -1059,21 +1054,24 @@ RETSIGTYPE DeadPipe(int sig)
 	SIGNAL_RETURN;
 }
 
-void CMD_Module(F_CMD_ARGS)
+void CMD_Module(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	do_execute_module(F_PASS_ARGS, False, False);
+	do_execute_module(exc, action, False, False);
 
 	return;
 }
 
-void CMD_ModuleListenOnly(F_CMD_ARGS)
+void CMD_ModuleListenOnly(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	do_execute_module(F_PASS_ARGS, False, True);
+	do_execute_module(exc, action, False, True);
 
 	return;
 }
 
-void CMD_KillModule(F_CMD_ARGS)
+void CMD_KillModule(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *name;
 	char *alias = NULL;
@@ -1094,7 +1092,8 @@ void CMD_KillModule(F_CMD_ARGS)
 	return;
 }
 
-void CMD_ModuleSynchronous(F_CMD_ARGS)
+void CMD_ModuleSynchronous(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int sec = 0;
 	char *next;
@@ -1145,7 +1144,7 @@ void CMD_ModuleSynchronous(F_CMD_ARGS)
 		goto done;
 	}
 
-	module = do_execute_module(F_PASS_ARGS, False, False);
+	module = do_execute_module(exc, action, False, False);
 	if (module == NULL)
 	{
 		/* executing the module failed, just return */
@@ -1277,7 +1276,8 @@ done:
 
 /* mask handling - does this belong here? */
 
-void CMD_set_mask(F_CMD_ARGS)
+void CMD_set_mask(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	unsigned long val;
 
@@ -1294,7 +1294,8 @@ void CMD_set_mask(F_CMD_ARGS)
 	return;
 }
 
-void CMD_set_sync_mask(F_CMD_ARGS)
+void CMD_set_sync_mask(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	unsigned long val;
 
@@ -1311,7 +1312,8 @@ void CMD_set_sync_mask(F_CMD_ARGS)
 	return;
 }
 
-void CMD_set_nograb_mask(F_CMD_ARGS)
+void CMD_set_nograb_mask(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	unsigned long val;
 

--- a/fvwm/module_list.h
+++ b/fvwm/module_list.h
@@ -6,9 +6,6 @@
 #include "libs/Module.h"
 #include "libs/fqueue.h"
 
-/* for F_CMD_ARGS */
-#include "fvwm/fvwm.h"
-
 /* please don't use msg_masks_t and PipeMask outside of module_interface.c.
  * They are only global to allow to access the IS_MESSAGE_SELECTED macro without
  * having to call a function. */
@@ -104,7 +101,7 @@ void module_kill_all(void);
 void module_kill(fmodule *module);
 
 /* execute module wrapper, desperate mode */
-fmodule *executeModuleDesperate(F_CMD_ARGS);
+fmodule *executeModuleDesperate(const exec_context_t *exc, char *action);
 
 
 /*

--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -1450,7 +1450,7 @@ static void DisplaySize(
 	return;
 }
 
-static Bool resize_move_window(F_CMD_ARGS)
+static Bool resize_move_window(const exec_context_t *exc, char *action)
 {
 	position final_pos = { 0, 0 };
 	size_rect final_size = { 0, 0 };
@@ -1552,17 +1552,18 @@ static Bool resize_move_window(F_CMD_ARGS)
 	return True;
 }
 
-void CMD_ResizeMove(F_CMD_ARGS)
+void CMD_ResizeMove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmWindow *fw = exc->w.fw;
 
 	if (IS_EWMH_FULLSCREEN(fw))
 	{
 		/* do not unmaximize ! */
-		CMD_ResizeMoveMaximize(F_PASS_ARGS);
+		CMD_ResizeMoveMaximize(cond_rc, exc, action, pc);
 		return;
 	}
-	resize_move_window(F_PASS_ARGS);
+	resize_move_window(exc, action);
 
 	return;
 }
@@ -2110,7 +2111,8 @@ void move_icon(
 	return;
 }
 
-static void _move_window(F_CMD_ARGS, Bool do_animate, int mode)
+static void _move_window(const exec_context_t *exc, char *action,
+	Bool do_animate, int mode)
 {
 	position final = { 0, 0 };
 	int n;
@@ -2310,27 +2312,31 @@ static void _move_window(F_CMD_ARGS, Bool do_animate, int mode)
 	return;
 }
 
-void CMD_Move(F_CMD_ARGS)
+void CMD_Move(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	_move_window(F_PASS_ARGS, False, MOVE_NORMAL);
+	_move_window(exc, action, False, MOVE_NORMAL);
 	update_fvwm_monitor(exc->w.fw);
 }
 
-void CMD_AnimatedMove(F_CMD_ARGS)
+void CMD_AnimatedMove(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	_move_window(F_PASS_ARGS, True, MOVE_NORMAL);
+	_move_window(exc, action, True, MOVE_NORMAL);
 	update_fvwm_monitor(exc->w.fw);
 }
 
-void CMD_MoveToPage(F_CMD_ARGS)
+void CMD_MoveToPage(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	_move_window(F_PASS_ARGS, False, MOVE_PAGE);
+	_move_window(exc, action, False, MOVE_PAGE);
 	update_fvwm_monitor(exc->w.fw);
 }
 
-void CMD_MoveToScreen(F_CMD_ARGS)
+void CMD_MoveToScreen(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	_move_window(F_PASS_ARGS, False, MOVE_SCREEN);
+	_move_window(exc, action, False, MOVE_SCREEN);
 	update_fvwm_monitor(exc->w.fw);
 }
 
@@ -3296,7 +3302,8 @@ Bool move_loop(
 	return do_resize_too;
 }
 
-void CMD_MoveThreshold(F_CMD_ARGS)
+void CMD_MoveThreshold(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val = 0;
 
@@ -3312,7 +3319,8 @@ void CMD_MoveThreshold(F_CMD_ARGS)
 	return;
 }
 
-void CMD_OpaqueMoveSize(F_CMD_ARGS)
+void CMD_OpaqueMoveSize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val;
 
@@ -3387,7 +3395,8 @@ static bool set_geom_win_position_val(char *s, int *coord, bool *neg, bool *rel)
 	return true;
 }
 
-void CMD_GeometryWindow(F_CMD_ARGS)
+void CMD_GeometryWindow(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val;
 	char *token = NULL, *s = NULL;
@@ -3439,7 +3448,8 @@ void CMD_GeometryWindow(F_CMD_ARGS)
 
 static Pixmap XorPixmap = None;
 
-void CMD_XorValue(F_CMD_ARGS)
+void CMD_XorValue(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int val;
 	XGCValues gcv;
@@ -3488,7 +3498,8 @@ void CMD_XorValue(F_CMD_ARGS)
 }
 
 
-void CMD_XorPixmap(F_CMD_ARGS)
+void CMD_XorPixmap(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char *PixmapName;
 	FvwmPicture *xp;
@@ -3501,7 +3512,7 @@ void CMD_XorPixmap(F_CMD_ARGS)
 	{
 		/* return to default value. */
 		action = "0";
-		CMD_XorValue(F_PASS_ARGS);
+		CMD_XorValue(cond_rc, exc, action, pc);
 		return;
 	}
 	/* get the picture in the root visual, colorlimit is ignored because the
@@ -3967,7 +3978,7 @@ static void _resize_step(
 }
 
 /* Starts a window resize operation */
-static Bool _resize_window(F_CMD_ARGS)
+static Bool _resize_window(const exec_context_t *exc, char *action)
 {
 	FvwmWindow *fw = exc->w.fw;
 	Bool is_finished = False, is_done = False, is_aborted = False;
@@ -4775,18 +4786,19 @@ static Bool _resize_window(F_CMD_ARGS)
 	return True;
 }
 
-void CMD_Resize(F_CMD_ARGS)
+void CMD_Resize(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow *fw = exc->w.fw;
 
 	if (IS_EWMH_FULLSCREEN(fw))
 	{
 		/* do not unmaximize ! */
-		CMD_ResizeMaximize(F_PASS_ARGS);
+		CMD_ResizeMaximize(cond_rc, exc, action, pc);
 		return;
 	}
 
-	_resize_window(F_PASS_ARGS);
+	_resize_window(exc, action);
 	update_fvwm_monitor(fw);
 
 	return;
@@ -5141,7 +5153,8 @@ fprintf(stderr,"%d %d %d %d, g.max_offset.x = %d, g.max_offset.y = %d, %d %d %d 
  *      (Un)Maximize a window.
  *
  */
-void CMD_Maximize(F_CMD_ARGS)
+void CMD_Maximize(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	position page;
 	int val1, val2, val1_unit, val2_unit;
@@ -5502,7 +5515,8 @@ void CMD_Maximize(F_CMD_ARGS)
  * without touching the normal geometry.
  *
  */
-void CMD_ResizeMaximize(F_CMD_ARGS)
+void CMD_ResizeMaximize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	rectangle normal_g;
 	rectangle max_g;
@@ -5513,7 +5527,7 @@ void CMD_ResizeMaximize(F_CMD_ARGS)
 	/* keep a copy of the old geometry */
 	normal_g = fw->g.normal;
 	/* resize the window normally */
-	was_resized = _resize_window(F_PASS_ARGS);
+	was_resized = _resize_window(exc, action);
 	if (was_resized == True)
 	{
 		/* set the new geometry as the maximized geometry and restore
@@ -5531,7 +5545,8 @@ void CMD_ResizeMaximize(F_CMD_ARGS)
 	return;
 }
 
-void CMD_ResizeMoveMaximize(F_CMD_ARGS)
+void CMD_ResizeMoveMaximize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	rectangle normal_g;
 	rectangle max_g;
@@ -5542,7 +5557,7 @@ void CMD_ResizeMoveMaximize(F_CMD_ARGS)
 	/* keep a copy of the old geometry */
 	normal_g = fw->g.normal;
 	/* resize the window normally */
-	was_resized = resize_move_window(F_PASS_ARGS);
+	was_resized = resize_move_window(exc, action);
 	if (was_resized == True)
 	{
 		/* set the new geometry as the maximized geometry and restore
@@ -5562,7 +5577,7 @@ void CMD_ResizeMoveMaximize(F_CMD_ARGS)
 
 /* ----------------------------- stick code -------------------------------- */
 
-int stick_across_pages(F_CMD_ARGS, int toggle)
+int stick_across_pages(const exec_context_t *exc, char *action, int toggle)
 {
 	FvwmWindow *fw = exc->w.fw;
 
@@ -5581,7 +5596,7 @@ int stick_across_pages(F_CMD_ARGS, int toggle)
 		    fw->m->virtual_scr.CurrentDesk))
 		{
 			action = "";
-			_move_window(F_PASS_ARGS, False, MOVE_PAGE);
+			_move_window(exc, action, False, MOVE_PAGE);
 			update_fvwm_monitor(fw);
 		}
 		SET_STICKY_ACROSS_PAGES(fw, 1);
@@ -5590,7 +5605,7 @@ int stick_across_pages(F_CMD_ARGS, int toggle)
 	return 1;
 }
 
-int stick_across_desks(F_CMD_ARGS, int toggle)
+int stick_across_desks(const exec_context_t *exc, int toggle)
 {
 	FvwmWindow *fw = exc->w.fw;
 
@@ -5638,13 +5653,13 @@ static void _handle_stick_exit(
 	return;
 }
 
-void handle_stick_across_pages(
-	F_CMD_ARGS, int toggle, int do_not_draw, int do_silently)
+void handle_stick_across_pages(const exec_context_t *exc, char *action,
+	int toggle, int do_not_draw, int do_silently)
 {
 	FvwmWindow *fw = exc->w.fw;
 	int did_change;
 
-	did_change = stick_across_pages(F_PASS_ARGS, toggle);
+	did_change = stick_across_pages(exc, action, toggle);
 	if (did_change)
 	{
 		_handle_stick_exit(fw, do_not_draw, do_silently);
@@ -5653,13 +5668,13 @@ void handle_stick_across_pages(
 	return;
 }
 
-void handle_stick_across_desks(
-	F_CMD_ARGS, int toggle, int do_not_draw, int do_silently)
+void handle_stick_across_desks(const exec_context_t *exc, int toggle,
+	int do_not_draw, int do_silently)
 {
 	FvwmWindow *fw = exc->w.fw;
 	int did_change;
 
-	did_change = stick_across_desks(F_PASS_ARGS, toggle);
+	did_change = stick_across_desks(exc, toggle);
 	if (did_change)
 	{
 		_handle_stick_exit(fw, do_not_draw, do_silently);
@@ -5668,16 +5683,15 @@ void handle_stick_across_desks(
 	return;
 }
 
-void handle_stick(
-	F_CMD_ARGS, int toggle_page, int toggle_desk, int do_not_draw,
-	int do_silently)
+void handle_stick(const exec_context_t *exc, char *action,
+	int toggle_page, int toggle_desk, int do_not_draw, int do_silently)
 {
 	FvwmWindow *fw = exc->w.fw;
 	int did_change;
 
 	did_change = 0;
-	did_change |= stick_across_desks(F_PASS_ARGS, toggle_desk);
-	did_change |= stick_across_pages(F_PASS_ARGS, toggle_page);
+	did_change |= stick_across_desks(exc, toggle_desk);
+	did_change |= stick_across_pages(exc, action, toggle_page);
 	if (did_change)
 	{
 		_handle_stick_exit(fw, do_not_draw, do_silently);
@@ -5686,7 +5700,8 @@ void handle_stick(
 	return;
 }
 
-void CMD_Stick(F_CMD_ARGS)
+void CMD_Stick(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int toggle;
 
@@ -5698,27 +5713,29 @@ void CMD_Stick(F_CMD_ARGS)
 		 * rather switch it off completely */
 		toggle = 0;
 	}
-	handle_stick(F_PASS_ARGS, toggle, toggle, 0, 0);
+	handle_stick(exc, action, toggle, toggle, 0, 0);
 
 	return;
 }
 
-void CMD_StickAcrossPages(F_CMD_ARGS)
+void CMD_StickAcrossPages(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int toggle;
 
 	toggle = ParseToggleArgument(action, &action, -1, 0);
-	handle_stick_across_pages(F_PASS_ARGS, toggle, 0, 0);
+	handle_stick_across_pages(exc, action, toggle, 0, 0);
 
 	return;
 }
 
-void CMD_StickAcrossDesks(F_CMD_ARGS)
+void CMD_StickAcrossDesks(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int toggle;
 
 	toggle = ParseToggleArgument(action, &action, -1, 0);
-	handle_stick_across_desks(F_PASS_ARGS, toggle, 0, 0);
+	handle_stick_across_desks(exc, toggle, 0, 0);
 
 	return;
 }

--- a/fvwm/move_resize.h
+++ b/fvwm/move_resize.h
@@ -22,8 +22,8 @@ Bool move_loop(
 int is_window_sticky_across_pages(FvwmWindow *fw);
 int is_window_sticky_across_desks(FvwmWindow *fw);
 void handle_stick(
-	F_CMD_ARGS, int toggle_page, int toggle_desk, int do_not_draw,
-	int do_silently);
+	const exec_context_t *exc, char *action,
+	int toggle_page, int toggle_desk, int do_not_draw, int do_silently);
 void resize_geometry_window(void);
 void move_icon(
 	FvwmWindow *fw, position new, position old,

--- a/fvwm/placement.c
+++ b/fvwm/placement.c
@@ -2443,7 +2443,8 @@ Bool setup_window_placement(
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_PlaceAgain(F_CMD_ARGS)
+void CMD_PlaceAgain(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int old_desk;
 	char *token;

--- a/fvwm/read.c
+++ b/fvwm/read.c
@@ -306,7 +306,8 @@ static void cursor_control(Bool grab)
 	return;
 }
 
-void CMD_Read(F_CMD_ARGS)
+void CMD_Read(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char* filename;
 	int read_quietly;
@@ -354,7 +355,8 @@ void CMD_Read(F_CMD_ARGS)
 	return;
 }
 
-void CMD_PipeRead(F_CMD_ARGS)
+void CMD_PipeRead(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	char* command;
 	int read_quietly;

--- a/fvwm/schedule.c
+++ b/fvwm/schedule.c
@@ -261,7 +261,8 @@ int squeue_get_last_id(void)
 	return last_schedule_id;
 }
 
-void CMD_Schedule(F_CMD_ARGS)
+void CMD_Schedule(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	Window xw;
 	Time time;
@@ -329,7 +330,8 @@ void CMD_Schedule(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Deschedule(F_CMD_ARGS)
+void CMD_Deschedule(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int id;
 	int *pid;

--- a/fvwm/screen.h
+++ b/fvwm/screen.h
@@ -501,7 +501,8 @@ void simplify_style_list(void);
 /*
  * Diverts a style definition to an FvwmDecor structure (veliaa@rpi.edu)
  */
-void AddToDecor(F_CMD_ARGS, FvwmDecor *decor);
+void AddToDecor(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc, FvwmDecor *decor);
 
 extern ScreenInfo Scr;
 

--- a/fvwm/session.c
+++ b/fvwm/session.c
@@ -1929,21 +1929,24 @@ Bool save_quit_session(void)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_QuitSession(F_CMD_ARGS)
+void CMD_QuitSession(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	quit_session();
 
 	return;
 }
 
-void CMD_SaveSession(F_CMD_ARGS)
+void CMD_SaveSession(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	save_session();
 
 	return;
 }
 
-void CMD_SaveQuitSession(F_CMD_ARGS)
+void CMD_SaveQuitSession(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	save_quit_session();
 

--- a/fvwm/stack.c
+++ b/fvwm/stack.c
@@ -2061,28 +2061,32 @@ Bool is_on_top_of_layer_and_above_unmanaged(FvwmWindow *fw)
 
 /* ----------------------------- built in functions ----------------------- */
 
-void CMD_Raise(F_CMD_ARGS)
+void CMD_Raise(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	RaiseWindow(exc->w.fw, False);
 
 	return;
 }
 
-void CMD_Lower(F_CMD_ARGS)
+void CMD_Lower(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	LowerWindow(exc->w.fw, False);
 
 	return;
 }
 
-void CMD_RestackTransients(F_CMD_ARGS)
+void CMD_RestackTransients(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	RestackWindow(exc->w.fw, False);
 
 	return;
 }
 
-void CMD_RaiseLower(F_CMD_ARGS)
+void CMD_RaiseLower(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	Bool ontop;
 	FvwmWindow * const fw = exc->w.fw;
@@ -2100,7 +2104,8 @@ void CMD_RaiseLower(F_CMD_ARGS)
 	return;
 }
 
-void CMD_Layer(F_CMD_ARGS)
+void CMD_Layer(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int n, layer, val[2];
 	char *token;
@@ -2147,7 +2152,8 @@ void CMD_Layer(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DefaultLayers(F_CMD_ARGS)
+void CMD_DefaultLayers(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	char *bot = NULL;
 	char *def = NULL;

--- a/fvwm/style.c
+++ b/fvwm/style.c
@@ -4723,7 +4723,8 @@ void parse_and_set_window_style(char *action, char *prefix, window_style *ps)
  * must be freed in ProcessDestroyStyle().
  */
 
-static void _style_command(F_CMD_ARGS, char *prefix, Bool is_window_style)
+static void _style_command(const exec_context_t *exc, char *action,
+	char *prefix, Bool is_window_style)
 {
 	/* temp area to build name list */
 	window_style *ps;
@@ -5556,28 +5557,32 @@ void style_destroy_style(style_id_t s_id)
 
 /* ---------------------------- builtin commands --------------------------- */
 
-void CMD_Style(F_CMD_ARGS)
+void CMD_Style(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
-	_style_command(F_PASS_ARGS, NULL, False);
+	_style_command(exc, action, NULL, False);
 
 	return;
 }
 
-void CMD_WindowStyle(F_CMD_ARGS)
+void CMD_WindowStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	_style_command(F_PASS_ARGS, NULL, True);
+	_style_command(exc, action, NULL, True);
 
 	return;
 }
 
-void CMD_FocusStyle(F_CMD_ARGS)
+void CMD_FocusStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
-	_style_command(F_PASS_ARGS, "FP", False);
+	_style_command(exc, action, "FP", False);
 
 	return;
 }
 
-void CMD_DestroyStyle(F_CMD_ARGS)
+void CMD_DestroyStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	style_id_t s_id;
 
@@ -5590,7 +5595,8 @@ void CMD_DestroyStyle(F_CMD_ARGS)
 	style_destroy_style(s_id);
 }
 
-void CMD_DestroyWindowStyle(F_CMD_ARGS)
+void CMD_DestroyWindowStyle(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	style_id_t s_id;
 

--- a/fvwm/update.c
+++ b/fvwm/update.c
@@ -147,18 +147,16 @@ static void apply_window_updates(
 		{
 			/* stick and unstick the window to force the icon on
 			 * the current page */
-			handle_stick(
-				NULL, exc, "", NULL,
+			handle_stick(exc, "",
 				S_IS_STICKY_ACROSS_PAGES(SCF(*pstyle)),
 				S_IS_STICKY_ACROSS_DESKS(SCF(*pstyle)), 1, 1);
-			handle_stick(NULL, exc, "", NULL, 0, 0, 1, 0);
+			handle_stick(exc, "", 0, 0, 1, 0);
 		}
 		flags->do_update_icon_title = True;
 	}
 	else if (flags->do_update_stick)
 	{
-		handle_stick(
-			NULL, exc, "", NULL,
+		handle_stick(exc, "",
 			S_IS_STICKY_ACROSS_PAGES(SCF(*pstyle)),
 			S_IS_STICKY_ACROSS_DESKS(SCF(*pstyle)), 0, 0);
 	}
@@ -809,7 +807,8 @@ void flush_window_updates(void)
 	return;
 }
 
-void CMD_UpdateStyles(F_CMD_ARGS)
+void CMD_UpdateStyles(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	if (Scr.flags.do_need_window_update)
 	{

--- a/fvwm/virtual.c
+++ b/fvwm/virtual.c
@@ -2028,18 +2028,21 @@ void parse_edge_leave_command(char *action, int type)
 }
 
 /* EdgeCommand - binds a function to a pan frame enter event */
-void CMD_EdgeCommand(F_CMD_ARGS)
+void CMD_EdgeCommand(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	parse_edge_leave_command(action, EDGE_CMD);
 }
 
 /* EdgeLeaveCommand - binds a function to a pan frame Leave event */
-void CMD_EdgeLeaveCommand(F_CMD_ARGS)
+void CMD_EdgeLeaveCommand(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	parse_edge_leave_command(action, EDGE_LEAVE_CMD);
 }
 
-void CMD_EdgeThickness(F_CMD_ARGS)
+void CMD_EdgeThickness(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val, n;
 	char *option;
@@ -2094,7 +2097,8 @@ void CMD_EdgeThickness(F_CMD_ARGS)
 	}
 }
 
-void CMD_EdgeScroll(F_CMD_ARGS)
+void CMD_EdgeScroll(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val1, val2, val1_unit, val2_unit, n;
 	char *token, *option;
@@ -2180,7 +2184,8 @@ void CMD_EdgeScroll(F_CMD_ARGS)
 	}
 }
 
-void CMD_EdgeResistance(F_CMD_ARGS)
+void CMD_EdgeResistance(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val[3];
 	int n;
@@ -2239,7 +2244,8 @@ void CMD_EdgeResistance(F_CMD_ARGS)
 	return;
 }
 
-void CMD_DesktopConfiguration(F_CMD_ARGS)
+void CMD_DesktopConfiguration(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	FvwmWindow	*t;
 	struct monitor	*m = monitor_get_current();
@@ -2430,7 +2436,8 @@ calculate_page_sizes(struct monitor *m, int dx, int dy)
 		monitor_get_all_heights() - monitor_get_all_heights();
 }
 
-void CMD_DesktopSize(F_CMD_ARGS)
+void CMD_DesktopSize(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val[2];
 	struct monitor	*m;
@@ -2470,7 +2477,8 @@ void CMD_DesktopSize(F_CMD_ARGS)
  * Move to a new desktop
  *
  */
-void CMD_GotoDesk(F_CMD_ARGS)
+void CMD_GotoDesk(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	struct monitor  *m = NULL, *m_loop;
 	char		*token;
@@ -2536,7 +2544,8 @@ void CMD_GotoDesk(F_CMD_ARGS)
  *     viewport is moved, then switch the viewport, then the desk.
  *
  */
-void CMD_GotoDeskAndPage(F_CMD_ARGS)
+void CMD_GotoDeskAndPage(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int val[3];
 	int current_desk;
@@ -2623,7 +2632,8 @@ done:
 	return;
 }
 
-void CMD_GotoPage(F_CMD_ARGS)
+void CMD_GotoPage(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	FvwmWindow * const fw = exc->w.fw;
 	struct monitor	*m = (fw && fw->m) ? fw->m : monitor_get_current();
@@ -2664,7 +2674,8 @@ void CMD_GotoPage(F_CMD_ARGS)
 }
 
 /* function with parsing of command line */
-void CMD_MoveToDesk(F_CMD_ARGS)
+void CMD_MoveToDesk(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	int desk;
 	FvwmWindow * const fw = exc->w.fw;
@@ -2696,7 +2707,8 @@ void CMD_MoveToDesk(F_CMD_ARGS)
 	do_move_window_to_desk(fw, desk);
 }
 
-void CMD_Scroll(F_CMD_ARGS)
+void CMD_Scroll(cond_rc_t *cond_rc, const exec_context_t *exc, char *action,
+	cmdparser_context_t *pc)
 {
 	int x,y;
 	int val1, val2, val1_unit, val2_unit;
@@ -3050,7 +3062,8 @@ apply_desktops_monitor(struct monitor *m)
  * Defines the name of a desktop
  *
  */
-void CMD_DesktopName(F_CMD_ARGS)
+void CMD_DesktopName(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	struct monitor	*m;
 	int		 desk;

--- a/fvwm/windowlist.c
+++ b/fvwm/windowlist.c
@@ -184,7 +184,8 @@ static int compareReverse(const  FvwmWindow **a, const  FvwmWindow **b)
  * specifier to each item in the list.  This means allocating the
  * memory for each item (& freeing it) rather than just using the window
  * title directly. */
-void CMD_WindowList(F_CMD_ARGS)
+void CMD_WindowList(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	struct MenuRoot *mr;
 	struct MenuParameters mp;

--- a/fvwm/windowshade.c
+++ b/fvwm/windowshade.c
@@ -66,7 +66,8 @@
  *  Args: 1 -- shade, 2 -- unshade  No Arg: toggle
  *
  */
-void CMD_WindowShade(F_CMD_ARGS)
+void CMD_WindowShade(cond_rc_t *cond_rc, const exec_context_t *exc,
+	char *action, cmdparser_context_t *pc)
 {
 	direction_t shade_dir;
 	int toggle;


### PR DESCRIPTION
- Expanded `F_*_ARGS` macros into regular parameter lists, mainly for `CMD_*` functions.  
- Removed unused parameters that were previously passed via these macros (e.g. `bindings_cmd()` in `bindings.h`, `menustyle_parse_style()` in `menustyle.c`).  
- Removed variables that only existed to satisfy `F_PASS_ARGS` (notably in `menus.c`).  
- Updated the existing trivia comment in `fvwm.h` to match the current code.