### PR TITLE
Windowlist: Fix OnlySticky handling

### DIFF
--- a/fvwm/windowlist.c
+++ b/fvwm/windowlist.c
@@ -68,6 +68,7 @@
 #define SHOW_PAGE_Y		(1<<18)
 #define NO_LAYER		(1<<19)
 #define SHOW_SCREEN		(1<<20)
+#define SHOW_ONLY_STICKY     (1<<21)
 #define SHOW_DEFAULT (SHOW_GEOMETRY | SHOW_ALLDESKS | SHOW_NORMAL | \
 	SHOW_ICONIC | SHOW_STICKY_ACROSS_PAGES | SHOW_STICKY_ACROSS_DESKS)
 
@@ -417,8 +418,7 @@ void CMD_WindowList(F_CMD_ARGS)
 			}
 			else if (StrEquals(tok,"OnlySticky"))
 			{
-				flags = SHOW_STICKY_ACROSS_PAGES;
-				flags = SHOW_STICKY_ACROSS_DESKS;
+				flags |= SHOW_ONLY_STICKY;
 			}
 			else if (StrEquals(tok,"OnlyStickyPage"))
 			{
@@ -773,6 +773,11 @@ void CMD_WindowList(F_CMD_ARGS)
 			    (IS_STICKY_ACROSS_DESKS(t)))
 			{
 				/* don't want sticky ones - skip */
+				continue;
+			}
+			if ((flags & SHOW_ONLY_STICKY)  &&
+				(!IS_STICKY_ACROSS_PAGES(t) || !IS_STICKY_ACROSS_DESKS(t)))
+			{
 				continue;
 			}
 			if (!(flags & SHOW_NORMAL) &&


### PR DESCRIPTION
This pull request removes the `WindowList OnlySticky` option.

The `OnlySticky` handling was broken: the flags set by this option overwrote
each other, so the intended behavior never worked. An equivalent and
functional alternative already exists in the form of
`WindowList (sticky)`.

The `OnlySticky` code has been present for more than 20 years without ever
working correctly. It is therefore safe to assume that it has not been used
in practice, and removing it should not break existing user configurations.

This change is purely a cleanup and removes dead and misleading code.