### PR TITLE
FvwmPager: Always use ULONG_MAX for undefined color.

### DIFF
--- a/modules/FvwmPager/init_pager.c
+++ b/modules/FvwmPager/init_pager.c
@@ -184,13 +184,14 @@ void initialize_desks_and_monitors(void)
 	default_style->bg = GetSimpleColor("white");
 	default_style->hi_fg = GetSimpleColor("black");
 	default_style->hi_bg = GetSimpleColor("grey");
-	default_style->win_fg = ULONG_MAX; /* Use fvwm pixel unless defined. */
-	default_style->win_bg = None;
+	/* Use ULONG_MAX for default undefined value because "black" is 0. */
+	default_style->win_fg = ULONG_MAX;
+	default_style->win_bg = ULONG_MAX;
 	default_style->focus_fg = ULONG_MAX;
-	default_style->focus_bg = None;
-	default_style->balloon_fg = None;
-	default_style->balloon_bg = None;
-	default_style->balloon_border = None;
+	default_style->focus_bg = ULONG_MAX;
+	default_style->balloon_fg = ULONG_MAX;
+	default_style->balloon_bg = ULONG_MAX;
+	default_style->balloon_border = ULONG_MAX;
 	default_style->bgPixmap = NULL;
 	default_style->hiPixmap = NULL;
 	TAILQ_INSERT_TAIL(&desk_style_q, default_style, entry);

--- a/modules/FvwmPager/x_pager.c
+++ b/modules/FvwmPager/x_pager.c
@@ -1368,7 +1368,7 @@ void AddNewWindow(PagerWindow *t)
 	}
 
 	valuemask = CWBackPixel | CWEventMask;
-	attributes.background_pixel = (style->win_bg) ?
+	attributes.background_pixel = (style->win_bg < ULONG_MAX) ?
 				      style->win_bg : t->back;
 	/* ric@giccs.georgetown.edu -- added Enter and Leave events for
 	   popping up balloon window */
@@ -2059,15 +2059,19 @@ void setup_balloon_window(PagerWindow *t)
 	/* Store Balloon.cs for future events. */
 	Balloon.cs = style->balloon_cs;
 
-	fg = (style->balloon_fg) ? style->balloon_fg :
+	fg = (style->balloon_fg < ULONG_MAX) ? style->balloon_fg :
 	     (style->win_fg < ULONG_MAX) ? style->win_fg : t->text;
 	XSetForeground(dpy, Balloon.gc, fg);
 
 	XUnmapWindow(dpy, Scr.balloon_w);
-	xswa.border_pixel = (style->balloon_border) ? style->balloon_border :
-			    (style->balloon_fg) ? style->balloon_fg : t->text;
-	xswa.background_pixel = (style->balloon_bg) ? style->balloon_bg :
-				(style->win_bg) ? style->win_bg : t->back;
+	xswa.border_pixel = (style->balloon_border < ULONG_MAX)
+			    ? style->balloon_border
+			    : (style->balloon_fg < ULONG_MAX)
+			      ? style->balloon_fg : t->text;
+	xswa.background_pixel = (style->balloon_bg < ULONG_MAX)
+				? style->balloon_bg
+				: (style->win_bg < ULONG_MAX)
+				  ? style->win_bg : t->back;
 	if (style->balloon_cs >= 0 && Colorset[style->balloon_cs].pixmap) {
 		/* set later */
 		xswa.background_pixmap = None;

--- a/modules/FvwmPager/x_update.c
+++ b/modules/FvwmPager/x_update.c
@@ -169,7 +169,7 @@ void update_window_background(PagerWindow *t)
 	if (t == FocusWin) {
 		if (style->focus_cs >= 0) {
 			cs = style->focus_cs;
-		} else if (style->focus_bg) {
+		} else if (style->focus_bg < ULONG_MAX) {
 			pix = style->focus_bg;
 		} else {
 			pix = Scr.focus_win_bg;
@@ -177,7 +177,7 @@ void update_window_background(PagerWindow *t)
 	} else {
 		if (style->win_cs >= 0) {
 			cs = style->win_cs;
-		} else if (style->win_bg) {
+		} else if (style->win_bg < ULONG_MAX) {
 			pix = style->win_bg;
 		} else {
 			pix = t->back;


### PR DESCRIPTION
Since the color "black" is equal to "0", a false value, conditionals fail to use any user setting of "black" for different colors. This was fixed for the foreground color previously, but the problem still exists for background and balloon colors.

This consistently uses `ULONG_MAX` to represent an undefined value for the default of different configurable colors in FvwmPager, so any user setting of `black` will correctly be used.

Fixes #1297.