### PR TITLE
FvwmIconMan: Add DrawIcons none option.

### DIFF
--- a/doc/FvwmIconMan.adoc
+++ b/doc/FvwmIconMan.adoc
@@ -179,11 +179,16 @@ The following options may be specified:
 *FvwmIconMan: [id] Colorset colorset::
   The default colorset used. Overrides background and foreground.
 *FvwmIconMan: [id] DrawIcons value::
-  If your version of fvwm is capable of using mini icons, then this
-  option determines if FvwmIconMan displays the mini icons. Otherwise,
-  it generates an error message. "true" means that mini icons are shown
-  for iconified windows, "false" that mini icons are never shown, and
-  "always" that mini icons are shown for all windows.
+  This sets the behavior of the space placed before each button label.
+  The default is "false" which means there is an empty space before each
+  label in which a relief button will be drawn next to all iconified
+  windows, provided 'ReliefThickness' is not zero. If this is set to
+  "true" a mini icon will be drawn in place of the relief button next
+  to all iconified windows. If this is set to "always", a mini icon
+  will be drawn for all windows. Note, iconified windows without mini
+  icons will still show a relief button unless 'ReliefThickness' is zero.
+  Last, if this is "none", the space before the label is completely
+  removed and no mini icons or relief buttons are shown.
 *FvwmIconMan: [id] FocusAndSelectButton style [forecolor backcolor]::
   Same as the plainbutton option, but specifies the look of buttons
   which are both selected, and have the keyboard focus.

--- a/modules/FvwmIconMan/readconfig.c
+++ b/modules/FvwmIconMan/readconfig.c
@@ -1539,6 +1539,9 @@ void read_in_resources(void)
 	  else if (!strcasecmp(p, "always")) {
 	    i = 2;
 	  }
+	  else if (!strcasecmp(p, "none")) {
+	    i = 3;
+	  }
 	  else if (!strcasecmp(p, "false")) {
 	    i = 0;
 	  }

--- a/modules/FvwmIconMan/xmanager.c
+++ b/modules/FvwmIconMan/xmanager.c
@@ -1392,7 +1392,12 @@ static void get_button_geometry(WinManager *man, Button *button,
   g->button_h = button->h;
 
 /* [BV 16-Apr-97] Mini Icons work on black-and-white too */
-  if (FMiniIconsSupported && man->draw_icons && win && win->pic.picture) {
+  if (man->draw_icons == 3) {
+    /* Icons are disabled, don't reserve any space for them. */
+    g->icon_x = g->icon_y = g->icon_h = g->icon_w = 0;
+  }
+  else if (FMiniIconsSupported && man->draw_icons && win && win->pic.picture)
+  {
     /* If no window, then icon_* aren't used, so doesn't matter what
        they are */
     g->icon_w = min(win->pic.width, g->button_h);
@@ -1457,7 +1462,8 @@ static void draw_button_background(
 static void draw_3d_icon(WinManager *man, int box, ButtonGeometry *g,
 			  int iconified, Contexts contextId)
 {
-  if ((iconified == 0) || (man->relief_thickness == 0))
+  /* If man->draw_icons == 3, iconify box is disabled, nothing to do. */
+  if (iconified == 0 || man->relief_thickness == 0 || man->draw_icons == 3)
     return;
   else
     RelieveRectangle(theDisplay, man->theWindow, g->icon_x, g->icon_y,
@@ -1476,7 +1482,8 @@ static void iconify_box(WinManager *man, WinData *win, int box,
 	int cset = man->colorsets[contextId];
 	Bool erase = False;
 
-	if (!man->window_up)
+	/* If draw_icons == 3, the iconify box has been removed. */
+	if (!man->window_up || man->draw_icons == 3)
 	{
 		return;
 	}
@@ -1802,6 +1809,12 @@ static void draw_button(WinManager *man, int button, int force)
 			draw_background = 1;
 			draw_string = 1;
 		}
+	}
+
+	/* Check if iconfiy box is disabled. */
+	if (man->draw_icons == 3) {
+		draw_icon = 0;
+		clear_old_pic = 0;
 	}
 
 	if (draw_background || draw_icon || draw_string)


### PR DESCRIPTION
This option removes the space reserved for the iconified relief button and mini icons.

This option was requested in #1289.