### PR TITLE
events: restrict Expose weeding scope to prevent cross-window coalescing

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -271,7 +271,14 @@ static int _pred_weed_accumulate_expose(
 static int _pred_weed_is_expose(
 	Display *display, XEvent *event, XPointer arg)
 {
-	return (event->type == Expose);
+  if (event->type == Expose)
+  {
+    /* Include Expose in weeding (rc & 1) and stop scanning early (rc & 2)
+     * to avoid coalescing Expose events across different windows.
+     */
+    return (1 /* match */ | 2 /* stop */);
+  }
+  return 0;
 }
 
 static int _pred_weed_handle_expose(


### PR DESCRIPTION
### What does this PR do?
Expose events are currently processed within a single weeding pass, which can coalesce events across multiple windows.  In some cases, this can result in repaint obligations being dropped when Expose activity from one window affects another.

This change keeps the existing weeding pipeline intact, but returns both match (`rc & 1`) and stop (`rc & 2`) for Expose events.  This limits each weeding pass to a smaller scope so Expose events are not coalesced across unrelated windows.

This preserves existing event handling behavior while preventing cross-window interaction during Expose coalescing.

### Screenshots (if applicable)
N/A (behavioral fix; verified via `xev -id` and icon repaint testing)

### Issue number(s)
Fixes #818