### PR TITLE
Set NumberOfDesktops to valid EWMH minimum (1) to prevent wmctrl issues

### DIFF
--- a/fvwm/fvwm3.c
+++ b/fvwm/fvwm3.c
@@ -2278,6 +2278,7 @@ int main(int argc, char **argv)
 
 	is_tracking_shared = false;
 	RB_FOREACH(m, monitors, &monitor_q) {
+		m->ewmhc.NumberOfDesktops = 1;
 		EWMH_Init(m);
 
 		/* Having initialised the monitor at startup here, we can


### PR DESCRIPTION
`m->ewmhc.NumberOfDesktops` is initialized with 0.
Setting it to 1 during initialization (in the `RB_FOREACH` monitor setup loop).

Fixes the issue #1304
