### PR TITLE
Fix switching monitors which are located at the same position.

### DIFF
--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -442,14 +442,27 @@ monitor_compare(struct monitor *a, struct monitor *b)
 {
 	int adisable = a->flags & MONITOR_DISABLED;
 	int bdisable = b->flags & MONITOR_DISABLED;
-	if (adisable && bdisable)
-		return strcmp(a->si->name, b->si->name);
+
 	if (adisable && !bdisable)
 		return 1;
+
 	if (!adisable && bdisable)
 		return -1;
-	return (a->si->y == b->si->y) ?
+
+	int coord_comp = (a->si->y == b->si->y) ?
 		(a->si->x - b->si->x) : (a->si->y - b->si->y);
+
+	if (coord_comp != 0)
+		return coord_comp;
+
+	int size_comp = (a->si->w == b->si->w) ?
+		(a->si->h - b->si->h) : (a->si->w - b->si->w);
+
+	if (size_comp != 0)
+		return size_comp;
+
+	return strcmp(a->si->name, b->si->name);
+
 }
 
 static void


### PR DESCRIPTION
* **What does this PR do?**

When simultaneously disabling and enabling monitor which are placed at the same position, Fvwm will chicken out because it comes to believe that no monitor is active anymore.
This is in a sense caused by the way scan_screens processes changes, however, can be fixed by changing monitor_compare. The latter only considers the position of a monitor, and if a monitor is en - or disabled. When inserting a monitor into the RB-tree, a previously unknown monitor will be considered the same as the one being disabled.
By extending the criteria by which monitors are checked, monitors which actually differ are not considered being the same anymore, and a previously unknown one is properly added to the RB-tree. After insertion, the process in scan_screens will yield a correct configuration and Fvwm will happily continue.

fixes fvwmorg/fvwm3#1281