### PR TITLE
Fix moving windows from one desktop to another.

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -2246,7 +2246,11 @@ static void _move_window(F_CMD_ARGS, Bool do_animate, int mode)
 		final.x = r.x;
 		final.y = r.y;
 
-		fw->Desk = m->virtual_scr.CurrentDesk;
+		if (fw->Desk != m->virtual_scr.CurrentDesk)
+		{
+			fw->UpdateDesk = m->virtual_scr.CurrentDesk;
+		}
+
 		fw->m = m;
 	}
 	else


### PR DESCRIPTION
* **What does this PR do?**

It turns out that windows disappear when being moved from one desktop to another, when the current desktop is the desktop the window is to be moved to, and, yes, the original desktop is not the current one ;)

I believe this fixes that problem.