### PR TITLE
Fix situation in which edge commands are not triggered.

### DIFF
--- a/fvwm/events.c
+++ b/fvwm/events.c
@@ -2261,13 +2261,6 @@ void HandleEnterNotify(const evh_args_t *ea)
 		char *edge_command = NULL;
 		struct monitor	*m = monitor_get_current();
 
-		if (
-			Scr.UnknownWinFocused != None &&
-			(sf = get_focus_window()) != NULL &&
-			sf == Scr.StolenFocusFvwmWin)
-		{
-			_refocus_stolen_focus_win(ea);
-		}
 		/* check for edge commands */
 		if (ewp->window == m->PanFrameTop.win)
 		{
@@ -2285,6 +2278,15 @@ void HandleEnterNotify(const evh_args_t *ea)
 		{
 			edge_command = m->PanFrameRight.command;
 		}
+
+		if (
+			Scr.UnknownWinFocused != None &&
+			(sf = get_focus_window()) != NULL &&
+			sf == Scr.StolenFocusFvwmWin)
+		{
+			_refocus_stolen_focus_win(ea);
+		}
+
 		if (edge_command && ewp->mode == NotifyUngrab &&
 		    ewp->detail == NotifyAncestor)
 		{


### PR DESCRIPTION
* **What does this PR do?**

Situation is as follows. Application window is maximised. One opens a menu in that application. Menu is closed. One moves the pointer to an edge. Edge command is not triggered.

This commit fixes that. Rationale: when refocusing too early, the edge is not considered anymore and not command is triggered.