### PR TITLE
move_resize: fix resize-against-working-area edge cases

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -913,14 +913,14 @@ int GetMoveArguments(FvwmWindow *fw,
 			EWMH_USE_WORKING_AREA);
 		if (x < scr_pos.x) {
 			dx = scr_pos.x - x;
-		} else if (x + s.width > scr_pos.x + scr_w) {
+		} if (x + dx + s.width > scr_pos.x + scr_w) {
 			dx = scr_pos.x + scr_w - x - s.width;
 			if (x + dx < scr_pos.x)
 				dx = scr_pos.x - x;
 		}
 		if (y < scr_pos.y) {
 			dy = scr_pos.y - y;
-		} else if (y + s.height > scr_pos.y + scr_h) {
+		} if (y + dy + s.height > scr_pos.y + scr_h) {
 			dy = scr_pos.y + scr_h - y - s.height;
 			if (y + dy < scr_pos.y)
 				dy = scr_pos.y - y;
@@ -966,6 +966,7 @@ static int ParseOneResizeArgument(
 	{
 		/* ewmh working area */
 		factor = (float)wa_size / 100.0;
+		add_size = 0;
 		arg[cch-1] = '\0';
 	}
 	else if (cch > 1 && arg[cch-2] == 'd' && arg[cch-1] == 'a')


### PR DESCRIPTION
When `ResizeMove` specifies a size with the `wa` (working area) suffix, e.g. `ResizeMove 50wa 100wa` for half-screen and quarter-screen snapping, two bugs conspire to push the window frame past the visible screen edge when EWMH struts reserve space.

**Bug 1 — `ParseOneResizeArgument` adds border overhead on top of `wa`-sized requests**

Percentage arguments with the `wa` suffix are scaled against the working area (`wa_size`), but `add_size` (window border thickness) is still added to the computed frame dimension. A `100wa` height request against a 1050 px working area produces a 1054 px frame, exceeding the area it was supposed to fit.

**Bug 2 — `GetMoveArguments` post-hoc position adjustment blocks bottom/right correction**

The horizontal and vertical edge checks use `else if`, so when the top/left condition fires, the opposing edge check is skipped entirely. A window pushed down by a top strut that simultaneously overflows the bottom edge receives only the top correction, leaving it partially off-screen. The check also measured against the pre-corrected position rather than the already-adjusted `dx`/`dy`.

**Fix**

1. Zero `add_size` when the `wa` suffix is detected so the frame size equals the working-area target.
2. Change both `else if` chains to plain `if` and reference `x+dx` / `y+dy` so horizontal and vertical edge corrections apply independently and account for prior adjustments within the same axis.

**Verification**

Tested with the following config snippet:
```
# Reserve 27 pixels at the top edge for xfce4-panel.
EwmhBaseStruts 0 0 27 0
Style * EWMHMaximizeUseWorkingArea

# Snap-to-zone tiling (Super/Mod4 + keys).
# Half-screen snaps:
Silent Key Left   A 4  ResizeMove 50wa 100wa 0 0
Silent Key Right  A 4  ResizeMove 50wa 100wa -0 0
Silent Key Up     A 4  ResizeMove 100wa 50wa 0 0
Silent Key Down   A 4  ResizeMove 100wa 50wa 0 -0

# Quarter-screen (corner) snaps:
Silent Key Semicolon  A 4  ResizeMove 50wa 50wa 0 0
Silent Key Apostrophe A 4  ResizeMove 50wa 50wa -0 0
Silent Key Period     A 4  ResizeMove 50wa 50wa 0 -0
Silent Key Slash      A 4  ResizeMove 50wa 50wa -0 -0
```

The snaps work perfectly now without overlapping or flowing off the screen.