### PR TITLE
FScreen: fix crash on transient empty RandR topology (lid reopen)

### DIFF
--- a/libs/FScreen.c
+++ b/libs/FScreen.c
@@ -354,7 +354,8 @@ monitor_check_primary(void)
 		struct monitor	*m;
 
 		m = RB_MIN(monitors, &monitor_q);
-		m->flags |= MONITOR_PRIMARY;
+		if (m != NULL)
+			m->flags |= MONITOR_PRIMARY;
 	}
 }
 
@@ -562,9 +563,21 @@ scan_screens(Display *dpy)
 	}
 
 	rrm = XRRGetMonitors(dpy, root, true, &n);
-	if (n <= 0 && (!randr_initialised && monitor_get_count() == 0)) {
-		fvwm_debug(__func__, "get monitors failed\n");
-		exit(101);
+	if (n <= 0) {
+		if (!randr_initialised && monitor_get_count() == 0) {
+			fvwm_debug(__func__, "get monitors failed\n");
+			exit(101);
+		}
+		/* Transient empty topology (e.g. a monitor has been
+		 * disabled but not yet re-enabled, as happens when a
+		 * laptop lid is reopened).  Retain the existing monitor
+		 * set and wait for the next RandR event.
+		 */
+		fvwm_debug(__func__,
+			"no monitors reported; retaining current set\n");
+		if (rrm != NULL)
+			XRRFreeMonitors(rrm);
+		return;
 	}
 
 	/*
@@ -891,10 +904,13 @@ FindScreenOfXY(int x, int y)
 		}
 	}
 
-	/* Shouldn't happen. */
+	/* Shouldn't happen.  If it does (e.g. all monitors transiently
+	 * disabled), degrade gracefully rather than killing the WM.
+	 */
 	if (m_min == NULL) {
-		fvwm_debug(__func__, "Couldn't find any monitor");
-		exit(106);
+		fvwm_debug(__func__,
+			"Couldn't find any monitor; using global");
+		return (monitor_get_global());
 	}
 	return (m_min);
 }


### PR DESCRIPTION
When a laptop lid is reopened, the kernel disables and then re-enables the internal panel.  If `XRRGetMonitors()` returns `n=0` during that window, `scan_screens` would mark every monitor `MONITOR_DISABLED`, and the next `FindScreenOfXY` call would hit `exit(106)`, killing the WM.

Two fixes:
1. scan_screens: when `randr_initialised` and `n <= 0`, retain the existing monitor set and return early instead of clearing all state.
2. `FindScreenOfXY`: degrade to `monitor_get_global()` rather than `exit(106)`, as defence-in-depth against any residual path hitting an all-disabled queue.

Also add a `NULL`-check in `monitor_check_primary()` on `RB_MIN` to avoid a potential null dereference on genuinely empty queues.

