### PR TITLE
bin/fvwm-menu-desktop.in: Escape submenu titles.

### DIFF
--- a/bin/fvwm-menu-desktop.in
+++ b/bin/fvwm-menu-desktop.in
@@ -804,7 +804,7 @@ def parsemenu(menu, name="", title="", desktop_entries=[]):
             if insert_in_menu and name == top and menu_list_length == 1:
                 printtext('AddToMenu "%s"' % name)
             else:
-                printtext('AddToMenu "%s" "%s" Title' % (name, title))
+                printtext('AddToMenu "%s" "%s" Title' % (name, escapemenutext(title)))
         else:
             printtext('AddToMenu "%s"' % name)
     for entry in menu.getEntries():


### PR DESCRIPTION
* **What does this PR do?**

This is a one-line change to `fvwm-menu-desktop.in` to escape ampersands (e.g. `Lost & Found`) and percent signs in popup titles in the generated XDG menu. These characters are otherwise not rendered.