### PR TITLE
m_count is not used, remove references to it

### DIFF
--- a/fvwm/builtins.c
+++ b/fvwm/builtins.c
@@ -133,7 +133,7 @@ status_send(void)
 {
 	cJSON		*msg = NULL, *screens = NULL;
 	cJSON		*desk_doc[1024], *individual_d[1024];
-	int 		 m_count, d_count;
+	int 		 d_count;
 	FvwmWindow	*fw_cur;
 	DesktopsInfo 	*di;
 	struct monitor	*m, *m_cur;
@@ -160,7 +160,7 @@ status_send(void)
 
 	screens = cJSON_AddObjectToObject(msg, "screens");
 
-	d_count = 0, m_count = 0;
+	d_count = 0;
 	RB_FOREACH(m, monitors, &monitor_q) {
 		cJSON	*this_desktop;
 		if ((desk_doc[d_count] = cJSON_CreateObject()) == NULL)
@@ -200,7 +200,6 @@ status_send(void)
 		    m->number);
 
 		d_count++;
-		m_count++;
 	}
 	if ((as_json = cJSON_PrintUnformatted(msg)) == NULL)
 		goto out;


### PR DESCRIPTION
* **What does this PR do?**
  removes m_count from three place in builtins.c to avoid compiler warning message
  ../fvwm/builtins.c:136:26: warning: variable ‘m_count’ set but not used  [-Wunused-but-set-variable=]

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/main/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```
